### PR TITLE
test: mock-env

### DIFF
--- a/test/mock-env.ts
+++ b/test/mock-env.ts
@@ -1,0 +1,47 @@
+/**
+ * Represents a currently active mock-env session
+ */
+export type MockEnvSession = {
+  /**
+   * Stops this mock-env session and revert to the original {@link process.env}
+   */
+  unhook(): void;
+};
+
+/**
+ * Replaces {@link process.env} with the given object until the session
+ * is unhooked
+ * @param env The replacement env
+ * @returns A session object that can be used to unhook the replacement env
+ */
+export function mockEnv(env: object): MockEnvSession {
+  const originalEnv = process.env;
+  if ("IS_MOCK" in originalEnv)
+    throw new Error(
+      "A mock-env session is already in progress. Did you forget to unhook?"
+    );
+  process.env = { ...env, IS_MOCK: "TRUE" };
+  return {
+    unhook() {
+      process.env = originalEnv;
+    },
+  };
+}
+
+/**
+ * Runs the given function while setting {@link process.env} to the given
+ * replacement object. Resets env back to original afterward.
+ * @param env The replacement env
+ * @param func The function to execute
+ * @returns The result of the function
+ * @throws unknown Any errors the original function may throw. Env is cleaned
+ * up even if an error was thrown.
+ */
+export function runWithEnv<T>(env: object, func: () => T): T {
+  const envSession = mockEnv(env);
+  try {
+    return func();
+  } finally {
+    envSession.unhook();
+  }
+}

--- a/test/test-cmd-login.ts
+++ b/test/test-cmd-login.ts
@@ -54,7 +54,7 @@ describe("cmd-login.ts", function () {
   });
 
   describe("getNpmrcPath", function () {
-    it("should includes .npmrc", async function () {
+    it("should include .npmrc", async function () {
       getNpmrcPath().includes(".npmrc").should.be.ok();
     });
   });

--- a/test/test-cmd-login.ts
+++ b/test/test-cmd-login.ts
@@ -1,6 +1,8 @@
 import "nock";
 import { generateNpmrcLines, getNpmrcPath } from "../src/cmd-login";
 import { registryUrl } from "../src/types/registry-url";
+import { runWithEnv } from "./mock-env";
+import should from "should";
 
 describe("cmd-login.ts", function () {
   describe("generateNpmrcLines", function () {
@@ -54,8 +56,16 @@ describe("cmd-login.ts", function () {
   });
 
   describe("getNpmrcPath", function () {
-    it("should include .npmrc", async function () {
-      getNpmrcPath().includes(".npmrc").should.be.ok();
+    it("should be USERPROFILE if defined", function () {
+      const path = runWithEnv({ USERPROFILE: "/user/dir" }, getNpmrcPath);
+      should(path).be.equal("/user/dir/.npmrc");
+    });
+    it("should be HOME if USERPROFILE is not defined", function () {
+      const path = runWithEnv({ HOME: "/user/dir" }, getNpmrcPath);
+      should(path).be.equal("/user/dir/.npmrc");
+    });
+    it("should fail if HOME and USERPROFILE are not defined", function () {
+      should(() => runWithEnv({}, getNpmrcPath)).throw();
     });
   });
 });

--- a/test/test-upm-config-io.ts
+++ b/test/test-upm-config-io.ts
@@ -1,0 +1,40 @@
+import { describe } from "mocha";
+import { runWithEnv } from "./mock-env";
+import { getUpmConfigDir } from "../src/utils/upm-config-io";
+import should from "should";
+
+describe("upm-config-io", function () {
+  describe("get directory", function () {
+    describe("no wsl and no system-user", function () {
+      it("should be USERPROFILE if defined", async function () {
+        const expected = "user/dir";
+
+        const actual = await runWithEnv(
+          {
+            USERPROFILE: expected,
+          },
+          () => getUpmConfigDir(false, false)
+        );
+
+        should(actual).be.equal(expected);
+      });
+      it("should be HOME if defined and USERPROFILE is undefined", async function () {
+        const expected = "user/dir";
+
+        const actual = await runWithEnv(
+          {
+            HOME: expected,
+          },
+          () => getUpmConfigDir(false, false)
+        );
+
+        should(actual).be.equal(expected);
+      });
+      it("should fail if HOME and USERPROFILE and undefined", async function () {
+        await should(
+          runWithEnv({}, () => getUpmConfigDir(false, false))
+        ).rejected();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a mock-env utility for testing with a mocked `process.env`. Also rewrote some tests to use this new functionality.