### PR TITLE
refactor: misc improvements in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-vue": "^8.7.1",
+        "fast-check": "^3.13.2",
         "mocha": "^10.0.0",
         "nock": "^13.2.4",
         "prettier": "^2.6.2",
@@ -3525,6 +3526,28 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.13.2.tgz",
+      "integrity": "sha512-ouTiFyeMoqmNg253xqy4NSacr5sHxH6pZpLOaHgaAdgZxFWdtsfxExwolpveoAE9CJdV+WYjqErNGef6SqA5Mg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8487,6 +8510,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/q": {
       "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/pkginfo": "^0.4.1",
         "@types/promptly": "^3.0.3",
         "@types/request": "^2.48.11",
-        "@types/should": "^13.0.0",
         "@types/test-console": "^2.0.1",
         "@types/update-notifier": "^6.0.5",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
@@ -1461,14 +1460,6 @@
       "version": "7.5.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/should": {
-      "version": "13.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should": "*"
-      }
     },
     "node_modules/@types/ssri": {
       "version": "7.1.2",
@@ -11519,13 +11510,6 @@
     "@types/semver": {
       "version": "7.5.3",
       "dev": true
-    },
-    "@types/should": {
-      "version": "13.0.0",
-      "dev": true,
-      "requires": {
-        "should": "*"
-      }
     },
     "@types/ssri": {
       "version": "7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-vue": "^8.7.1",
-        "fast-check": "^3.13.2",
         "mocha": "^10.1.0",
         "nock": "^13.2.4",
         "prettier": "^2.6.2",
@@ -3642,28 +3641,6 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
-    },
-    "node_modules/fast-check": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.13.2.tgz",
-      "integrity": "sha512-ouTiFyeMoqmNg253xqy4NSacr5sHxH6pZpLOaHgaAdgZxFWdtsfxExwolpveoAE9CJdV+WYjqErNGef6SqA5Mg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "dependencies": {
-        "pure-rand": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8633,22 +8610,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ]
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "dev": true,
@@ -12834,15 +12795,6 @@
     "extsprintf": {
       "version": "1.3.0"
     },
-    "fast-check": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.13.2.tgz",
-      "integrity": "sha512-ouTiFyeMoqmNg253xqy4NSacr5sHxH6pZpLOaHgaAdgZxFWdtsfxExwolpveoAE9CJdV+WYjqErNGef6SqA5Mg==",
-      "dev": true,
-      "requires": {
-        "pure-rand": "^6.0.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3"
     },
@@ -16101,12 +16053,6 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
-    },
-    "pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
-      "dev": true
     },
     "q": {
       "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "openupm-cli",
   "version": "1.16.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -32,7 +32,7 @@
         "openupm-cn": "lib/index-cn.js"
       },
       "devDependencies": {
-        "@babel/core": "^7.17.10",
+        "@babel/core": "^7.18.6",
         "@babel/eslint-parser": "^7.17.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
@@ -57,7 +57,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-vue": "^8.7.1",
         "fast-check": "^3.13.2",
-        "mocha": "^10.0.0",
+        "mocha": "^10.1.0",
         "nock": "^13.2.4",
         "prettier": "^2.6.2",
         "rimraf": "^5.0.5",
@@ -92,44 +92,119 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.17.10",
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.18.2",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-compilation-targets": "^7.18.2",
-        "@babel/helper-module-transforms": "^7.18.0",
-        "@babel/helpers": "^7.18.2",
-        "@babel/parser": "^7.18.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2",
-        "convert-source-map": "^1.7.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.2",
+        "@babel/parser": "^7.23.3",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -157,12 +232,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.2",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.2",
-        "@jridgewell/gen-mapping": "^0.3.0",
+        "@babel/types": "^7.23.3",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -170,11 +247,12 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.1",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
         "@jridgewell/trace-mapping": "^0.3.9"
       },
