### PR TITLE
refactor: add better typing for string property

### DIFF
--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -49,7 +49,7 @@ export type Dependency = {
   upstream: boolean;
   self: boolean;
   internal: boolean;
-  reason: string | null;
+  reason: "package404" | "version404" | null;
   resolved?: boolean;
 };
 


### PR DESCRIPTION
Instead of using string, we can see in the code that it will always be one of a few values. This allows the compiler to better check on the other side if we have checked all posibillities