### PR TITLE
fix: eslint-prettier error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,6 @@ module.exports = {
   },
   extends: [
     "eslint:recommended",
-    "plugin:vue/recommended",
-    "prettier/vue",
     "plugin:prettier/recommended"
   ],
   rules: {


### PR DESCRIPTION
When attempting to fix eslint rules in file, the following error appeared

```Error: "prettier/vue" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21```

Reading the linked changelog, it seemed the fix was to simply only use the prettier/recommended extension. Simplified eslintrc to reflect this.