### PR TITLE
fix: npm auth null

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -120,7 +120,7 @@ export const parseEnv = async function (
         `failed to parse auth info for ${registry} in .upmconfig.toml: missing token or _auth fields`
       );
     }
-    return null;
+    return npmAuth;
   }
 
   if (upmConfig !== undefined && upmConfig.npmAuth !== undefined) {

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -75,7 +75,11 @@ export const loadUpmConfig = async (
  * @param configDir The directory in which to save the config
  */
 export const saveUpmConfig = async (config: UPMConfig, configDir: string) => {
-  mkdirp.sync(configDir);
+  try {
+    mkdirp.sync(configDir);
+  } catch {
+    /* empty */
+  }
   const configPath = path.join(configDir, configFileName);
   const content = TOML.stringify(config);
   fs.writeFileSync(configPath, content, "utf8");


### PR DESCRIPTION
An error was introduced a while ago where npm-auth loaded from .upmconfig would be discarded and null always returned. This was fixed. Also added a few tests to test for this behaviour-