### PR TITLE
refactor: remove null check

### DIFF
--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -87,7 +87,7 @@ export const compareEditorVersion = function (
  *   locBuild: 4
  */
 export const tryParseEditorVersion = function (
-  version: string | null
+  version: string
 ): EditorVersion | null {
   type RegexMatchGroups = {
     major: `${number}`;
@@ -98,8 +98,6 @@ export const tryParseEditorVersion = function (
     loc?: "c";
     locBuild?: `${number}`;
   };
-
-  if (!version) return null;
   const regex =
     /^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+)((?<flag>a|b|f|c)(?<build>\d+)((?<loc>c)(?<locBuild>\d+))?)?)?/;
   const match = regex.exec(version);

--- a/test/test-editor-version.ts
+++ b/test/test-editor-version.ts
@@ -8,9 +8,6 @@ import assert from "assert";
 
 describe("editor-version", function () {
   describe("parseEditorVersion", function () {
-    it("test null", function () {
-      (tryParseEditorVersion(null) === null).should.be.ok();
-    });
     it("test x.y", function () {
       const version = tryParseEditorVersion("2019.2");
       assert(version !== null);


### PR DESCRIPTION
The `version` parameter of `tryParseEditorVersion` is nullable needlessly. Made it non-nullable in order to simplify code. Also removed corresponding test.