### PR TITLE
fix: allow running cli with npx v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "bin": {
     "openupm": "bin/openupm",
+    "openupm-cli": "bin/openupm",
     "openupm-cn": "bin/openupm-cn"
   },
   "repository": {


### PR DESCRIPTION
With npm v6, we were allowed to run openupm like `npx openupm-cli add ...`. But npm v7 had some changes which broke this functionality. It is still possible to call it as `npx -p openupm-cli openupm add ...` but that is verbose. 

From [NPM docs](https://docs.npmjs.com/cli/v7/commands/npm-exec#description):

>  If no --package options are provided, then npm will attempt to determine the executable name from the package specifier provided as the first positional argument according to the following heuristic:
> - If the package has a single entry in its bin field in package.json, or if all entries are aliases of the same command, then that command will be used.
> - If the package has multiple bin entries, and one of them matches the unscoped portion of the name field, then that command will be used.
> - If this does not result in exactly one option (either because there are no bin entries, or none of them match the name of the package), then npm exec exits with an error.

Basically, the bin entry name should be same as package name for the terse syntax to work. So this PR should fix it and allow calling it like `npx openupm-cli add ...` again.