### PR TITLE
desp: install node types matching node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/libnpmsearch": "^2.0.4",
         "@types/lodash": "^4.14.199",
         "@types/mocha": "^10.0.3",
-        "@types/node": "^14.18.63",
+        "@types/node": "^16.18.68",
         "@types/node-fetch": "^2.6.9",
         "@types/npmlog": "^4.1.4",
         "@types/pkginfo": "^0.4.1",
@@ -1335,9 +1335,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "dev": true,
-      "license": "MIT"
+      "version": "16.18.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.9",
@@ -11194,7 +11195,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.63",
+      "version": "16.18.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/libnpmsearch": "^2.0.4",
     "@types/lodash": "^4.14.199",
     "@types/mocha": "^10.0.3",
-    "@types/node": "^14.18.63",
+    "@types/node": "^16.18.68",
     "@types/node-fetch": "^2.6.9",
     "@types/npmlog": "^4.1.4",
     "@types/pkginfo": "^0.4.1",


### PR DESCRIPTION
Since the project used node 16, we should also use the types for node 16