### PR TITLE
refactor: enable record undefined checks

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -89,7 +89,7 @@ export const add = async function (
 
       if (version === undefined)
         throw new Error("Could not determine package version to add");
-      const versionInfo = pkgInfo.versions[version];
+      const versionInfo = pkgInfo.versions[version]!;
       // verify editor version
       if (versionInfo.unity) {
         const requiredEditorVersion = versionInfo.unityRelease

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -108,7 +108,7 @@ const getTableRow = function (pkg: SearchedPkgInfo): TableRow {
   const name = pkg.name;
   const version = tryGetLatestVersion(pkg);
   let date = "";
-  if (pkg.time && pkg.time.modified) date = pkg.time.modified.split("T")[0];
+  if (pkg.time && pkg.time.modified) date = pkg.time.modified.split("T")[0]!;
   if (pkg.date) {
     date = pkg.date.toISOString().slice(0, 10);
   }

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -47,7 +47,7 @@ const printInfo = function (pkg: PkgInfo) {
   const versionCount = Object.keys(pkg.versions).length;
   const ver = tryGetLatestVersion(pkg);
   assert(ver !== undefined);
-  const verInfo = pkg.versions[ver];
+  const verInfo = pkg.versions[ver]!;
   const license = verInfo.license || "proprietary or unlicensed";
   const displayName = verInfo.displayName;
   const description = verInfo.description || pkg.description;

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -240,7 +240,7 @@ export const fetchPackageDependencies = async function (
         // add dependencies to pending list
         if (depObj.self || deep) {
           const deps: NameVersionPair[] = (
-            _.toPairs(pkgInfo.versions[entry.version]["dependencies"]) as [
+            _.toPairs(pkgInfo.versions[entry.version]!["dependencies"]) as [
               DomainName,
               SemanticVersion
             ][]

--- a/src/types/domain-name.ts
+++ b/src/types/domain-name.ts
@@ -38,7 +38,7 @@ export function namespaceFor(hostname: string): DomainName {
     // 2-part domains, like unity.com
     if (count < 3) return segments;
     // Domains with two short extensions like my-school.ac.at
-    if (segments[count - 1].length <= 3 && segments[count - 2].length <= 3)
+    if (segments[count - 1]!.length <= 3 && segments[count - 2]!.length <= 3)
       return segments.slice(count - 3);
     // Domains with one extension such as registry.npmjs.org
     return segments.slice(count - 2);

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -63,8 +63,8 @@ export const compareEditorVersion = function (
   const arrA = editorVersionToArray(verA);
   const arrB = editorVersionToArray(verB);
   for (let i = 0; i < arrA.length; i++) {
-    const valA = arrA[i];
-    const valB = arrB[i];
+    const valA = arrA[i]!;
+    const valB = arrB[i]!;
     if (valA > valB) return 1;
     else if (valA < valB) return -1;
   }

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -4,5 +4,5 @@ export function trySplitAtFirstOccurrenceOf(
 ): [string, string | undefined] {
   const elements = s.split(split);
   if (elements.length === 1) return [s, undefined];
-  return [elements[0], elements.slice(1).join(split)];
+  return [elements[0]!, elements.slice(1).join(split)];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -98,7 +98,7 @@
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */


### PR DESCRIPTION
The [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) flag in tsconfig is not enabled by default when using `strict: true`, so it was not enabled until now. Enabled it for safer value access from records and fixed resulting warnings.