### PR TITLE
feat: basic cli-argument validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "another-npm-registry-client": "^8.7.0",
         "chalk": "^4.1.2",
         "cli-table": "^0.3.11",
-        "commander": "^9.3.0",
+        "commander": "^9.5.0",
         "fs-extra": "^10.1.0",
         "is-wsl": "^2.2.0",
         "libnpmsearch": "^5.0.3",
@@ -2697,8 +2697,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "9.3.0",
-      "license": "MIT",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -12039,7 +12040,9 @@
       }
     },
     "commander": {
-      "version": "9.3.0"
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
     },
     "compare-func": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@babel/core": "^7.18.6",
         "@babel/eslint-parser": "^7.17.0",
+        "@commander-js/extra-typings": "^9.5.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@types/cli-table": "^0.3.2",
@@ -602,6 +603,15 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-9.5.0.tgz",
+      "integrity": "sha512-OdIzg8hLlFyiV3BOEd7yRMtrqZ+L+bjAjGILpeG0LKUlE+N68tjp65JqKhapqWMHS6nDGGt+KjDf1y+eOQjwfw==",
+      "dev": true,
+      "peerDependencies": {
+        "commander": "9.5.x"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -10682,6 +10692,13 @@
       "version": "1.5.0",
       "dev": true,
       "optional": true
+    },
+    "@commander-js/extra-typings": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-9.5.0.tgz",
+      "integrity": "sha512-OdIzg8hLlFyiV3BOEd7yRMtrqZ+L+bjAjGILpeG0LKUlE+N68tjp65JqKhapqWMHS6nDGGt+KjDf1y+eOQjwfw==",
+      "dev": true,
+      "requires": {}
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.17.0",
+    "@commander-js/extra-typings": "^9.5.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/cli-table": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "another-npm-registry-client": "^8.7.0",
     "chalk": "^4.1.2",
     "cli-table": "^0.3.11",
-    "commander": "^9.3.0",
+    "commander": "^9.5.0",
     "fs-extra": "^10.1.0",
     "is-wsl": "^2.2.0",
     "libnpmsearch": "^5.0.3",

