### PR TITLE
fix: type error

### DIFF
--- a/src/utils/error-type-guards.ts
+++ b/src/utils/error-type-guards.ts
@@ -1,11 +1,17 @@
 import { HttpErrorBase } from "npm-registry-fetch";
 import { AssertionError } from "assert";
 
+/*
+ * Note: We are in a Node context, where Errors have the "code" property.
+ * We need to make sure we use Node's error type instead of the default one
+ * @see https://dev.to/jdbar/the-problem-with-handling-node-js-errors-in-typescript-and-the-workaround-m64
+ */
+import ErrnoException = NodeJS.ErrnoException;
 
 /**
  * @throws AssertionError The given parameter is not an error
  */
-export function assertIsError(x: unknown): asserts x is Error {
+export function assertIsError(x: unknown): asserts x is ErrnoException {
   if (!(x instanceof Error))
     throw new AssertionError({
       message: "Argument was not an error!",


### PR DESCRIPTION
This reverts a0f1abea67a42238e17c1bb8c300661147ead81c. As it turns out ErrnoException was used on purpose, because that type includes the `code` property.

A comment was added in order to make this more clear.