### PR TITLE
refactor: improve type declaration

### DIFF
--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -17,7 +17,7 @@ import { packageReference } from "./types/package-reference";
 import { RegistryUrl } from "./types/registry-url";
 
 export type NpmClient = {
-  rawClient: RegClient;
+  rawClient: RegClient.Instance;
   /**
    * @throws {NpmClientError}
    */
@@ -82,7 +82,7 @@ export function assertIsNpmClientError(
  * also takes care of binding and promisifying.
  */
 function normalizeClientFunction<TParam, TData>(
-  client: RegClient,
+  client: RegClient.Instance,
   fn: (uri: string, params: TParam, cb: ClientCallback<TData>) => void
 ): (uri: string, params: TParam) => Promise<TData> {
   const bound = fn.bind(client);

--- a/src/types/another-npm-registry-client.d.ts
+++ b/src/types/another-npm-registry-client.d.ts
@@ -1,42 +1,49 @@
-import { Response } from "request";
-
-import { PkgInfo } from "./pkg-info";
-
 declare module "another-npm-registry-client" {
-  export type NpmAuth =
-    | {
-        username: string;
-        password: string;
-        email: string;
-        alwaysAuth?: boolean;
-      }
-    | { token: string; alwaysAuth?: boolean };
-  export type AddUserParams = { auth: NpmAuth };
+  import { type Response } from "request";
 
-  export type GetParams = {
-    timeout?: number;
-    follow?: boolean;
-    staleOk?: boolean;
-    auth?: NpmAuth;
-    fullMetadata?: boolean;
-  };
+  namespace RegClient {
+    type NpmAuth =
+      | {
+          username: string;
+          password: string;
+          email: string;
+          alwaysAuth?: boolean;
+        }
+      | { token: string; alwaysAuth?: boolean };
 
-  export type AddUserResponse = { ok: true; token: string } | { ok: false };
+    type AddUserParams = { auth: NpmAuth };
 
-  export type ClientCallback<TData> = (
-    error: Error | null,
-    data: TData,
-    raw: string,
-    res: Response
-  ) => void;
+    type GetParams = {
+      timeout?: number;
+      follow?: boolean;
+      staleOk?: boolean;
+      auth?: NpmAuth;
+      fullMetadata?: boolean;
+    };
 
-  export default class RegClient {
-    constructor(...args: unknown[]);
-    get(uri: string, params: GetParams, cb: ClientCallback<PkgInfo>): void;
-    adduser(
-      uri: string,
-      params: AddUserParams,
-      cb: ClientCallback<AddUserResponse>
-    ): void;
+    type AddUserResponse = { ok: true; token: string } | { ok: false };
+
+    type ClientCallback<TData> = (
+      error: Error | null,
+      data: TData,
+      raw: string,
+      res: Response
+    ) => void;
+
+    type Instance = {
+      get(
+        uri: string,
+        params: GetParams,
+        cb: ClientCallback<import("./pkg-info").PkgInfo>
+      ): void;
+      adduser(
+        uri: string,
+        params: AddUserParams,
+        cb: ClientCallback<AddUserResponse>
+      ): void;
+    };
   }
+
+  const RegClient: new (...args: unknown[]) => RegClient.Instance;
+  export = RegClient;
 }


### PR DESCRIPTION
Improves type declaration for `another-npm-registry-client`. Previously my IDE did not give good intellisense for its types and I guessed it was somewhat incorrectly declared. I'm not sure I did it correct this time either, but at least everything has the correct color and I get intellisense, so thats good.