### PR TITLE
refactor: remove outdated comments

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -77,7 +77,6 @@ export const add = async function (
       }
       // verify version
       const versions = Object.keys(pkgInfo.versions) as SemanticVersion[];
-      // eslint-disable-next-line require-atomic-updates
       if (!version || version === "latest")
         version = tryGetLatestVersion(pkgInfo);
       if (versions.filter((x) => x === version).length <= 0) {

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -134,11 +134,6 @@ export async function search(
     results = (await searchOld(env.registry, keyword)) || [];
   }
   // search upstream
-  // if (env.upstream) {
-  //   const upstreamResults =
-  //     (await searchEndpoint(keyword, env.upstreamRegistry)) || [];
-  //   results.push(...upstreamResults);
-  // }
   if (results && results.length) {
     results.forEach((x) => table.push(x.slice(0, -1)));
     console.log(table.toString());

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -121,22 +121,12 @@ export const fetchPackageInfo = async function (
   const client = getNpmClient();
   try {
     return await client.get(pkgPath, { auth: registry.auth || undefined });
-    // eslint-disable-next-line no-empty
-  } catch (err) {}
+  } catch (err) {
+    /* empty */
+  }
 };
 
-/* Fetch package [valid dependencies, invalid dependencies] with a structure of
-  [
-    {
-      name,
-      version,
-      upstream,   // whether belongs to upstream registry
-      self,       // whether is the source package
-      internal,     // whether is an internal package
-      reason      // invalid reason of "version404", "package404"
-    }, ...
-  ]
- */
+// Fetch package dependencies
 export const fetchPackageDependencies = async function (
   registry: Registry,
   upstreamRegistry: Registry,
@@ -221,7 +211,6 @@ export const fetchPackageDependencies = async function (
         if (!entry.version || entry.version == "latest") {
           const latestVersion = tryGetLatestVersion(pkgInfo);
           assert(latestVersion !== undefined);
-          // eslint-disable-next-line require-atomic-updates
           depObj.version = entry.version = latestVersion;
         }
         // handle version not exist
@@ -234,9 +223,6 @@ export const fetchPackageDependencies = async function (
             )} is not a valid choice of ${versions.reverse().join(", ")}`
           );
           depObj.reason = "version404";
-          // eslint-disable-next-line require-atomic-updates
-          // depObj.version = entry.version = getLatestVersion(pkgInfo);
-          // log.warn("notarget", `fallback to ${entry.name}@${entry.version}`);
           depsInvalid.push(depObj);
           continue;
         }

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -74,17 +74,6 @@ export const compareEditorVersion = function (
 
 /**
  * Attempts to parse editor version string to groups
- *
- * E.g. 2020.2.0f2c4
- *   major: 2020
- *   minor: 2
- *   patch: 0
- *   flag: 'f'
- *   flagValue: 2
- *   build: 2
- *   loc: 'c'
- *   locValue: 1
- *   locBuild: 4
  */
 export const tryParseEditorVersion = function (
   version: string | null

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -127,8 +127,6 @@ export const parseEnv = async function (
     env.registry.auth = tryGetAuthForRegistry(env.registry.url);
     env.upstreamRegistry.auth = tryGetAuthForRegistry(env.upstreamRegistry.url);
   }
-  // log.verbose("env.npmAuth", env.npmAuth);
-  // log.verbose("env.auth", env.auth);
   // return if no need to check path
   if (!checkPath) return env;
   // cwd


### PR DESCRIPTION
Mostly
- Commented out code
- Eslint commands that don't do anything
- Type descriptions which are now handled through TS