@@ -183,14 +261,93 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.18.2",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.20.2",
-        "semver": "^6.3.0"
+        "@babel/compat-data": "^7.22.9",
+        "@babel/helper-validator-option": "^7.22.15",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -199,124 +356,79 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.17.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.18.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.0",
-        "@babel/types": "^7.18.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.18.2",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.2"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.16.7",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.18.2",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.12",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -325,8 +437,9 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -336,8 +449,9 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -349,37 +463,42 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -388,9 +507,10 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.3",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -399,31 +519,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.16.7",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.18.2",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.18.0",
-        "@babel/types": "^7.18.2",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -432,11 +554,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.18.2",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -687,9 +811,10 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.7",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -703,17 +828,19 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.13",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1789,11 +1916,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "dev": true,
@@ -2246,7 +2368,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.20.3",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "funding": [
         {
@@ -2256,15 +2380,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2491,7 +2617,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001344",
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
       "dev": true,
       "funding": [
         {
@@ -2501,9 +2629,12 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -2804,17 +2935,10 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -3103,9 +3227,10 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.141",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.585",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.585.tgz",
+      "integrity": "sha512-B4yBlX0azdA3rVMxpYwLQfDpdwOgcnLCkpvSOd68iFmeedo+WYjaBJS3/W58LVD8CB2nf+o7C4K9xz1l09RkWg==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3951,8 +4076,9 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -4525,8 +4651,9 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4545,8 +4672,9 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -4586,9 +4714,10 @@
       "license": "ISC"
     },
     "node_modules/json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5197,11 +5326,11 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.0.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -5365,9 +5494,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -8288,8 +8418,9 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9064,8 +9195,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9668,8 +9800,9 @@
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -9929,6 +10062,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/update-notifier": {
@@ -10335,6 +10498,6802 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    }
+  },
+  "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "dev": true
+    },
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.2",
+        "@babel/parser": "^7.23.3",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.18.2",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.23.3",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.22.9",
+        "@babel/helper-validator-option": "^7.22.15",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true
+    },
+    "@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.15"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "dev": true,
+      "optional": true
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "dev": true
+        }
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.9.1",
+      "dev": true
+    },
+    "@eslint/eslintrc": {
+      "version": "2.1.2",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.23.0",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "dev": true
+        }
+      }
+    },
+    "@eslint/js": {
+      "version": "8.51.0",
+      "dev": true
+    },
+    "@gar/promisify": {
+      "version": "1.1.3"
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.11.11",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "dev": true
+    },
+    "@iarna/toml": {
+      "version": "2.2.5"
+    },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@npmcli/fs": {
+      "version": "2.1.0",
+      "requires": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@npmcli/move-file": {
+      "version": "2.0.0",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4"
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.6.0",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.8.0",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "11.2.0",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.34.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "dev": true,
+      "requires": {}
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.3",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.12.0",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.34.0",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@semantic-release/changelog": {
+      "version": "6.0.1",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@semantic-release/commit-analyzer": {
+      "version": "9.0.2",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.2.3",
+        "debug": "^4.0.0",
+        "import-from": "^4.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.2"
+      }
+    },
+    "@semantic-release/error": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "@semantic-release/git": {
+      "version": "10.0.1",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
+      }
+    },
+    "@semantic-release/github": {
+      "version": "8.0.4",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "^18.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "issue-parser": "^6.0.0",
+        "lodash": "^4.17.4",
+        "mime": "^3.0.0",
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "@semantic-release/error": {
+          "version": "2.2.0",
+          "dev": true
+        }
+      }
+    },
+    "@semantic-release/npm": {
+      "version": "9.0.1",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^6.0.0",
+        "npm": "^8.3.0",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^4.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^1.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@semantic-release/release-notes-generator": {
+      "version": "10.0.3",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.2.3",
+        "debug": "^4.0.0",
+        "get-stream": "^6.0.0",
+        "import-from": "^4.0.0",
+        "into-stream": "^6.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^7.0.0"
+      }
+    },
+    "@sindresorhus/is": {
+      "version": "0.14.0"
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@tootallnate/once": {
+      "version": "2.0.0"
+    },
+    "@types/caseless": {
+      "version": "0.12.4",
+      "dev": true
+    },
+    "@types/cli-table": {
+      "version": "0.3.2",
+      "dev": true
+    },
+    "@types/configstore": {
+      "version": "6.0.0",
+      "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "11.0.3",
+      "dev": true,
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.14",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "dev": true,
+      "optional": true
+    },
+    "@types/jsonfile": {
+      "version": "6.1.3",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/libnpmsearch": {
+      "version": "2.0.4",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/npm-registry-fetch": "*"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.199",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "10.0.3",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.18.63",
+      "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.6.6",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "dev": true
+    },
+    "@types/npm-package-arg": {
+      "version": "6.1.2",
+      "dev": true
+    },
+    "@types/npm-registry-fetch": {
+      "version": "8.0.5",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/node-fetch": "*",
+        "@types/npm-package-arg": "*",
+        "@types/npmlog": "*",
+        "@types/ssri": "*"
+      }
+    },
+    "@types/npmlog": {
+      "version": "4.1.4",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "@types/pkginfo": {
+      "version": "0.4.1",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/promptly": {
+      "version": "3.0.3",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/request": {
+      "version": "2.48.11",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.5.3",
+      "dev": true
+    },
+    "@types/should": {
+      "version": "13.0.0",
+      "dev": true,
+      "requires": {
+        "should": "*"
+      }
+    },
+    "@types/ssri": {
+      "version": "7.1.2",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/test-console": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.4",
+      "dev": true
+    },
+    "@types/update-notifier": {
+      "version": "6.0.5",
+      "dev": true,
+      "requires": {
+        "@types/configstore": "*",
+        "boxen": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "dev": true
+        },
+        "boxen": {
+          "version": "7.1.1",
+          "dev": true,
+          "requires": {
+            "ansi-align": "^3.0.1",
+            "camelcase": "^7.0.1",
+            "chalk": "^5.2.0",
+            "cli-boxes": "^3.0.0",
+            "string-width": "^5.1.2",
+            "type-fest": "^2.13.0",
+            "widest-line": "^4.0.1",
+            "wrap-ansi": "^8.1.0"
+          }
+        },
+        "camelcase": {
+          "version": "7.0.1",
+          "dev": true
+        },
+        "chalk": {
+          "version": "5.3.0",
+          "dev": true
+        },
+        "cli-boxes": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "dev": true
+        },
+        "widest-line": {
+          "version": "4.0.1",
+          "dev": true,
+          "requires": {
+            "string-width": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.8.0",
+        "@typescript-eslint/type-utils": "6.8.0",
+        "@typescript-eslint/utils": "6.8.0",
+        "@typescript-eslint/visitor-keys": "6.8.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "6.8.0",
+        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/typescript-estree": "6.8.0",
+        "@typescript-eslint/visitor-keys": "6.8.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/visitor-keys": "6.8.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "6.8.0",
+        "@typescript-eslint/utils": "6.8.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "6.8.0",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/visitor-keys": "6.8.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.8.0",
+        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/typescript-estree": "6.8.0",
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "6.8.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "6.8.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "dev": true
+        }
+      }
+    },
+    "acorn": {
+      "version": "8.10.0",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "requires": {}
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "another-npm-registry-client": {
+      "version": "8.7.0",
+      "requires": {
+        "concat-stream": "^1.5.2",
+        "graceful-fs": "^4.1.6",
+        "normalize-package-data": "~1.0.1 || ^2.0.0",
+        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+        "once": "^1.3.3",
+        "request": "^2.74.0",
+        "retry": "^0.13.1",
+        "safe-buffer": "^5.1.1",
+        "semver": "^7.3.5",
+        "slide": "^1.1.3",
+        "ssri": "^8.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.7",
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "ansi-align": {
+      "version": "3.0.1",
+      "requires": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "type-fest": "^1.0.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1"
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "ansicolors": {
+      "version": "0.3.2",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "2.0.0"
+    },
+    "are-we-there-yet": {
+      "version": "3.0.0",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "argv-formatter": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "array-ify": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.6",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0"
+    },
+    "asynckit": {
+      "version": "0.4.0"
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0"
+    },
+    "aws4": {
+      "version": "1.11.0"
+    },
+    "balanced-match": {
+      "version": "1.0.2"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "dev": true
+    },
+    "boxen": {
+      "version": "5.1.2",
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0"
+        },
+        "type-fest": {
+          "version": "0.20.2"
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2"
+    },
+    "builtins": {
+      "version": "1.0.3"
+    },
+    "cacache": {
+      "version": "16.1.0",
+      "requires": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4"
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "ssri": {
+          "version": "9.0.1",
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        }
+      }
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0"
+        },
+        "normalize-url": {
+          "version": "4.5.1"
+        }
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
+      "dev": true
+    },
+    "cardinal": {
+      "version": "2.1.1",
+      "dev": true,
+      "requires": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0"
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "chownr": {
+      "version": "2.0.0"
+    },
+    "ci-info": {
+      "version": "2.0.0"
+    },
+    "clean-stack": {
+      "version": "2.2.0"
+    },
+    "cli-boxes": {
+      "version": "2.2.1"
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
+    "cli-table3": {
+      "version": "0.6.2",
+      "dev": true,
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "string-width": "^4.2.0"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "optional": true
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4"
+    },
+    "color-support": {
+      "version": "1.1.3"
+    },
+    "colors": {
+      "version": "1.0.3"
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "9.3.0"
+    },
+    "compare-func": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1"
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0"
+    },
+    "conventional-changelog-angular": {
+      "version": "5.0.13",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-writer": {
+      "version": "5.0.1",
+      "dev": true,
+      "requires": {
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.7",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      }
+    },
+    "conventional-commits-filter": {
+      "version": "2.0.7",
+      "dev": true,
+      "requires": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
+      }
+    },
+    "conventional-commits-parser": {
+      "version": "3.2.4",
+      "dev": true,
+      "requires": {
+        "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      }
+    },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3"
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "dev": true
+        }
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "crypto-random-string": {
+      "version": "2.0.0"
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.4",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "dev": true
+        }
+      }
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0"
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "dev": true
+    },
+    "defer-to-connect": {
+      "version": "1.1.3"
+    },
+    "del": {
+      "version": "6.1.1",
+      "dev": true,
+      "requires": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0"
+    },
+    "delegates": {
+      "version": "1.0.0"
+    },
+    "depd": {
+      "version": "1.1.2"
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4"
+    },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.4.585",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.585.tgz",
+      "integrity": "sha512-B4yBlX0azdA3rVMxpYwLQfDpdwOgcnLCkpvSOd68iFmeedo+WYjaBJS3/W58LVD8CB2nf+o7C4K9xz1l09RkWg==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0"
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "env-ci": {
+      "version": "5.5.0",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0",
+        "fromentries": "^1.3.2",
+        "java-properties": "^1.0.0"
+      }
+    },
+    "err-code": {
+      "version": "2.0.3"
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "escape-goat": {
+      "version": "2.1.1"
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "eslint": {
+      "version": "8.51.0",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.51.0",
+        "@humanwhocodes/config-array": "^0.11.11",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "7.2.2",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "dev": true
+        },
+        "globals": {
+          "version": "13.23.0",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-vue": {
+      "version": "8.7.1",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.0.1",
+        "postcss-selector-parser": "^6.0.9",
+        "semver": "^7.3.5",
+        "vue-eslint-parser": "^8.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.6.1",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.5.0",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "dev": true
+    },
+    "execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2"
+    },
+    "extsprintf": {
+      "version": "1.3.0"
+    },
+    "fast-check": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.13.2.tgz",
+      "integrity": "sha512-ouTiFyeMoqmNg253xqy4NSacr5sHxH6pZpLOaHgaAdgZxFWdtsfxExwolpveoAE9CJdV+WYjqErNGef6SqA5Mg==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^6.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3"
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.2.11",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "dev": true
+        }
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^3.1.2"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "3.2.5",
+      "dev": true
+    },
+    "foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1"
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "fromentries": {
+      "version": "1.3.2",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0"
+    },
+    "function-bind": {
+      "version": "1.1.1"
+    },
+    "gauge": {
+      "version": "4.0.4",
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      }
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "git-log-parser": {
+      "version": "1.2.0",
+      "dev": true,
+      "requires": {
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
+      },
+      "dependencies": {
+        "split2": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "through2": "~2.0.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "7.2.0",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "global-dirs": {
+      "version": "3.0.0",
+      "requires": {
+        "ini": "2.0.0"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "globby": {
+      "version": "11.1.0",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "got": {
+      "version": "9.6.0",
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.10"
+    },
+    "graphemer": {
+      "version": "1.4.0",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0"
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0"
+    },
+    "has-unicode": {
+      "version": "2.0.1"
+    },
+    "has-yarn": {
+      "version": "2.1.0"
+    },
+    "he": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "hook-std": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.8.9"
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0"
+    },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "optional": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "ignore": {
+      "version": "5.2.4",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "import-from": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0"
+    },
+    "imurmurhash": {
+      "version": "0.1.4"
+    },
+    "indent-string": {
+      "version": "4.0.0"
+    },
+    "infer-owner": {
+      "version": "1.0.4"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4"
+    },
+    "ini": {
+      "version": "1.3.8"
+    },
+    "into-stream": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      }
+    },
+    "ip": {
+      "version": "1.1.8"
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.9.0",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-docker": {
+      "version": "2.2.1"
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0"
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.4.0",
+      "requires": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      }
+    },
+    "is-lambda": {
+      "version": "1.0.1"
+    },
+    "is-npm": {
+      "version": "5.0.0"
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "2.0.0"
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "3.0.3"
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "text-extensions": "^1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0"
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "is-yarn-global": {
+      "version": "0.3.0"
+    },
+    "isarray": {
+      "version": "1.0.0"
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2"
+    },
+    "issue-parser": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
+      }
+    },
+    "jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "java-properties": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1"
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0"
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.4.0"
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1"
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1"
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1"
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "dev": true
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "requires": {
+        "package-json": "^6.3.0"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "libnpmsearch": {
+      "version": "5.0.3",
+      "requires": {
+        "npm-registry-fetch": "^13.0.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21"
+    },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "dev": true
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "dev": true
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "dev": true
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1"
+    },
+    "lru-cache": {
+      "version": "7.10.1"
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "dev": true
+    },
+    "make-fetch-happen": {
+      "version": "10.1.6",
+      "requires": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.1.1",
+        "ssri": "^9.0.0"
+      },
+      "dependencies": {
+        "ssri": {
+          "version": "9.0.1",
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        }
+      }
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.0.16",
+      "dev": true
+    },
+    "marked-terminal": {
+      "version": "5.1.1",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^5.0.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^5.0.0",
+        "cli-table3": "^0.6.1",
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.0.1",
+          "dev": true
+        }
+      }
+    },
+    "meow": {
+      "version": "8.1.2",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.18.1",
+          "dev": true
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "mime": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.52.0"
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1"
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6"
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
+    "minipass": {
+      "version": "3.1.6",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-fetch": {
+      "version": "2.1.0",
+      "requires": {
+        "encoding": "^0.1.13",
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-json-stream": {
+      "version": "1.0.1",
+      "requires": {
+        "jsonparse": "^1.3.1",
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "3.0.1"
+    },
+    "mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "modify-values": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2"
+    },
+    "mute-stream": {
+      "version": "0.0.8"
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.3"
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "dev": true
+    },
+    "nerf-dart": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "nock": {
+      "version": "13.2.4",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      }
+    },
+    "node-emoji": {
+      "version": "1.11.0",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-releases": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1"
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "6.1.0",
+      "dev": true
+    },
+    "npm": {
+      "version": "8.11.0",
+      "dev": true,
+      "requires": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.1.0",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^3.0.1",
+        "abbrev": "~1.1.1",
+        "archy": "~1.0.0",
+        "cacache": "^16.1.0",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
+        "cli-columns": "^4.0.0",
+        "cli-table3": "^0.6.2",
+        "columnify": "^1.6.0",
+        "fastest-levenshtein": "^1.0.12",
+        "glob": "^8.0.1",
+        "graceful-fs": "^4.2.10",
+        "hosted-git-info": "^5.0.0",
+        "ini": "^3.0.0",
+        "init-package-json": "^3.0.2",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^6.0.2",
+        "libnpmdiff": "^4.0.2",
+        "libnpmexec": "^4.0.2",
+        "libnpmfund": "^3.0.1",
+        "libnpmhook": "^8.0.2",
+        "libnpmorg": "^4.0.2",
+        "libnpmpack": "^4.0.2",
+        "libnpmpublish": "^6.0.2",
+        "libnpmsearch": "^5.0.2",
+        "libnpmteam": "^4.0.2",
+        "libnpmversion": "^3.0.1",
+        "make-fetch-happen": "^10.1.5",
+        "minipass": "^3.1.6",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^9.0.0",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.0.2",
+        "npm-pick-manifest": "^7.0.1",
+        "npm-profile": "^6.0.3",
+        "npm-registry-fetch": "^13.1.1",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^6.0.2",
+        "opener": "^1.5.2",
+        "pacote": "^13.4.1",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "read": "~1.0.7",
+        "read-package-json": "^5.0.1",
+        "read-package-json-fast": "^2.0.3",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
+        "tar": "^6.1.11",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "treeverse": "^2.0.0",
+        "validate-npm-package-name": "^4.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^4.0.1"
+      },
+      "dependencies": {
+        "@colors/colors": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "@gar/promisify": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "@isaacs/string-locale-compare": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/arborist": {
+          "version": "5.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@isaacs/string-locale-compare": "^1.1.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/map-workspaces": "^2.0.3",
+            "@npmcli/metavuln-calculator": "^3.0.1",
+            "@npmcli/move-file": "^2.0.0",
+            "@npmcli/name-from-folder": "^1.0.1",
+            "@npmcli/node-gyp": "^2.0.0",
+            "@npmcli/package-json": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
+            "bin-links": "^3.0.0",
+            "cacache": "^16.0.6",
+            "common-ancestor-path": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.1",
+            "json-stringify-nice": "^1.1.4",
+            "mkdirp": "^1.0.4",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
+            "npm-install-checks": "^5.0.0",
+            "npm-package-arg": "^9.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.0",
+            "npmlog": "^6.0.2",
+            "pacote": "^13.0.5",
+            "parse-conflict-json": "^2.0.1",
+            "proc-log": "^2.0.0",
+            "promise-all-reject-late": "^1.0.0",
+            "promise-call-limit": "^1.0.1",
+            "read-package-json-fast": "^2.0.2",
+            "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.7",
+            "ssri": "^9.0.0",
+            "treeverse": "^2.0.0",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "@npmcli/ci-detect": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/config": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/map-workspaces": "^2.0.2",
+            "ini": "^3.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
+            "proc-log": "^2.0.0",
+            "read-package-json-fast": "^2.0.3",
+            "semver": "^7.3.5",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "@npmcli/disparity-colors": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.3.0"
+          }
+        },
+        "@npmcli/fs": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.1.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/git": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^3.0.0",
+            "lru-cache": "^7.4.4",
+            "mkdirp": "^1.0.4",
+            "npm-pick-manifest": "^7.0.0",
+            "proc-log": "^2.0.0",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.5",
+            "which": "^2.0.2"
+          }
+        },
+        "@npmcli/installed-package-contents": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-bundled": "^1.1.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "@npmcli/map-workspaces": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/name-from-folder": "^1.0.1",
+            "glob": "^8.0.1",
+            "minimatch": "^5.0.1",
+            "read-package-json-fast": "^2.0.3"
+          }
+        },
+        "@npmcli/metavuln-calculator": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cacache": "^16.0.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "pacote": "^13.0.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/move-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "@npmcli/name-from-folder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/node-gyp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/package-json": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.1"
+          }
+        },
+        "@npmcli/promise-spawn": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "infer-owner": "^1.0.4"
+          }
+        },
+        "@npmcli/run-script": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/node-gyp": "^2.0.0",
+            "@npmcli/promise-spawn": "^3.0.0",
+            "node-gyp": "^9.0.0",
+            "read-package-json-fast": "^2.0.3"
+          }
+        },
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "agent-base": {
+          "version": "6.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "agentkeepalive": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "depd": "^1.1.2",
+            "humanize-ms": "^1.2.1"
+          }
+        },
+        "aggregate-error": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aproba": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bin-links": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cmd-shim": "^5.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-normalize-package-bin": "^1.0.0",
+            "read-cmd-shim": "^3.0.0",
+            "rimraf": "^3.0.0",
+            "write-file-atomic": "^4.0.0"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "builtins": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^7.0.0"
+          }
+        },
+        "cacache": {
+          "version": "16.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^2.0.0",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
+            "glob": "^8.0.1",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^9.0.0",
+            "tar": "^6.1.11",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cidr-regex": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ip-regex": "^4.1.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cli-columns": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@colors/colors": "1.5.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "cmd-shim": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mkdirp-infer-owner": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "columnify": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-ansi": "^6.0.1",
+            "wcwidth": "^1.0.0"
+          }
+        },
+        "common-ancestor-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.2"
+          }
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "^2.0.0",
+            "wrappy": "1"
+          }
+        },
+        "diff": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "encoding": {
+          "version": "0.1.13",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "iconv-lite": "^0.6.2"
+          }
+        },
+        "env-paths": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "err-code": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "fastest-levenshtein": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "4.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
+            "has-unicode": "^2.0.1",
+            "signal-exit": "^3.0.7",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.5"
+          }
+        },
+        "glob": {
+          "version": "8.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "bundled": true,
+          "dev": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^7.5.1"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^5.0.1"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "init-package-json": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-package-arg": "^9.0.1",
+            "promzard": "^0.3.0",
+            "read": "^1.0.7",
+            "read-package-json": "^5.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4",
+            "validate-npm-package-name": "^4.0.0"
+          }
+        },
+        "ip": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true
+        },
+        "ip-regex": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-cidr": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cidr-regex": "^3.1.1"
+          }
+        },
+        "is-core-module": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-lambda": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-nice": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "just-diff": {
+          "version": "5.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "just-diff-apply": {
+          "version": "5.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "libnpmaccess": {
+          "version": "6.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "minipass": "^3.1.1",
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmdiff": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/disparity-colors": "^2.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "binary-extensions": "^2.2.0",
+            "diff": "^5.0.0",
+            "minimatch": "^5.0.1",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.0.5",
+            "tar": "^6.1.0"
+          }
+        },
+        "libnpmexec": {
+          "version": "4.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^5.0.0",
+            "@npmcli/ci-detect": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
+            "chalk": "^4.1.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npmlog": "^6.0.2",
+            "pacote": "^13.0.5",
+            "proc-log": "^2.0.0",
+            "read": "^1.0.7",
+            "read-package-json-fast": "^2.0.2",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "libnpmfund": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^5.0.0"
+          }
+        },
+        "libnpmhook": {
+          "version": "8.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmpack": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/run-script": "^3.0.0",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.5.0"
+          }
+        },
+        "libnpmpublish": {
+          "version": "6.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^4.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0",
+            "semver": "^7.3.7",
+            "ssri": "^9.0.0"
+          }
+        },
+        "libnpmsearch": {
+          "version": "5.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmversion": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/run-script": "^3.0.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "proc-log": "^2.0.0",
+            "semver": "^7.3.7"
+          }
+        },
+        "lru-cache": {
+          "version": "7.9.0",
+          "bundled": true,
+          "dev": true
+        },
+        "make-fetch-happen": {
+          "version": "10.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^16.1.0",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^2.0.3",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^6.1.1",
+            "ssri": "^9.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "3.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minipass-collect": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-fetch": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.1.2"
+          }
+        },
+        "minipass-flush": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-json-stream": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "^1.3.1",
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-pipeline": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-sized": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp-infer-owner": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.3",
+          "bundled": true,
+          "dev": true
+        },
+        "node-gyp": {
+          "version": "9.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.6",
+            "make-fetch-happen": "^10.0.3",
+            "nopt": "^5.0.0",
+            "npmlog": "^6.0.0",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.2",
+            "which": "^2.0.2"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "normalize-package-data": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^5.0.0",
+            "is-core-module": "^2.8.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
+        "npm-audit-report": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-install-checks": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^7.1.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-package-arg": {
+          "version": "9.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^5.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-name": "^4.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^8.0.1",
+            "ignore-walk": "^5.0.1",
+            "npm-bundled": "^1.1.2",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "7.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-install-checks": "^5.0.0",
+            "npm-normalize-package-bin": "^1.0.1",
+            "npm-package-arg": "^9.0.0",
+            "semver": "^7.3.5"
+          }
+        },
+        "npm-profile": {
+          "version": "6.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-registry-fetch": "^13.0.1",
+            "proc-log": "^2.0.0"
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "13.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "make-fetch-happen": "^10.0.6",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.3",
+            "minipass-json-stream": "^1.0.1",
+            "minizlib": "^2.1.2",
+            "npm-package-arg": "^9.0.1",
+            "proc-log": "^2.0.0"
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npmlog": {
+          "version": "6.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "^3.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^4.0.3",
+            "set-blocking": "^2.0.0"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "opener": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "pacote": {
+          "version": "13.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/promise-spawn": "^3.0.0",
+            "@npmcli/run-script": "^3.0.1",
+            "cacache": "^16.0.0",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
+            "infer-owner": "^1.0.4",
+            "minipass": "^3.1.6",
+            "mkdirp": "^1.0.4",
+            "npm-package-arg": "^9.0.0",
+            "npm-packlist": "^5.1.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.1",
+            "proc-log": "^2.0.0",
+            "promise-retry": "^2.0.1",
+            "read-package-json": "^5.0.0",
+            "read-package-json-fast": "^2.0.3",
+            "rimraf": "^3.0.2",
+            "ssri": "^9.0.0",
+            "tar": "^6.1.11"
+          }
+        },
+        "parse-conflict-json": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.1",
+            "just-diff": "^5.0.1",
+            "just-diff-apply": "^5.2.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "proc-log": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-all-reject-late": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-call-limit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-retry": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "read": "1"
+          }
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mute-stream": "~0.0.4"
+          }
+        },
+        "read-cmd-shim": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "read-package-json": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^8.0.1",
+            "json-parse-even-better-errors": "^2.3.1",
+            "normalize-package-data": "^4.0.0",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "read-package-json-fast": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.0",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
+          }
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "smart-buffer": {
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "socks": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ip": "^1.1.5",
+            "smart-buffer": "^4.2.0"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "6.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.11",
+          "bundled": true,
+          "dev": true
+        },
+        "ssri": {
+          "version": "9.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "treeverse": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "unique-filename": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtins": "^5.0.0"
+          }
+        },
+        "walk-up-path": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "defaults": "^1.0.3"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2 || 3 || 4"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.1.1",
+      "requires": {
+        "hosted-git-info": "^2.7.1",
+        "osenv": "^0.1.5",
+        "semver": "^5.6.0",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1"
+        }
+      }
+    },
+    "npm-registry-fetch": {
+      "version": "13.1.1",
+      "requires": {
+        "make-fetch-happen": "^10.0.6",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^2.0.3",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "dependencies": {
+        "builtins": {
+          "version": "5.0.1",
+          "requires": {
+            "semver": "^7.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "5.0.0",
+          "requires": {
+            "lru-cache": "^7.5.1"
+          }
+        },
+        "npm-package-arg": {
+          "version": "9.0.2",
+          "requires": {
+            "hosted-git-info": "^5.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-name": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "4.0.0",
+          "requires": {
+            "builtins": "^5.0.0"
+          }
+        }
+      }
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "6.0.2",
+      "requires": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "optional": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0"
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.3",
+      "dev": true,
+      "requires": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2"
+    },
+    "os-tmpdir": {
+      "version": "1.0.2"
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "1.1.0"
+    },
+    "p-each-series": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "p-filter": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "p-map": "^2.0.0"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "dev": true
+        }
+      }
+    },
+    "p-is-promise": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-reduce": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "p-retry": {
+      "version": "4.6.2",
+      "dev": true,
+      "requires": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1"
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7"
+    },
+    "path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "dev": true
+        },
+        "minipass": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+          "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+          "dev": true
+        }
+      }
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0"
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "dev": true
+        }
+      }
+    },
+    "pkginfo": {
+      "version": "0.4.1"
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.10",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0"
+    },
+    "prettier": {
+      "version": "2.6.2",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "proc-log": {
+      "version": "2.0.1"
+    },
+    "process-nextick-args": {
+      "version": "2.0.1"
+    },
+    "promise-inflight": {
+      "version": "1.0.1"
+    },
+    "promise-retry": {
+      "version": "2.0.1",
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.12.0"
+        }
+      }
+    },
+    "promptly": {
+      "version": "3.2.0",
+      "requires": {
+        "read": "^1.0.4"
+      }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0"
+    },
+    "pump": {
+      "version": "3.0.0",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1"
+    },
+    "pupa": {
+      "version": "2.1.1",
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
+    },
+    "pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.3"
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1"
+        }
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2"
+        }
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "redeyed": {
+      "version": "2.1.1",
+      "dev": true,
+      "requires": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "4.2.1",
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.22.0",
+      "requires": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "retry": {
+      "version": "0.13.1"
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "dev": true,
+      "requires": {
+        "glob": "^10.3.7"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "10.3.10",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+          "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^2.3.5",
+            "minimatch": "^9.0.1",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+          "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+          "dev": true
+        }
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1"
+    },
+    "safer-buffer": {
+      "version": "2.1.2"
+    },
+    "semantic-release": {
+      "version": "19.0.3",
+      "dev": true,
+      "requires": {
+        "@semantic-release/commit-analyzer": "^9.0.2",
+        "@semantic-release/error": "^3.0.0",
+        "@semantic-release/github": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
+        "@semantic-release/release-notes-generator": "^10.0.0",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^7.0.0",
+        "debug": "^4.0.0",
+        "env-ci": "^5.0.0",
+        "execa": "^5.0.0",
+        "figures": "^3.0.0",
+        "find-versions": "^4.0.0",
+        "get-stream": "^6.0.0",
+        "git-log-parser": "^1.2.0",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^4.0.0",
+        "lodash": "^4.17.21",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.2",
+        "semver-diff": "^3.1.1",
+        "signale": "^1.2.1",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+    },
+    "semver-diff": {
+      "version": "3.1.1",
+      "requires": {
+        "semver": "^6.3.0"
+      }
+    },
+    "semver-regex": {
+      "version": "3.1.4",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0"
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "should": {
+      "version": "13.2.3",
+      "dev": true,
+      "requires": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.7"
+    },
+    "signale": {
+      "version": "1.4.0",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.2",
+        "figures": "^2.0.0",
+        "pkg-conf": "^2.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6"
+    },
+    "smart-buffer": {
+      "version": "4.2.0"
+    },
+    "socks": {
+      "version": "2.6.2",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.2.0",
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "spawn-error-forwarder": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0"
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11"
+    },
+    "split": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "split2": {
+      "version": "3.2.2",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.17.0",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "8.0.1",
+      "requires": {
+        "minipass": "^3.1.1"
+      }
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "dev": true,
+      "requires": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2"
+        }
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0"
+    },
+    "tar": {
+      "version": "6.1.11",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4"
+        }
+      }
+    },
+    "temp-dir": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "tempy": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "del": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.16.0",
+          "dev": true
+        }
+      }
+    },
+    "test-console": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "text-extensions": {
+      "version": "1.9.0",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "dev": true
+    },
+    "through2": {
+      "version": "4.0.2",
+      "dev": true,
+      "requires": {
+        "readable-stream": "3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true
+    },
+    "to-readable-stream": {
+      "version": "1.0.0"
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "ts-api-utils": {
+      "version": "1.0.3",
+      "dev": true,
+      "requires": {}
+    },
+    "ts-mocha": {
+      "version": "10.0.0",
+      "dev": true,
+      "requires": {
+        "ts-node": "7.0.1",
+        "tsconfig-paths": "^3.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.14.2",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.2",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5"
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "1.4.0",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6"
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "typescript": {
+      "version": "5.2.2",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.15.5",
+      "dev": true,
+      "optional": true
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "requires": {
+        "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "dev": true
+    },
+    "universalify": {
+      "version": "2.0.0"
+    },
+    "update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "update-notifier": {
+      "version": "5.1.0",
+      "requires": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "dev": true
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "uuid": {
+      "version": "3.4.0"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "requires": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "vue-eslint-parser": {
+      "version": "8.3.0",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.2",
+        "eslint-scope": "^7.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.0.0",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "7.1.1",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "widest-line": {
+      "version": "3.1.0",
+      "requires": {
+        "string-width": "^4.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2"
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0"
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0"
+    },
+    "yaml": {
+      "version": "2.1.0"
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "dev": true
+        }
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.7.1",
-    "fast-check": "^3.13.2",
     "mocha": "^10.1.0",
     "nock": "^13.2.4",
     "prettier": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.7.1",
+    "fast-check": "^3.13.2",
     "mocha": "^10.0.0",
     "nock": "^13.2.4",
     "prettier": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://openupm.com",
   "devDependencies": {
-    "@babel/core": "^7.17.10",
+    "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.17.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
@@ -58,7 +58,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.7.1",
     "fast-check": "^3.13.2",
-    "mocha": "^10.0.0",
+    "mocha": "^10.1.0",
     "nock": "^13.2.4",
     "prettier": "^2.6.2",
     "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@types/pkginfo": "^0.4.1",
     "@types/promptly": "^3.0.3",
     "@types/request": "^2.48.11",
-    "@types/should": "^13.0.0",
     "@types/test-console": "^2.0.1",
     "@types/update-notifier": "^6.0.5",
     "@typescript-eslint/eslint-plugin": "^6.8.0",

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -19,10 +19,17 @@ export type AddOptions = {
   _global: GlobalOptions;
 };
 
+type ResultCode = 0 | 1;
+
+type AddResult = {
+  dirty: boolean;
+  code: ResultCode;
+};
+
 export const add = async function (
   pkgs: PkgName | PkgName[],
   options: AddOptions
-): Promise<number> {
+): Promise<ResultCode> {
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
   const envOk = await parseEnv(options, { checkPath: true });
@@ -33,7 +40,7 @@ export const add = async function (
     results.push(
       await _add({ pkg, testables: options.test, force: options.force })
     );
-  const result = {
+  const result: AddResult = {
     code: results.filter((x) => x.code != 0).length > 0 ? 1 : 0,
     dirty: results.filter((x) => x.dirty).length > 0,
   };
@@ -51,7 +58,7 @@ const _add = async function ({
   pkg: PkgName;
   testables?: boolean;
   force?: boolean;
-}) {
+}): Promise<AddResult> {
   // dirty flag
   let dirty = false;
   // is upstream package flag

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -46,7 +46,7 @@ const printInfo = function (pkg: PkgInfo) {
   const homepage = verInfo.homepage;
   const dist = verInfo.dist;
   const dependencies = verInfo.dependencies;
-  const latest = pkg["dist-tags"].latest;
+  const latest = pkg["dist-tags"]?.latest;
   let time = pkg.time.modified;
   if (!time && latest && latest in pkg.time) time = pkg.time[latest];
 

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -44,27 +44,49 @@ export type Dist = {
   integrity: string;
 };
 
+export type Contact = {
+  name: string;
+  email?: string;
+  url?: string;
+};
+
 export type PkgVersionInfo = {
+  _id?: PkgName;
+  _nodeVersion?: string;
+  _npmVersion?: string;
+  _rev?: string;
+  name: string;
+  version: string;
   unity?: string;
-  unityRelease: string;
-  dependencies: Record<PkgName, PkgVersion>;
+  unityRelease?: string;
+  dependencies?: Record<PkgName, PkgVersion>;
   license?: string;
-  displayName: string;
+  displayName?: string;
   description?: string;
   keywords?: string[];
-  homepage: string;
+  homepage?: string;
+  category?: string;
+  gitHead?: string;
+  readmeFilename?: string;
+  author?: Contact;
+  contributors?: Contact[];
   dist?: Dist;
 };
 
 export type PkgInfo = {
   name: PkgName;
+  _id?: PkgName;
+  _rev?: string;
+  _attachments?: Record<string, unknown>;
+  readme?: string;
   versions: Record<PkgVersion, PkgVersionInfo>;
-  "dist-tags": { latest?: PkgVersion };
+  "dist-tags"?: { latest?: PkgVersion };
   version?: PkgVersion;
   description?: string;
   keywords?: string[];
   time: Record<"created" | "modified" | PkgVersion, string>;
   date?: Date;
+  users?: Record<string, unknown>;
 };
 
 export type NameVersionPair = {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -74,7 +74,7 @@ export type PkgVersionInfo = {
 };
 
 export type PkgInfo = {
-  name: PkgName;
+  name: ReverseDomainName;
   _id?: PkgName;
   _rev?: string;
   _attachments?: Record<string, unknown>;

--- a/src/utils/pkg-info.ts
+++ b/src/utils/pkg-info.ts
@@ -10,9 +10,10 @@ const hasLatestDistTag = (
  * Attempt to get the latest version from a package
  * @param pkgInfo The package. All properties are assumed to be potentially missing
  */
-export const tryGetLatestVersion = function (
-  pkgInfo: Partial<PkgInfo>
-): PkgVersion | undefined {
+export const tryGetLatestVersion = function (pkgInfo: {
+  "dist-tags"?: { latest?: PkgVersion };
+  version?: PkgVersion;
+}): PkgVersion | undefined {
   if (hasLatestDistTag(pkgInfo)) return pkgInfo["dist-tags"].latest;
   else if (pkgInfo.version) return pkgInfo.version;
 };

--- a/test/manifest-assertions.ts
+++ b/test/manifest-assertions.ts
@@ -1,0 +1,25 @@
+import { PkgManifest, PkgName, PkgVersion } from "../src/types/global";
+import { loadManifest } from "../src/utils/manifest";
+import "should";
+import should from "should";
+
+function requireManifest(): PkgManifest {
+  const manifest = loadManifest();
+  (manifest !== null).should.be.ok();
+  return manifest!;
+}
+
+export function shouldHaveManifestMatching(
+  expected: PkgManifest
+): should.Assertion {
+  const manifest = requireManifest();
+  return manifest.should.be.deepEqual(expected);
+}
+
+export function shouldHaveManifestWithDependency(
+  name: PkgName,
+  version: PkgVersion
+): should.Assertion {
+  const manifest = requireManifest();
+  return should(manifest.dependencies[name]).equal(version);
+}

--- a/test/manifest-assertions.ts
+++ b/test/manifest-assertions.ts
@@ -12,6 +12,21 @@ export function shouldHaveDependency(
   manifest: PkgManifest,
   name: PkgName,
   version: PkgVersion
-): should.Assertion {
-  return should(manifest.dependencies[name]).equal(version);
+) {
+  should(manifest.dependencies[name]).equal(version);
+}
+export function shouldNotHaveDependency(manifest: PkgManifest, name: PkgName) {
+  should(manifest.dependencies[name]).be.undefined();
+}
+
+export function shouldHaveRegistryWithScopes(
+  manifest: PkgManifest,
+  scopes: PkgName[]
+) {
+  should(manifest.scopedRegistries).not.be.undefined();
+  manifest
+    .scopedRegistries!.some((registry) =>
+      scopes.every((scope) => registry.scopes.includes(scope))
+    )
+    .should.be.true("At least one scope was missing");
 }

--- a/test/manifest-assertions.ts
+++ b/test/manifest-assertions.ts
@@ -8,12 +8,21 @@ export function shouldHaveManifest(): PkgManifest {
   return manifest!;
 }
 
+export function shouldHaveNoManifest() {
+  const manifest = loadManifest();
+  should(manifest).be.null();
+}
+
 export function shouldHaveDependency(
   manifest: PkgManifest,
   name: PkgName,
   version: PkgVersion
 ) {
   should(manifest.dependencies[name]).equal(version);
+}
+
+export function shouldNotHaveAnyDependencies(manifest: PkgManifest) {
+  should(manifest.dependencies).be.empty();
 }
 export function shouldNotHaveDependency(manifest: PkgManifest, name: PkgName) {
   should(manifest.dependencies[name]).be.undefined();

--- a/test/manifest-assertions.ts
+++ b/test/manifest-assertions.ts
@@ -1,25 +1,17 @@
 import { PkgManifest, PkgName, PkgVersion } from "../src/types/global";
 import { loadManifest } from "../src/utils/manifest";
-import "should";
 import should from "should";
 
-function requireManifest(): PkgManifest {
+export function shouldHaveManifest(): PkgManifest {
   const manifest = loadManifest();
-  (manifest !== null).should.be.ok();
+  should(manifest).not.be.null();
   return manifest!;
 }
 
-export function shouldHaveManifestMatching(
-  expected: PkgManifest
-): should.Assertion {
-  const manifest = requireManifest();
-  return manifest.should.be.deepEqual(expected);
-}
-
-export function shouldHaveManifestWithDependency(
+export function shouldHaveDependency(
+  manifest: PkgManifest,
   name: PkgName,
   version: PkgVersion
 ): should.Assertion {
-  const manifest = requireManifest();
   return should(manifest.dependencies[name]).equal(version);
 }

--- a/test/mock-console.ts
+++ b/test/mock-console.ts
@@ -1,0 +1,23 @@
+import testConsole from "test-console";
+
+export const getOutputs = function (
+  stdouInspect: testConsole.Inspector,
+  stderrInsepct: testConsole.Inspector
+): [string, string] {
+  const results: [string, string] = [
+    stdouInspect.output.join(""),
+    stderrInsepct.output.join(""),
+  ];
+  stdouInspect.restore();
+  stderrInsepct.restore();
+  return results;
+};
+
+export const getInspects = function (): [
+  testConsole.Inspector,
+  testConsole.Inspector
+] {
+  const stdoutInspect = testConsole.stdout.inspect();
+  const stderrInspect = testConsole.stderr.inspect();
+  return [stdoutInspect, stderrInspect];
+};

--- a/test/mock-console.ts
+++ b/test/mock-console.ts
@@ -1,8 +1,10 @@
 import testConsole from "test-console";
 
+export type MockConsoleInspector = testConsole.Inspector;
+
 export const getOutputs = function (
-  stdouInspect: testConsole.Inspector,
-  stderrInsepct: testConsole.Inspector
+  stdouInspect: MockConsoleInspector,
+  stderrInsepct: MockConsoleInspector
 ): [string, string] {
   const results: [string, string] = [
     stdouInspect.output.join(""),
@@ -14,8 +16,8 @@ export const getOutputs = function (
 };
 
 export const getInspects = function (): [
-  testConsole.Inspector,
-  testConsole.Inspector
+  MockConsoleInspector,
+  MockConsoleInspector
 ] {
   const stdoutInspect = testConsole.stdout.inspect();
   const stderrInspect = testConsole.stderr.inspect();

--- a/test/mock-console.ts
+++ b/test/mock-console.ts
@@ -1,25 +1,23 @@
 import testConsole from "test-console";
 
-export type MockConsoleInspector = testConsole.Inspector;
+type Stream = "out" | "error";
 
-export const getOutputs = function (
-  stdouInspect: MockConsoleInspector,
-  stderrInsepct: MockConsoleInspector
-): [string, string] {
-  const results: [string, string] = [
-    stdouInspect.output.join(""),
-    stderrInsepct.output.join(""),
-  ];
-  stdouInspect.restore();
-  stderrInsepct.restore();
-  return results;
+export type MockConsole = {
+  hasLineIncluding(stream: Stream, text: string): boolean;
+  detach(): void;
 };
 
-export const getInspects = function (): [
-  MockConsoleInspector,
-  MockConsoleInspector
-] {
-  const stdoutInspect = testConsole.stdout.inspect();
-  const stderrInspect = testConsole.stderr.inspect();
-  return [stdoutInspect, stderrInspect];
-};
+export function attachMockConsole(): MockConsole {
+  const out = testConsole.stdout.inspect();
+  const error = testConsole.stderr.inspect();
+  return {
+    hasLineIncluding(stream: Stream, text: string): boolean {
+      const inspector = stream === "out" ? out : error;
+      return inspector.output.some((line) => line.includes(text));
+    },
+    detach() {
+      out.restore();
+      error.restore();
+    },
+  };
+}

--- a/test/mock-registry.ts
+++ b/test/mock-registry.ts
@@ -2,15 +2,15 @@ import { PkgInfo, PkgName } from "../src/types/global";
 import nock from "nock";
 import { SearchEndpointResult } from "./types";
 
-const unityRegistryUrl = "https://packages.unity.com";
-const registryUrl = "http://example.com";
+export const unityRegistryUrl = "https://packages.unity.com";
+export const exampleRegistryUrl = "http://example.com";
 
 export function startMockRegistry() {
   if (!nock.isActive()) nock.activate();
 }
 
 export function registerRemotePkg(pkg: PkgInfo) {
-  nock(registryUrl)
+  nock(exampleRegistryUrl)
     .persist()
     .get(`/${pkg.name}`)
     .reply(200, pkg, { "Content-Type": "application/json" });
@@ -20,11 +20,11 @@ export function registerRemoteUpstreamPkg(pkg: PkgInfo) {
   nock(unityRegistryUrl).persist().get(`/${pkg.name}`).reply(200, pkg, {
     "Content-Type": "application/json",
   });
-  nock(registryUrl).persist().get(`/${pkg.name}`).reply(404);
+  nock(exampleRegistryUrl).persist().get(`/${pkg.name}`).reply(404);
 }
 
 export function registerMissingPackage(name: PkgName) {
-  nock(registryUrl).persist().get(`/${name}`).reply(404);
+  nock(exampleRegistryUrl).persist().get(`/${name}`).reply(404);
   nock(unityRegistryUrl).persist().get(`/${name}`).reply(404);
 }
 
@@ -32,7 +32,7 @@ export function registerSearchResult(
   searchText: string,
   result: SearchEndpointResult
 ) {
-  nock(registryUrl)
+  nock(exampleRegistryUrl)
     .get(new RegExp(`-\\/v1\\/search\\?text=${searchText}`))
     .reply(200, result, {
       "Content-Type": "application/json",

--- a/test/mock-registry.ts
+++ b/test/mock-registry.ts
@@ -1,0 +1,45 @@
+import { PkgInfo, PkgName } from "../src/types/global";
+import nock from "nock";
+import { SearchEndpointResult } from "./types";
+
+const unityRegistryUrl = "https://packages.unity.com";
+const registryUrl = "http://example.com";
+
+export function startMockRegistry() {
+  if (!nock.isActive()) nock.activate();
+}
+
+export function registerRemotePkg(pkg: PkgInfo) {
+  nock(registryUrl)
+    .persist()
+    .get(`/${pkg.name}`)
+    .reply(200, pkg, { "Content-Type": "application/json" });
+}
+
+export function registerRemoteUpstreamPkg(pkg: PkgInfo) {
+  nock(unityRegistryUrl).persist().get(`/${pkg.name}`).reply(200, pkg, {
+    "Content-Type": "application/json",
+  });
+  nock(registryUrl).persist().get(`/${pkg.name}`).reply(404);
+}
+
+export function registerMissingPackage(name: PkgName) {
+  nock(registryUrl).persist().get(`/${name}`).reply(404);
+  nock(unityRegistryUrl).persist().get(`/${name}`).reply(404);
+}
+
+export function registerSearchResult(
+  searchText: string,
+  result: SearchEndpointResult
+) {
+  nock(registryUrl)
+    .get(new RegExp(`-\\/v1\\/search\\?text=${searchText}`))
+    .reply(200, result, {
+      "Content-Type": "application/json",
+    });
+}
+
+export function stopMockRegistry() {
+  nock.restore();
+  nock.cleanAll();
+}

--- a/test/mock-work-dir.ts
+++ b/test/mock-work-dir.ts
@@ -1,19 +1,16 @@
-import fse from "fs-extra";
 import path from "path";
 import os from "os";
-import testConsole from "test-console";
 import { PkgManifest } from "../src/types/global";
+import fse from "fs-extra";
 import _ from "lodash";
 
 export type ManifestCreationOptions = {
   manifest: boolean | PkgManifest;
   editorVersion?: string;
 };
-
 export const getWorkDir = function (pathToTmp: string): string {
   return path.join(os.tmpdir(), pathToTmp);
 };
-
 export const createWorkDir = function (
   pathToTmp: string,
   { manifest, editorVersion }: ManifestCreationOptions
@@ -37,30 +34,7 @@ export const createWorkDir = function (
     );
   }
 };
-
 export const removeWorkDir = function (pathToTmp: string) {
   const cwd = getWorkDir(pathToTmp);
   fse.removeSync(cwd);
-};
-
-export const getOutputs = function (
-  stdouInspect: testConsole.Inspector,
-  stderrInsepct: testConsole.Inspector
-): [string, string] {
-  const results: [string, string] = [
-    stdouInspect.output.join(""),
-    stderrInsepct.output.join(""),
-  ];
-  stdouInspect.restore();
-  stderrInsepct.restore();
-  return results;
-};
-
-export const getInspects = function (): [
-  testConsole.Inspector,
-  testConsole.Inspector
-] {
-  const stdoutInspect = testConsole.stdout.inspect();
-  const stderrInspect = testConsole.stderr.inspect();
-  return [stdoutInspect, stderrInspect];
 };

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -2,7 +2,7 @@ import "assert";
 import nock from "nock";
 import "should";
 
-import { add } from "../src/cmd-add";
+import { add, AddOptions } from "../src/cmd-add";
 
 import {
   createWorkDir,
@@ -16,23 +16,24 @@ import {
 import testConsole from "test-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
+import { PkgInfo, PkgManifest } from "../src/types/global";
 
 describe("cmd-add.ts", function () {
-  const options = {
+  const options: AddOptions = {
     _global: {
       registry: "http://example.com",
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };
-  const upstreamOptions = {
+  const upstreamOptions: AddOptions = {
     _global: {
       registry: "http://example.com",
       upstream: true,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };
-  const testableOptions = {
+  const testableOptions: AddOptions = {
     _global: {
       registry: "http://example.com",
       upstream: false,
@@ -40,7 +41,7 @@ describe("cmd-add.ts", function () {
     },
     test: true,
   };
-  const forceOptions = {
+  const forceOptions: AddOptions = {
     _global: {
       registry: "http://example.com",
       upstream: false,
@@ -51,7 +52,7 @@ describe("cmd-add.ts", function () {
   describe("add", function () {
     let stdoutInspect: testConsole.Inspector = null!;
     let stderrInspect: testConsole.Inspector = null!;
-    const remotePkgInfoA = {
+    const remotePkgInfoA: PkgInfo = {
       name: "com.base.package-a",
       versions: {
         "0.1.0": {
@@ -68,8 +69,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoB = {
+    const remotePkgInfoB: PkgInfo = {
       name: "com.base.package-b",
       versions: {
         "1.0.0": {
@@ -81,8 +83,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoC = {
+    const remotePkgInfoC: PkgInfo = {
       name: "com.base.package-c",
       versions: {
         "1.0.0": {
@@ -97,8 +100,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoD = {
+    const remotePkgInfoD: PkgInfo = {
       name: "com.base.package-d",
       versions: {
         "1.0.0": {
@@ -112,8 +116,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoWithLowerEditorVersion = {
+    const remotePkgInfoWithLowerEditorVersion: PkgInfo = {
       name: "com.base.package-with-lower-editor-version",
       versions: {
         "1.0.0": {
@@ -126,8 +131,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoWithHigherEditorVersion = {
+    const remotePkgInfoWithHigherEditorVersion: PkgInfo = {
       name: "com.base.package-with-higher-editor-version",
       versions: {
         "1.0.0": {
@@ -139,8 +145,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoWithWrongEditorVersion = {
+    const remotePkgInfoWithWrongEditorVersion: PkgInfo = {
       name: "com.base.package-with-wrong-editor-version",
       versions: {
         "1.0.0": {
@@ -152,8 +159,9 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoUp = {
+    const remotePkgInfoUp: PkgInfo = {
       name: "com.upstream.package-up",
       versions: {
         "1.0.0": {
@@ -165,11 +173,12 @@ describe("cmd-add.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const defaultManifest = {
+    const defaultManifest: PkgManifest = {
       dependencies: {},
     };
-    const expectedManifestA = {
+    const expectedManifestA: PkgManifest = {
       dependencies: {
         "com.base.package-a": "1.0.0",
       },
@@ -181,7 +190,7 @@ describe("cmd-add.ts", function () {
         },
       ],
     };
-    const expectedManifestAB = {
+    const expectedManifestAB: PkgManifest = {
       dependencies: {
         "com.base.package-a": "1.0.0",
         "com.base.package-b": "1.0.0",
@@ -194,7 +203,7 @@ describe("cmd-add.ts", function () {
         },
       ],
     };
-    const expectedManifestC = {
+    const expectedManifestC: PkgManifest = {
       dependencies: {
         "com.base.package-c": "1.0.0",
       },
@@ -206,12 +215,12 @@ describe("cmd-add.ts", function () {
         },
       ],
     };
-    const expectedManifestUpstream = {
+    const expectedManifestUpstream: PkgManifest = {
       dependencies: {
         "com.upstream.package-up": "1.0.0",
       },
     };
-    const expectedManifestTestable = {
+    const expectedManifestTestable: PkgManifest = {
       dependencies: {
         "com.base.package-a": "1.0.0",
       },

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -13,8 +13,8 @@ import {
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import {
-  shouldHaveManifest,
   shouldHaveDependency,
+  shouldHaveManifest,
 } from "./manifest-assertions";
 
 describe("cmd-add.ts", function () {

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -1,4 +1,3 @@
-import "assert";
 import "should";
 import { add, AddOptions } from "../src/cmd-add";
 import { PkgInfo, PkgManifest } from "../src/types/global";

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -15,6 +15,7 @@ import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
 import { PkgInfo, PkgManifest } from "../src/types/global";
 import {
+  exampleRegistryUrl,
   registerMissingPackage,
   registerRemotePkg,
   registerRemoteUpstreamPkg,
@@ -25,21 +26,21 @@ import {
 describe("cmd-add.ts", function () {
   const options: AddOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };
   const upstreamOptions: AddOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       upstream: true,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };
   const testableOptions: AddOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
@@ -47,7 +48,7 @@ describe("cmd-add.ts", function () {
   };
   const forceOptions: AddOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
@@ -190,7 +191,7 @@ describe("cmd-add.ts", function () {
         {
           name: "example.com",
           scopes: ["com.base.package-a", "com.example"],
-          url: "http://example.com",
+          url: exampleRegistryUrl,
         },
       ],
     };
@@ -203,7 +204,7 @@ describe("cmd-add.ts", function () {
         {
           name: "example.com",
           scopes: ["com.base.package-a", "com.base.package-b", "com.example"],
-          url: "http://example.com",
+          url: exampleRegistryUrl,
         },
       ],
     };
@@ -215,7 +216,7 @@ describe("cmd-add.ts", function () {
         {
           name: "example.com",
           scopes: ["com.base.package-c", "com.base.package-d", "com.example"],
-          url: "http://example.com",
+          url: exampleRegistryUrl,
         },
       ],
     };
@@ -232,7 +233,7 @@ describe("cmd-add.ts", function () {
         {
           name: "example.com",
           scopes: ["com.base.package-a", "com.example"],
-          url: "http://example.com",
+          url: exampleRegistryUrl,
         },
       ],
       testables: ["com.base.package-a"],

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -3,13 +3,7 @@ import "should";
 
 import { add, AddOptions } from "../src/cmd-add";
 
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import testConsole from "test-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
@@ -22,6 +16,7 @@ import {
   startMockRegistry,
   stopMockRegistry,
 } from "./mock-registry";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-add.ts", function () {
   const options: AddOptions = {

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -13,8 +13,8 @@ import {
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import {
-  shouldHaveManifestMatching,
-  shouldHaveManifestWithDependency,
+  shouldHaveManifest,
+  shouldHaveDependency,
 } from "./manifest-assertions";
 
 describe("cmd-add.ts", function () {
@@ -260,21 +260,24 @@ describe("cmd-add.ts", function () {
     it("add pkg", async function () {
       const retCode = await add("com.base.package-a", options);
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestA);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestA);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
     it("add pkg@1.0.0", async function () {
       const retCode = await add("com.base.package-a@1.0.0", options);
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestA);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestA);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
     it("add pkg@latest", async function () {
       const retCode = await add("com.base.package-a@latest", options);
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestA);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestA);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
@@ -283,7 +286,8 @@ describe("cmd-add.ts", function () {
       retCode1.should.equal(0);
       const retCode2 = await add("com.base.package-a@1.0.0", options);
       retCode2.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestA);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestA);
       mockConsole.hasLineIncluding("out", "modified ").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
@@ -292,14 +296,16 @@ describe("cmd-add.ts", function () {
       retCode1.should.equal(0);
       const retCode2 = await add("com.base.package-a@1.0.0", options);
       retCode2.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestA);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestA);
       mockConsole.hasLineIncluding("out", "existed ").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
     it("add pkg@not-exist-version", async function () {
       const retCode = await add("com.base.package-a@2.0.0", options);
       retCode.should.equal(1);
-      shouldHaveManifestMatching(defaultManifest);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(defaultManifest);
       mockConsole
         .hasLineIncluding("out", "version 2.0.0 is not a valid choice")
         .should.be.ok();
@@ -309,7 +315,8 @@ describe("cmd-add.ts", function () {
       const gitUrl = "https://github.com/yo/com.base.package-a";
       const retCode = await add("com.base.package-a@" + gitUrl, options);
       retCode.should.equal(0);
-      shouldHaveManifestWithDependency("com.base.package-a", gitUrl);
+      const manifest = shouldHaveManifest();
+      shouldHaveDependency(manifest, "com.base.package-a", gitUrl);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
@@ -317,7 +324,8 @@ describe("cmd-add.ts", function () {
       const gitUrl = "git@github.com:yo/com.base.package-a";
       const retCode = await add("com.base.package-a@" + gitUrl, options);
       retCode.should.equal(0);
-      shouldHaveManifestWithDependency("com.base.package-a", gitUrl);
+      const manifest = shouldHaveManifest();
+      shouldHaveDependency(manifest, "com.base.package-a", gitUrl);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
@@ -325,14 +333,16 @@ describe("cmd-add.ts", function () {
       const fileUrl = "file../yo/com.base.package-a";
       const retCode = await add("com.base.package-a@" + fileUrl, options);
       retCode.should.equal(0);
-      shouldHaveManifestWithDependency("com.base.package-a", fileUrl);
+      const manifest = shouldHaveManifest();
+      shouldHaveDependency(manifest, "com.base.package-a", fileUrl);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
     it("add pkg-not-exist", async function () {
       const retCode = await add("pkg-not-exist", options);
       retCode.should.equal(1);
-      shouldHaveManifestMatching(defaultManifest);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(defaultManifest);
       mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
     });
     it("add more than one pkgs", async function () {
@@ -341,7 +351,8 @@ describe("cmd-add.ts", function () {
         options
       );
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestAB);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestAB);
       mockConsole
         .hasLineIncluding("out", "added com.base.package-a")
         .should.be.ok();
@@ -353,7 +364,8 @@ describe("cmd-add.ts", function () {
     it("add pkg from upstream", async function () {
       const retCode = await add("com.upstream.package-up", upstreamOptions);
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestUpstream);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestUpstream);
       mockConsole
         .hasLineIncluding("out", "added com.upstream.package-up")
         .should.be.ok();
@@ -362,20 +374,23 @@ describe("cmd-add.ts", function () {
     it("add pkg-not-exist from upstream", async function () {
       const retCode = await add("pkg-not-exist", upstreamOptions);
       retCode.should.equal(1);
-      shouldHaveManifestMatching(defaultManifest);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(defaultManifest);
       mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
     });
     it("add pkg with nested dependencies", async function () {
       const retCode = await add("com.base.package-c@latest", upstreamOptions);
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestC);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestC);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
     it("add pkg with tests", async function () {
       const retCode = await add("com.base.package-a", testableOptions);
       retCode.should.equal(0);
-      shouldHaveManifestMatching(expectedManifestTestable);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(expectedManifestTestable);
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -1,10 +1,7 @@
 import "assert";
 import "should";
-
 import { add, AddOptions } from "../src/cmd-add";
-
-import { loadManifest } from "../src/utils/manifest";
-import { PkgInfo, PkgManifest, PkgName, PkgVersion } from "../src/types/global";
+import { PkgInfo, PkgManifest } from "../src/types/global";
 import {
   exampleRegistryUrl,
   registerMissingPackage,
@@ -15,6 +12,10 @@ import {
 } from "./mock-registry";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 import { attachMockConsole, MockConsole } from "./mock-console";
+import {
+  shouldHaveManifestMatching,
+  shouldHaveManifestWithDependency,
+} from "./manifest-assertions";
 
 describe("cmd-add.ts", function () {
   const options: AddOptions = {
@@ -255,27 +256,6 @@ describe("cmd-add.ts", function () {
       stopMockRegistry();
       mockConsole.detach();
     });
-
-    function shouldHaveManifest(): PkgManifest {
-      const manifest = loadManifest();
-      (manifest !== null).should.be.ok();
-      return manifest!;
-    }
-
-    function shouldHaveManifestMatching(expected: PkgManifest) {
-      const manifest = shouldHaveManifest();
-      manifest!.should.be.deepEqual(expected);
-    }
-
-    function shouldHaveManifestWithDependency(
-      name: PkgName,
-      version: PkgVersion
-    ) {
-      const manifest = shouldHaveManifest();
-      const dependency = manifest.dependencies[name];
-      (dependency !== undefined).should.be.ok();
-      dependency.should.be.equal(version);
-    }
 
     it("add pkg", async function () {
       const retCode = await add("com.base.package-a", options);

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -3,8 +3,7 @@ import "should";
 
 import { add, AddOptions } from "../src/cmd-add";
 
-import { getInspects, getOutputs } from "./mock-console";
-import testConsole from "test-console";
+import { MockConsoleInspector, getInspects, getOutputs } from "./mock-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
 import { PkgInfo, PkgManifest } from "../src/types/global";
@@ -50,8 +49,8 @@ describe("cmd-add.ts", function () {
     force: true,
   };
   describe("add", function () {
-    let stdoutInspect: testConsole.Inspector = null!;
-    let stderrInspect: testConsole.Inspector = null!;
+    let stdoutInspect: MockConsoleInspector = null!;
+    let stderrInspect: MockConsoleInspector = null!;
     const remotePkgInfoA: PkgInfo = {
       name: "com.base.package-a",
       versions: {

--- a/test/test-cmd-deps.ts
+++ b/test/test-cmd-deps.ts
@@ -3,8 +3,7 @@ import "should";
 
 import { deps, DepsOptions } from "../src/cmd-deps";
 
-import { getInspects, getOutputs } from "./mock-console";
-import testConsole from "test-console";
+import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import {
   exampleRegistryUrl,
   registerMissingPackage,
@@ -24,8 +23,8 @@ describe("cmd-deps.ts", function () {
     },
   };
   describe("deps", function () {
-    let stdoutInspect: testConsole.Inspector = null!;
-    let stderrInspect: testConsole.Inspector = null!;
+    let stdoutInspect: MockConsoleInspector = null!;
+    let stderrInspect: MockConsoleInspector = null!;
 
     const remotePkgInfoA: PkgInfo = {
       name: "com.example.package-a",

--- a/test/test-cmd-deps.ts
+++ b/test/test-cmd-deps.ts
@@ -2,7 +2,7 @@ import "assert";
 import nock from "nock";
 import "should";
 
-import { deps } from "../src/cmd-deps";
+import { deps, DepsOptions } from "../src/cmd-deps";
 
 import {
   createWorkDir,
@@ -14,9 +14,10 @@ import {
   removeWorkDir,
 } from "./utils";
 import testConsole from "test-console";
+import { PkgInfo } from "../src/types/global";
 
 describe("cmd-deps.ts", function () {
-  const options = {
+  const options: DepsOptions = {
     _global: {
       registry: "http://example.com",
       chdir: getWorkDir("test-openupm-cli"),
@@ -26,7 +27,7 @@ describe("cmd-deps.ts", function () {
     let stdoutInspect: testConsole.Inspector = null!;
     let stderrInspect: testConsole.Inspector = null!;
 
-    const remotePkgInfoA = {
+    const remotePkgInfoA: PkgInfo = {
       name: "com.example.package-a",
       versions: {
         "1.0.0": {
@@ -40,8 +41,9 @@ describe("cmd-deps.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoB = {
+    const remotePkgInfoB: PkgInfo = {
       name: "com.example.package-b",
       versions: {
         "1.0.0": {
@@ -55,8 +57,9 @@ describe("cmd-deps.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
-    const remotePkgInfoUp = {
+    const remotePkgInfoUp: PkgInfo = {
       name: "com.example.package-up",
       versions: {
         "1.0.0": {
@@ -68,6 +71,7 @@ describe("cmd-deps.ts", function () {
       "dist-tags": {
         latest: "1.0.0",
       },
+      time: {},
     };
     beforeEach(function () {
       removeWorkDir("test-openupm-cli");

--- a/test/test-cmd-deps.ts
+++ b/test/test-cmd-deps.ts
@@ -3,13 +3,7 @@ import "should";
 
 import { deps, DepsOptions } from "../src/cmd-deps";
 
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import testConsole from "test-console";
 import {
   exampleRegistryUrl,
@@ -20,6 +14,7 @@ import {
   stopMockRegistry,
 } from "./mock-registry";
 import { PkgInfo } from "../src/types/global";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-deps.ts", function () {
   const options: DepsOptions = {

--- a/test/test-cmd-deps.ts
+++ b/test/test-cmd-deps.ts
@@ -1,8 +1,5 @@
-import "assert";
 import "should";
-
 import { deps, DepsOptions } from "../src/cmd-deps";
-
 import {
   exampleRegistryUrl,
   registerMissingPackage,

--- a/test/test-cmd-deps.ts
+++ b/test/test-cmd-deps.ts
@@ -12,6 +12,7 @@ import {
 } from "./utils";
 import testConsole from "test-console";
 import {
+  exampleRegistryUrl,
   registerMissingPackage,
   registerRemotePkg,
   registerRemoteUpstreamPkg,
@@ -23,7 +24,7 @@ import { PkgInfo } from "../src/types/global";
 describe("cmd-deps.ts", function () {
   const options: DepsOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };

--- a/test/test-cmd-login.ts
+++ b/test/test-cmd-login.ts
@@ -1,4 +1,3 @@
-import "assert";
 import "nock";
 import should from "should";
 import {

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -102,7 +102,7 @@ describe("cmd-remove.ts", function () {
         options
       );
       retCode.should.equal(0);
-      const manifest = await loadManifest();
+      const manifest = loadManifest();
       assert(manifest !== null);
       (
         manifest.dependencies["com.example.package-a"] == undefined

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -1,4 +1,3 @@
-import "assert";
 import "should";
 import { remove } from "../src/cmd-remove";
 import { PkgManifest } from "../src/types/global";

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -3,18 +3,13 @@ import "should";
 
 import { remove } from "../src/cmd-remove";
 
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import testConsole from "test-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
 import { PkgManifest } from "../src/types/global";
 import { exampleRegistryUrl } from "./mock-registry";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-remove.ts", function () {
   describe("remove", function () {

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -14,6 +14,7 @@ import testConsole from "test-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
 import { PkgManifest } from "../src/types/global";
+import { exampleRegistryUrl } from "./mock-registry";
 
 describe("cmd-remove.ts", function () {
   describe("remove", function () {
@@ -32,7 +33,7 @@ describe("cmd-remove.ts", function () {
             "com.example.package-a",
             "com.example.package-b",
           ],
-          url: "http://example.com",
+          url: exampleRegistryUrl,
         },
       ],
     };
@@ -51,7 +52,7 @@ describe("cmd-remove.ts", function () {
     it("remove pkg", async function () {
       const options = {
         _global: {
-          registry: "http://example.com",
+          registry: exampleRegistryUrl,
           chdir: getWorkDir("test-openupm-cli"),
         },
       };
@@ -75,7 +76,7 @@ describe("cmd-remove.ts", function () {
     it("remove pkg@1.0.0", async function () {
       const options = {
         _global: {
-          registry: "http://example.com",
+          registry: exampleRegistryUrl,
           chdir: getWorkDir("test-openupm-cli"),
         },
       };
@@ -90,7 +91,7 @@ describe("cmd-remove.ts", function () {
     it("remove pkg-not-exist", async function () {
       const options = {
         _global: {
-          registry: "http://example.com",
+          registry: exampleRegistryUrl,
           chdir: getWorkDir("test-openupm-cli"),
         },
       };
@@ -105,7 +106,7 @@ describe("cmd-remove.ts", function () {
     it("remove more than one pkgs", async function () {
       const options = {
         _global: {
-          registry: "http://example.com",
+          registry: exampleRegistryUrl,
           chdir: getWorkDir("test-openupm-cli"),
         },
       };

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -1,14 +1,11 @@
 import "assert";
 import "should";
 import { remove } from "../src/cmd-remove";
-import assert from "assert";
-import { loadManifest } from "../src/utils/manifest";
 import { PkgManifest } from "../src/types/global";
 import { exampleRegistryUrl } from "./mock-registry";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import {
-  shouldHaveDependency,
   shouldHaveManifest,
   shouldHaveRegistryWithScopes,
   shouldNotHaveDependency,

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -7,6 +7,12 @@ import { PkgManifest } from "../src/types/global";
 import { exampleRegistryUrl } from "./mock-registry";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 import { attachMockConsole, MockConsole } from "./mock-console";
+import {
+  shouldHaveDependency,
+  shouldHaveManifest,
+  shouldHaveRegistryWithScopes,
+  shouldNotHaveDependency,
+} from "./manifest-assertions";
 
 describe("cmd-remove.ts", function () {
   describe("remove", function () {
@@ -48,14 +54,9 @@ describe("cmd-remove.ts", function () {
       };
       const retCode = await remove("com.example.package-a", options);
       retCode.should.equal(0);
-      const manifest = loadManifest();
-      assert(manifest !== null);
-      (
-        manifest.dependencies["com.example.package-a"] == undefined
-      ).should.be.ok();
-      assert(manifest.scopedRegistries !== undefined);
-      assert(manifest.scopedRegistries[0] !== undefined);
-      manifest.scopedRegistries[0].scopes.should.be.deepEqual([
+      const manifest = shouldHaveManifest();
+      shouldNotHaveDependency(manifest, "com.example.package-a");
+      shouldHaveRegistryWithScopes(manifest, [
         "com.example",
         "com.example.package-b",
       ]);
@@ -71,9 +72,8 @@ describe("cmd-remove.ts", function () {
       };
       const retCode = await remove("com.example.package-a@1.0.0", options);
       retCode.should.equal(1);
-      const manifest = loadManifest();
-      assert(manifest !== null);
-      manifest.should.be.deepEqual(defaultManifest);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(defaultManifest);
       mockConsole.hasLineIncluding("out", "please replace").should.be.ok();
     });
     it("remove pkg-not-exist", async function () {
@@ -85,9 +85,8 @@ describe("cmd-remove.ts", function () {
       };
       const retCode = await remove("pkg-not-exist", options);
       retCode.should.equal(1);
-      const manifest = loadManifest();
-      assert(manifest !== null);
-      manifest.should.be.deepEqual(defaultManifest);
+      const manifest = shouldHaveManifest();
+      manifest.should.deepEqual(defaultManifest);
       mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
     });
     it("remove more than one pkgs", async function () {
@@ -102,17 +101,10 @@ describe("cmd-remove.ts", function () {
         options
       );
       retCode.should.equal(0);
-      const manifest = loadManifest();
-      assert(manifest !== null);
-      (
-        manifest.dependencies["com.example.package-a"] == undefined
-      ).should.be.ok();
-      (
-        manifest.dependencies["com.example.package-b"] == undefined
-      ).should.be.ok();
-      assert(manifest.scopedRegistries !== undefined);
-      assert(manifest.scopedRegistries[0] !== undefined);
-      manifest.scopedRegistries[0].scopes.should.be.deepEqual(["com.example"]);
+      const manifest = shouldHaveManifest();
+      shouldNotHaveDependency(manifest, "com.example.package-a");
+      shouldNotHaveDependency(manifest, "com.example.package-b");
+      shouldHaveRegistryWithScopes(manifest, ["com.example"]);
       mockConsole
         .hasLineIncluding("out", "removed com.example.package-a")
         .should.be.ok();

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -3,8 +3,7 @@ import "should";
 
 import { remove } from "../src/cmd-remove";
 
-import { getInspects, getOutputs } from "./mock-console";
-import testConsole from "test-console";
+import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
 import { PkgManifest } from "../src/types/global";
@@ -13,8 +12,8 @@ import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-remove.ts", function () {
   describe("remove", function () {
-    let stdoutInspect: testConsole.Inspector = null!;
-    let stderrInspect: testConsole.Inspector = null!;
+    let stdoutInspect: MockConsoleInspector = null!;
+    let stderrInspect: MockConsoleInspector = null!;
     const defaultManifest: PkgManifest = {
       dependencies: {
         "com.example.package-a": "1.0.0",

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -13,12 +13,13 @@ import {
 import testConsole from "test-console";
 import assert from "assert";
 import { loadManifest } from "../src/utils/manifest";
+import { PkgManifest } from "../src/types/global";
 
 describe("cmd-remove.ts", function () {
   describe("remove", function () {
     let stdoutInspect: testConsole.Inspector = null!;
     let stderrInspect: testConsole.Inspector = null!;
-    const defaultManifest = {
+    const defaultManifest: PkgManifest = {
       dependencies: {
         "com.example.package-a": "1.0.0",
         "com.example.package-b": "1.0.0",

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -3,8 +3,7 @@ import nock from "nock";
 import "should";
 import { search, SearchOptions } from "../src/cmd-search";
 
-import { getInspects, getOutputs } from "./mock-console";
-import testConsole from "test-console";
+import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import {
   exampleRegistryUrl,
   registerSearchResult,
@@ -15,8 +14,8 @@ import { SearchEndpointResult } from "./types";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-search.ts", function () {
-  let stdoutInspect: testConsole.Inspector = null!;
-  let stderrInspect: testConsole.Inspector = null!;
+  let stdoutInspect: MockConsoleInspector = null!;
+  let stderrInspect: MockConsoleInspector = null!;
 
   const options: SearchOptions = {
     _global: {

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -12,6 +12,7 @@ import {
 } from "./utils";
 import testConsole from "test-console";
 import {
+  exampleRegistryUrl,
   registerSearchResult,
   startMockRegistry,
   stopMockRegistry,
@@ -24,7 +25,7 @@ describe("cmd-search.ts", function () {
 
   const options: SearchOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
@@ -126,7 +127,7 @@ describe("cmd-search.ts", function () {
     };
     beforeEach(function () {
       startMockRegistry();
-      nock("http://example.com")
+      nock(exampleRegistryUrl)
         .persist()
         .get(/-\/v1\/search\?text=/)
         .reply(404);
@@ -135,7 +136,7 @@ describe("cmd-search.ts", function () {
       stopMockRegistry();
     });
     it("from remote", async function () {
-      nock("http://example.com").get("/-/all").reply(200, allResult, {
+      nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
         "Content-Type": "application/json",
       });
       const retCode = await search("package-a", options);
@@ -147,7 +148,7 @@ describe("cmd-search.ts", function () {
       stdout.includes("2019-10-02").should.be.ok();
     });
     it("pkg not exist", async function () {
-      nock("http://example.com").get("/-/all").reply(200, allResult, {
+      nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
         "Content-Type": "application/json",
       });
       const retCode = await search("pkg-not-exist", options);

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -3,13 +3,7 @@ import nock from "nock";
 import "should";
 import { search, SearchOptions } from "../src/cmd-search";
 
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import testConsole from "test-console";
 import {
   exampleRegistryUrl,
@@ -18,6 +12,7 @@ import {
   stopMockRegistry,
 } from "./mock-registry";
 import { SearchEndpointResult } from "./types";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-search.ts", function () {
   let stdoutInspect: testConsole.Inspector = null!;

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -27,8 +27,6 @@ describe("cmd-search.ts", function () {
   beforeEach(function () {
     removeWorkDir("test-openupm-cli");
     createWorkDir("test-openupm-cli", { manifest: true });
-    removeWorkDir("test-openupm-cli");
-    createWorkDir("test-openupm-cli", { manifest: true });
     mockConsole = attachMockConsole();
   });
   afterEach(function () {

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -1,4 +1,3 @@
-import "assert";
 import nock from "nock";
 import "should";
 import { search, SearchOptions } from "../src/cmd-search";

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -1,7 +1,7 @@
 import "assert";
 import nock from "nock";
 import "should";
-import { search } from "../src/cmd-search";
+import { SearchOptions, search } from "../src/cmd-search";
 
 import {
   createWorkDir,
@@ -13,12 +13,45 @@ import {
   removeWorkDir,
 } from "./utils";
 import testConsole from "test-console";
+import { PkgVersion, ReverseDomainName } from "../src/types/global";
+
+type Author = { name: string; email?: string; url?: string };
+
+type Maintainer = { username: string; email: string };
+
+type EndpointResult = {
+  objects: Array<{
+    package: {
+      name: ReverseDomainName;
+      description?: string;
+      date: string;
+      scope: "unscoped";
+      version: PkgVersion;
+      links: Record<string, unknown>;
+      author: Author;
+      publisher: Maintainer;
+      maintainers: Maintainer[];
+    };
+    flags: { unstable: boolean };
+    score: {
+      final: number;
+      detail: {
+        quality: number;
+        popularity: number;
+        maintenance: number;
+      };
+    };
+    searchScore: number;
+  }>;
+  total: number;
+  time: string;
+};
 
 describe("cmd-search.ts", function () {
   let stdoutInspect: testConsole.Inspector = null!;
   let stderrInspect: testConsole.Inspector = null!;
 
-  const options = {
+  const options: SearchOptions = {
     _global: {
       registry: "http://example.com",
       upstream: false,
@@ -39,20 +72,15 @@ describe("cmd-search.ts", function () {
     stderrInspect.restore();
   });
   describe("search endpoint", function () {
-    const searchEndpointResult = {
+    const searchEndpointResult: EndpointResult = {
       objects: [
         {
           package: {
             name: "com.example.package-a",
             scope: "unscoped",
-            "dist-tags": { latest: "1.0.0" },
-            versions: {
-              "1.0.0": "latest",
-            },
+            version: "1.0.0",
             description: "A demo package",
-            time: {
-              modified: "2019-10-02T04:02:38.335Z",
-            },
+            date: "2019-10-02T04:02:38.335Z",
             links: {},
             author: { name: "yo", url: "https://github.com/yo" },
             publisher: { username: "yo", email: "yo@example.com" },
@@ -73,7 +101,7 @@ describe("cmd-search.ts", function () {
       total: 1,
       time: "Sat Dec 07 2019 04:57:11 GMT+0000 (UTC)",
     };
-    const searchEndpointEmptyResult = {
+    const searchEndpointEmptyResult: EndpointResult = {
       objects: [],
       total: 0,
       time: "Sat Dec 07 2019 05:07:42 GMT+0000 (UTC)",

--- a/test/test-cmd-view.ts
+++ b/test/test-cmd-view.ts
@@ -11,6 +11,7 @@ import {
 import testConsole from "test-console";
 import { PkgInfo } from "../src/types/global";
 import {
+  exampleRegistryUrl,
   registerMissingPackage,
   registerRemotePkg,
   registerRemoteUpstreamPkg,
@@ -21,14 +22,14 @@ import {
 describe("cmd-view.ts", function () {
   const options: ViewOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };
   const upstreamOptions: ViewOptions = {
     _global: {
-      registry: "http://example.com",
+      registry: exampleRegistryUrl,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };

--- a/test/test-cmd-view.ts
+++ b/test/test-cmd-view.ts
@@ -1,8 +1,7 @@
 import "assert";
 import "should";
 import { view, ViewOptions } from "../src/cmd-view";
-import { getInspects, getOutputs } from "./mock-console";
-import testConsole from "test-console";
+import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import { PkgInfo } from "../src/types/global";
 import {
   exampleRegistryUrl,
@@ -29,8 +28,8 @@ describe("cmd-view.ts", function () {
     },
   };
   describe("view", function () {
-    let stdoutInspect: testConsole.Inspector = null!;
-    let stderrInspect: testConsole.Inspector = null!;
+    let stdoutInspect: MockConsoleInspector = null!;
+    let stderrInspect: MockConsoleInspector = null!;
 
     const remotePkgInfoA: PkgInfo = {
       name: "com.example.package-a",

--- a/test/test-cmd-view.ts
+++ b/test/test-cmd-view.ts
@@ -2,7 +2,7 @@ import "assert";
 import nock from "nock";
 import "should";
 
-import { view } from "../src/cmd-view";
+import { view, ViewOptions } from "../src/cmd-view";
 
 import {
   createWorkDir,
@@ -14,16 +14,17 @@ import {
   removeWorkDir,
 } from "./utils";
 import testConsole from "test-console";
+import { PkgInfo } from "../src/types/global";
 
 describe("cmd-view.ts", function () {
-  const options = {
+  const options: ViewOptions = {
     _global: {
       registry: "http://example.com",
       upstream: false,
       chdir: getWorkDir("test-openupm-cli"),
     },
   };
-  const upstreamOptions = {
+  const upstreamOptions: ViewOptions = {
     _global: {
       registry: "http://example.com",
       chdir: getWorkDir("test-openupm-cli"),
@@ -33,7 +34,7 @@ describe("cmd-view.ts", function () {
     let stdoutInspect: testConsole.Inspector = null!;
     let stderrInspect: testConsole.Inspector = null!;
 
-    const remotePkgInfoA = {
+    const remotePkgInfoA: PkgInfo = {
       name: "com.example.package-a",
       versions: {
         "1.0.0": {
@@ -79,7 +80,7 @@ describe("cmd-view.ts", function () {
       readme: "A demo package",
       _attachments: {},
     };
-    const remotePkgInfoUp = {
+    const remotePkgInfoUp: PkgInfo = {
       name: "com.example.package-up",
       versions: {
         "1.0.0": {

--- a/test/test-cmd-view.ts
+++ b/test/test-cmd-view.ts
@@ -1,13 +1,7 @@
 import "assert";
 import "should";
 import { view, ViewOptions } from "../src/cmd-view";
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import testConsole from "test-console";
 import { PkgInfo } from "../src/types/global";
 import {
@@ -18,6 +12,7 @@ import {
   startMockRegistry,
   stopMockRegistry,
 } from "./mock-registry";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("cmd-view.ts", function () {
   const options: ViewOptions = {

--- a/test/test-cmd-view.ts
+++ b/test/test-cmd-view.ts
@@ -1,4 +1,3 @@
-import "assert";
 import "should";
 import { view, ViewOptions } from "../src/cmd-view";
 import { PkgInfo } from "../src/types/global";

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -1,14 +1,13 @@
-import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import "should";
 import { env, parseEnv } from "../src/utils/env";
 import path from "path";
 import assert from "assert";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
+import { attachMockConsole, MockConsole } from "./mock-console";
 
 describe("env", function () {
   describe("parseEnv", function () {
-    let stdoutInspect: MockConsoleInspector = null!;
-    let stderrInspect: MockConsoleInspector = null!;
+    let mockConsole: MockConsole = null!;
     before(function () {
       removeWorkDir("test-openupm-cli");
       removeWorkDir("test-openupm-cli-no-manifest");
@@ -26,11 +25,10 @@ describe("env", function () {
       removeWorkDir("test-openupm-cli-no-manifest");
     });
     beforeEach(function () {
-      [stdoutInspect, stderrInspect] = getInspects();
+      mockConsole = attachMockConsole();
     });
     afterEach(function () {
-      stdoutInspect.restore();
-      stderrInspect.restore();
+      mockConsole.detach();
     });
     it("defaults", async function () {
       (await parseEnv({ _global: {} }, { checkPath: false })).should.be.ok();
@@ -61,8 +59,9 @@ describe("env", function () {
           { checkPath: true }
         )
       ).should.not.be.ok();
-      const [stdout] = getOutputs(stdoutInspect, stderrInspect);
-      stdout.includes("can not resolve path").should.be.ok();
+      mockConsole
+        .hasLineIncluding("out", "can not resolve path")
+        .should.be.ok();
     });
     it("can not locate manifest.json", async function () {
       (
@@ -71,8 +70,9 @@ describe("env", function () {
           { checkPath: true }
         )
       ).should.not.be.ok();
-      const [stdout] = getOutputs(stdoutInspect, stderrInspect);
-      stdout.includes("can not locate manifest.json").should.be.ok();
+      mockConsole
+        .hasLineIncluding("out", "can not locate manifest.json")
+        .should.be.ok();
     });
     it("custom registry", async function () {
       (

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -1,15 +1,10 @@
 import testConsole from "test-console";
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import "should";
 import { env, parseEnv } from "../src/utils/env";
 import path from "path";
 import assert from "assert";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("env", function () {
   describe("parseEnv", function () {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -1,5 +1,4 @@
-import testConsole from "test-console";
-import { getInspects, getOutputs } from "./mock-console";
+import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import "should";
 import { env, parseEnv } from "../src/utils/env";
 import path from "path";
@@ -8,8 +7,8 @@ import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("env", function () {
   describe("parseEnv", function () {
-    let stdoutInspect: testConsole.Inspector = null!;
-    let stderrInspect: testConsole.Inspector = null!;
+    let stdoutInspect: MockConsoleInspector = null!;
+    let stderrInspect: MockConsoleInspector = null!;
     before(function () {
       removeWorkDir("test-openupm-cli");
       removeWorkDir("test-openupm-cli-no-manifest");

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -1,9 +1,9 @@
 import "should";
 import { env, parseEnv } from "../src/utils/env";
 import path from "path";
-import assert from "assert";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 import { attachMockConsole, MockConsole } from "./mock-console";
+import should from "should";
 
 describe("env", function () {
   describe("parseEnv", function () {
@@ -157,8 +157,7 @@ describe("env", function () {
           { checkPath: true }
         )
       ).should.be.ok();
-      assert(env.editorVersion !== null);
-      env.editorVersion.should.be.equal("2019.2.13f1");
+      should(env.editorVersion).be.equal("2019.2.13f1");
     });
     it("region cn", async function () {
       (

--- a/test/test-manifest.ts
+++ b/test/test-manifest.ts
@@ -1,11 +1,5 @@
 import testConsole from "test-console";
-import {
-  createWorkDir,
-  getInspects,
-  getOutputs,
-  getWorkDir,
-  removeWorkDir,
-} from "./utils";
+import { getInspects, getOutputs } from "./mock-console";
 import fs from "fs";
 import "should";
 import path from "path";
@@ -13,6 +7,7 @@ import { loadManifest, saveManifest } from "../src/utils/manifest";
 import assert from "assert";
 import { describe } from "mocha";
 import { parseEnv } from "../src/utils/env";
+import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("manifest", function () {
   let stdoutInspect: testConsole.Inspector = null!;

--- a/test/test-manifest.ts
+++ b/test/test-manifest.ts
@@ -1,5 +1,4 @@
-import testConsole from "test-console";
-import { getInspects, getOutputs } from "./mock-console";
+import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
 import fs from "fs";
 import "should";
 import path from "path";
@@ -10,8 +9,8 @@ import { parseEnv } from "../src/utils/env";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("manifest", function () {
-  let stdoutInspect: testConsole.Inspector = null!;
-  let stderrInspect: testConsole.Inspector = null!;
+  let stdoutInspect: MockConsoleInspector = null!;
+  let stderrInspect: MockConsoleInspector = null!;
   beforeEach(function () {
     removeWorkDir("test-openupm-cli");
     createWorkDir("test-openupm-cli", { manifest: true });

--- a/test/test-manifest.ts
+++ b/test/test-manifest.ts
@@ -1,4 +1,4 @@
-import { getInspects, getOutputs, MockConsoleInspector } from "./mock-console";
+import { attachMockConsole, MockConsole } from "./mock-console";
 import fs from "fs";
 import "should";
 import path from "path";
@@ -9,8 +9,7 @@ import { parseEnv } from "../src/utils/env";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
 
 describe("manifest", function () {
-  let stdoutInspect: MockConsoleInspector = null!;
-  let stderrInspect: MockConsoleInspector = null!;
+  let mockConsole: MockConsole = null!;
   beforeEach(function () {
     removeWorkDir("test-openupm-cli");
     createWorkDir("test-openupm-cli", { manifest: true });
@@ -24,13 +23,12 @@ describe("manifest", function () {
       ),
       "wrong-json"
     );
-    [stdoutInspect, stderrInspect] = getInspects();
+    mockConsole = attachMockConsole();
   });
   afterEach(function () {
     removeWorkDir("test-openupm-cli");
     removeWorkDir("test-openupm-cli-wrong-json");
-    stdoutInspect.restore();
-    stderrInspect.restore();
+    mockConsole.detach();
   });
   it("loadManifest", async function () {
     (
@@ -52,8 +50,7 @@ describe("manifest", function () {
     ).should.be.ok();
     const manifest = loadManifest();
     (manifest === null).should.be.ok();
-    const [stdout] = getOutputs(stdoutInspect, stderrInspect);
-    stdout.includes("does not exist").should.be.ok();
+    mockConsole.hasLineIncluding("out", "does not exist").should.be.ok();
   });
   it("wrong json content", async function () {
     (
@@ -64,8 +61,7 @@ describe("manifest", function () {
     ).should.be.ok();
     const manifest = loadManifest();
     (manifest === null).should.be.ok();
-    const [stdout] = getOutputs(stdoutInspect, stderrInspect);
-    stdout.includes("failed to parse").should.be.ok();
+    mockConsole.hasLineIncluding("out", "failed to parse").should.be.ok();
   });
   it("saveManifest", async function () {
     (

--- a/test/test-manifest.ts
+++ b/test/test-manifest.ts
@@ -2,11 +2,15 @@ import { attachMockConsole, MockConsole } from "./mock-console";
 import fs from "fs";
 import "should";
 import path from "path";
-import { loadManifest, saveManifest } from "../src/utils/manifest";
-import assert from "assert";
+import { saveManifest } from "../src/utils/manifest";
 import { describe } from "mocha";
 import { parseEnv } from "../src/utils/env";
 import { createWorkDir, getWorkDir, removeWorkDir } from "./mock-work-dir";
+import {
+  shouldHaveManifest,
+  shouldHaveNoManifest,
+  shouldNotHaveAnyDependencies,
+} from "./manifest-assertions";
 
 describe("manifest", function () {
   let mockConsole: MockConsole = null!;
@@ -37,8 +41,7 @@ describe("manifest", function () {
         { checkPath: true }
       )
     ).should.be.ok();
-    const manifest = loadManifest();
-    assert(manifest !== null);
+    const manifest = shouldHaveManifest();
     manifest.should.be.deepEqual({ dependencies: {} });
   });
   it("no manifest file", async function () {
@@ -48,8 +51,7 @@ describe("manifest", function () {
         { checkPath: false }
       )
     ).should.be.ok();
-    const manifest = loadManifest();
-    (manifest === null).should.be.ok();
+    shouldHaveNoManifest();
     mockConsole.hasLineIncluding("out", "does not exist").should.be.ok();
   });
   it("wrong json content", async function () {
@@ -59,8 +61,7 @@ describe("manifest", function () {
         { checkPath: true }
       )
     ).should.be.ok();
-    const manifest = loadManifest();
-    (manifest === null).should.be.ok();
+    shouldHaveNoManifest();
     mockConsole.hasLineIncluding("out", "failed to parse").should.be.ok();
   });
   it("saveManifest", async function () {
@@ -70,13 +71,11 @@ describe("manifest", function () {
         { checkPath: true }
       )
     ).should.be.ok();
-    const manifest = loadManifest();
-    assert(manifest !== null);
-    manifest.should.be.deepEqual({ dependencies: {} });
+    const manifest = shouldHaveManifest();
+    shouldNotHaveAnyDependencies(manifest);
     manifest.dependencies["some-pack"] = "1.0.0";
     saveManifest(manifest).should.be.ok();
-    const manifest2 = loadManifest();
-    assert(manifest2 !== null);
+    const manifest2 = shouldHaveManifest();
     manifest2.should.be.deepEqual(manifest);
   });
 });

--- a/test/test-pgk-info.ts
+++ b/test/test-pgk-info.ts
@@ -1,14 +1,13 @@
 import { tryGetLatestVersion } from "../src/utils/pkg-info";
-import assert from "assert";
 import "should";
 import { describe } from "mocha";
+import should from "should";
 
 describe("pkg-info", function () {
   describe("tryGetLatestVersion", function () {
     it("from dist-tags", async function () {
       const version = tryGetLatestVersion({ "dist-tags": { latest: "1.0.0" } });
-      assert(version !== undefined);
-      version.should.equal("1.0.0");
+      should(version).equal("1.0.0");
     });
   });
 });

--- a/test/test-registry-client.ts
+++ b/test/test-registry-client.ts
@@ -5,6 +5,7 @@ import { parseEnv } from "../src/utils/env";
 import { fetchPackageInfo } from "../src/registry-client";
 import { PkgInfo } from "../src/types/global";
 import {
+  exampleRegistryUrl,
   registerMissingPackage,
   registerRemotePkg,
   startMockRegistry,
@@ -22,7 +23,7 @@ describe("registry-client", function () {
     it("simple", async function () {
       (
         await parseEnv(
-          { _global: { registry: "http://example.com" } },
+          { _global: { registry: exampleRegistryUrl } },
           { checkPath: false }
         )
       ).should.be.ok();
@@ -39,7 +40,7 @@ describe("registry-client", function () {
     it("404", async function () {
       (
         await parseEnv(
-          { _global: { registry: "http://example.com" } },
+          { _global: { registry: exampleRegistryUrl } },
           { checkPath: false }
         )
       ).should.be.ok();

--- a/test/test-registry-client.ts
+++ b/test/test-registry-client.ts
@@ -1,6 +1,5 @@
 import "assert";
 import "should";
-import assert from "assert";
 import { parseEnv } from "../src/utils/env";
 import { fetchPackageInfo } from "../src/registry-client";
 import { PkgInfo } from "../src/types/global";
@@ -11,6 +10,7 @@ import {
   startMockRegistry,
   stopMockRegistry,
 } from "./mock-registry";
+import should from "should";
 
 describe("registry-client", function () {
   describe("fetchPackageInfo", function () {
@@ -34,8 +34,7 @@ describe("registry-client", function () {
       };
       registerRemotePkg(pkgInfoRemote);
       const info = await fetchPackageInfo("package-a");
-      assert(info !== undefined);
-      info.should.deepEqual(pkgInfoRemote);
+      should(info).deepEqual(pkgInfoRemote);
     });
     it("404", async function () {
       (

--- a/test/test-registry-client.ts
+++ b/test/test-registry-client.ts
@@ -6,6 +6,7 @@ import { nockDown, nockUp } from "./utils";
 import assert from "assert";
 import { parseEnv } from "../src/utils/env";
 import { fetchPackageInfo } from "../src/registry-client";
+import { PkgInfo } from "../src/types/global";
 
 describe("registry-client", function () {
   describe("fetchPackageInfo", function () {
@@ -22,7 +23,11 @@ describe("registry-client", function () {
           { checkPath: false }
         )
       ).should.be.ok();
-      const pkgInfoRemote = { name: "com.littlebigfun.addressable-importer" };
+      const pkgInfoRemote: PkgInfo = {
+        name: "com.littlebigfun.addressable-importer",
+        versions: {},
+        time: {},
+      };
       nock("http://example.com")
         .get("/package-a")
         .reply(200, pkgInfoRemote, { "Content-Type": "application/json" });

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,31 @@
+import { Contact, PkgVersion, ReverseDomainName } from "../src/types/global";
+
+type Maintainer = { username: string; email: string };
+
+export type SearchEndpointResult = {
+  objects: Array<{
+    package: {
+      name: ReverseDomainName;
+      description?: string;
+      date: string;
+      scope: "unscoped";
+      version: PkgVersion;
+      links: Record<string, unknown>;
+      author: Contact;
+      publisher: Maintainer;
+      maintainers: Maintainer[];
+    };
+    flags: { unstable: boolean };
+    score: {
+      final: number;
+      detail: {
+        quality: number;
+        popularity: number;
+        maintenance: number;
+      };
+    };
+    searchScore: number;
+  }>;
+  total: number;
+  time: string;
+};

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,4 @@
 import fse from "fs-extra";
-import nock from "nock";
 import path from "path";
 import os from "os";
 import testConsole from "test-console";
@@ -42,15 +41,6 @@ export const createWorkDir = function (
 export const removeWorkDir = function (pathToTmp: string) {
   const cwd = getWorkDir(pathToTmp);
   fse.removeSync(cwd);
-};
-
-export const nockUp = function () {
-  if (!nock.isActive()) nock.activate();
-};
-
-export const nockDown = function () {
-  nock.restore();
-  nock.cleanAll();
 };
 
 export const getOutputs = function (


### PR DESCRIPTION
This PR was originally meant to introduce property-based tests (see https://github.com/openupm/openupm-cli/issues/59). After some experiments it did not seem to add to much test security, so this was abandoned (Notice fast-check dependency was added and later removed)

Instead this PR includes various small changes that can be summarized with:
- Fixed a few small type errors in the actual implementation code, based on type usage in tests (For example make some properties optional)
- Add typings in tests where applicable
- Introduce/refactor helper functions and types for
  - Mock package registry
  - Mock console
  - Mock manifest
  - Mock work directory
- Deduplicate a lot of code by adding helper
- Split `utilities.ts` and group common functionality in new modules
- Small dev-dependency version changes to fix warnings