### PR TITLE
chore: additional test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: npm run test
-        run: npm run test
+        run: npm run test:full
 
   release:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=16"
   },
   "scripts": {
-    "test": "cross-env NODE_ENV=test ts-mocha test/**/*.ts",
+    "test:quick": "cross-env NODE_ENV=test ts-mocha test/**/*.ts",
+    "test:full": "cross-env NODE_ENV=test ts-mocha test/**/*.ts --type-check",
     "clean": "rimraf lib",
     "build": "npm run clean && tsc -p tsconfig.build.json",
     "build:watch": "tsc -w -p tsconfig.build.json",


### PR DESCRIPTION
Adds a second test script for the project.

- `test:quick` runs test without type-checking
- `test:full` fully compiles ts before running tests, helping to uncover errors

Adjusted the cli to run `test:full`.