--- a/src/cli-parsing.ts
+++ b/src/cli-parsing.ts
@@ -1,0 +1,40 @@
+import { InvalidArgumentError } from "@commander-js/extra-typings";
+
+/**
+ * @throws {InvalidArgumentError}
+ */
+type CliValueParser<TOut> = (input: string, previous?: TOut) => TOut;
+
+export function mustSatisfy<TOut extends string>(
+  typeAssertion: (input: string) => input is TOut,
+  makeErrorMessage: (input: string) => string
+): CliValueParser<TOut> {
+  return (input) => {
+    if (!typeAssertion(input))
+      throw new InvalidArgumentError(makeErrorMessage(input));
+    return input;
+  };
+}
+
+export function mustBeParceable<TOut>(
+  parse: (input: string) => TOut,
+  makeErrorMessage: (input: string, error: unknown) => string
+): CliValueParser<TOut> {
+  return (input) => {
+    try {
+      return parse(input);
+    } catch (error) {
+      throw new InvalidArgumentError(makeErrorMessage(input, error));
+    }
+  };
+}
+
+export function eachValue<TOut>(
+  parser: CliValueParser<TOut>
+): CliValueParser<TOut[]> {
+  return (input, previous) => {
+    const parsed = parser(input);
+    if (previous === undefined) return [parsed];
+    else return [...previous, parsed];
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ const mustBePackageReference = mustSatisfy(
 
 const mustBeDomainName = mustSatisfy(
   isDomainName,
-  (input) => `"${input}" is not a valid domain name`
+  (input) => `"${input}" is not a valid package name`
 );
 
 const mustBeRegistryUrl = mustBeParceable(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,7 +111,6 @@ program
   .option("-u, --username <username>", "username")
   .option("-p, --password <password>", "password")
   .option("-e, --email <email>", "email address")
-  .option("-r, --registry <url>", "registry url")
   .option("--basic-auth", "use basic authentication instead of token")
   .option(
     "--always-auth",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,12 @@ program
   .option("--no-color", "disable color");
 
 program
-  .command("add <pkg> [otherPkgs...]")
+  .command("add")
+  .argument("<pkg>", "Reference to the package that should be added")
+  .argument(
+    "[otherPkgs...]",
+    "References to additional packages that should be added"
+  )
   .aliases(["install", "i"])
   .option("-t, --test", "add package as testable")
   .option(
@@ -50,7 +55,9 @@ openupm add <pkg>@<version> [otherPkgs...]`
   });
 
 program
-  .command("remove <pkg> [otherPkgs...]")
+  .command("remove")
+  .argument("<pkg>", "Name of the package to remove")
+  .argument("[otherPkgs...]", "Names of additional packages to remove")
   .aliases(["rm", "uninstall"])
   .description("remove package from manifest json")
   .action(async function (pkg, otherPkgs, options) {
@@ -61,7 +68,8 @@ program
   });
 
 program
-  .command("search <keyword>")
+  .command("search")
+  .argument("<keyword>", "The keyword to search")
   .aliases(["s", "se", "find"])
   .description("Search package by keyword")
   .action(async function (keyword, options) {
@@ -71,7 +79,8 @@ program
   });
 
 program
-  .command("view <pkg>")
+  .command("view")
+  .argument("<pkg>", "Reference to a package")
   .aliases(["v", "info", "show"])
   .description("view package information")
   .action(async function (pkg, options) {
@@ -81,7 +90,8 @@ program
   });
 
 program
-  .command("deps <pkg>")
+  .command("deps")
+  .argument("<pkg>", "Reference to a package")
   .alias("dep")
   .option("-d, --deep", "view package dependencies recursively")
   .description(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ openupm add <pkg>@<version> [otherPkgs...]`
     options._global = program.opts();
     const pkgs = [pkg].concat(otherPkgs);
     const retCode = await add(pkgs, options);
-    if (retCode) process.exit(retCode);
+    if (retCode !== 0) process.exit(retCode);
   });
 
 program
@@ -57,7 +57,7 @@ program
     options._global = program.opts();
     const pkgs = [pkg].concat(otherPkgs);
     const retCode = await remove(pkgs, options);
-    if (retCode) process.exit(retCode);
+    if (retCode !== 0) process.exit(retCode);
   });
 
 program
@@ -67,7 +67,7 @@ program
   .action(async function (keyword, options) {
     options._global = program.opts();
     const retCode = await search(keyword, options);
-    if (retCode) process.exit(retCode);
+    if (retCode !== 0) process.exit(retCode);
   });
 
 program
@@ -77,7 +77,7 @@ program
   .action(async function (pkg, options) {
     options._global = program.opts();
     const retCode = await view(pkg, options);
-    if (retCode) process.exit(retCode);
+    if (retCode !== 0) process.exit(retCode);
   });
 
 program
@@ -92,7 +92,7 @@ openupm deps <pkg>@<version>`
   .action(async function (pkg, options) {
     options._global = program.opts();
     const retCode = await deps(pkg, options);
-    if (retCode) process.exit(retCode);
+    if (retCode !== 0) process.exit(retCode);
   });
 
 program
@@ -112,7 +112,7 @@ program
     options._global = program.opts();
     try {
       const retCode = await login(options);
-      if (retCode) process.exit(retCode);
+      if (retCode !== 0) process.exit(retCode);
     } catch (err) {
       assertIsError(err);
       log.error("", err.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,6 @@ import log from "./logger";
 
 // update-notifier
 import pkg from "../package.json";
-import { assertIsError } from "./utils/error-type-guards";
 import { eachValue, mustBeParceable, mustSatisfy } from "./cli-parsing";
 import { isPackageReference } from "./types/package-reference";
 import { isDomainName } from "./types/domain-name";
@@ -152,14 +151,8 @@ program
   )
   .description("authenticate with a scoped registry")
   .action(async function (options) {
-    try {
-      const retCode = await login(makeCmdOptions(options));
-      if (retCode !== 0) process.exit(retCode);
-    } catch (err) {
-      assertIsError(err);
-      log.error("", err.message);
-      process.exit(1);
-    }
+    const retCode = await login(makeCmdOptions(options));
+    if (retCode !== 0) process.exit(retCode);
   });
 
 // prompt for invalid command


### PR DESCRIPTION
## Effects

- Bumps commander
- Adds dependency for better typings for commander
- Adds parsing / validation functions for arguments / options

This introduces checks, such as making sure, that when calling `openupm add` the package argument is a valid package name. 

This PR does not include any new tests. It would be nice to be able to test the app on the cli level, but further refactors are necessary for that.