### PR TITLE
refactor: null instead of error

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -121,7 +121,10 @@ export const add = async function (
           if (
             editorVersionResult &&
             requiredEditorVersionResult &&
-            compareEditorVersion(env.editorVersion, requiredEditorVersion) < 0
+            compareEditorVersion(
+              editorVersionResult,
+              requiredEditorVersionResult
+            ) < 0
           ) {
             log.warn(
               "editor.version",

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -35,23 +35,16 @@ export type EditorVersion = {
    */
   locBuild?: number;
 };
-
 /**
  * Compares two editor versions for ordering
- * @param a The first version
- * @param b The second version
- * @throws Error An editor version could not be parsed
+ * @param verA The first version
+ * @param verB The second version
+ * @returns A number indicating the ordering
  */
 export const compareEditorVersion = function (
-  a: string,
-  b: string
+  verA: EditorVersion,
+  verB: EditorVersion
 ): -1 | 0 | 1 {
-  const verA = tryParseEditorVersion(a);
-  const verB = tryParseEditorVersion(b);
-
-  if (verA === null || verB === null)
-    throw new Error("An editor version could not be parsed");
-
   const editorVersionToArray = (ver: EditorVersion) => [
     ver.major,
     ver.minor,
@@ -70,6 +63,22 @@ export const compareEditorVersion = function (
     else if (valA < valB) return -1;
   }
   return 0;
+};
+/**
+ * Attempts to compare two unparsed editor versions for ordering
+ * @param a The first version
+ * @param b The second version
+ * @returns A number indicating the ordering or null if either version could
+ * not be parsed
+ */
+export const tryCompareEditorVersion = function (
+  a: string,
+  b: string
+): -1 | 0 | 1 | null {
+  const verA = tryParseEditorVersion(a);
+  const verB = tryParseEditorVersion(b);
+  if (verA === null || verB === null) return null;
+  return compareEditorVersion(verA, verB);
 };
 
 /**

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -81,12 +81,13 @@ export function encodeBasicAuth(username: string, password: string): Base64 {
 /**
  * Decodes a base64 encoded username and password
  * @param base64 The base64 string
- * @throws Error if the string cannot be decoded
+ * @returns Password/username tuple or null if the decoded string could
+ * not be parsed
  */
-export function decodeBasicAuth(base64: Base64): [string, string] {
+export function tryDecodeBasicAuth(base64: Base64): [string, string] | null {
   const text = decodeBase64(base64);
   const [username, password] = trySplitAtFirstOccurrenceOf(text, ":");
-  if (password === undefined) throw new Error("Base64 had invalid format");
+  if (password === undefined) return null;
   return [username, password];
 }
 
@@ -105,7 +106,9 @@ function tryToNpmAuth(upmAuth: UpmAuth): NpmAuth | null {
       alwaysAuth: shouldAlwaysAuth(upmAuth),
     };
   } else if (isBasicAuth(upmAuth)) {
-    const [username, password] = decodeBasicAuth(upmAuth._auth);
+    const decoded = tryDecodeBasicAuth(upmAuth._auth);
+    if (decoded === null) return null;
+    const [username, password] = decoded;
     return {
       username,
       password: encodeBase64(password),

--- a/test/test-editor-version.ts
+++ b/test/test-editor-version.ts
@@ -1,10 +1,12 @@
 import { describe } from "mocha";
 import {
   compareEditorVersion,
+  tryCompareEditorVersion,
   tryParseEditorVersion,
 } from "../src/types/editor-version";
 import "should";
 import assert from "assert";
+import should from "should";
 
 describe("editor-version", function () {
   describe("parseEditorVersion", function () {
@@ -79,44 +81,45 @@ describe("editor-version", function () {
   });
 
   describe("compareEditorVersion", function () {
-    it("test 2019.1 == 2019.1", function () {
-      compareEditorVersion("2019.1", "2019.1").should.equal(0);
-    });
-    it("test 2019.1.1 == 2019.1.1", function () {
-      compareEditorVersion("2019.1.1", "2019.1.1").should.equal(0);
-    });
-    it("test 2019.1.1f1 == 2019.1.1f1", function () {
-      compareEditorVersion("2019.1.1f1", "2019.1.1f1").should.equal(0);
-    });
-    it("test 2019.1.1f1c1 == 2019.1.1f1c1", function () {
-      compareEditorVersion("2019.1.1f1c1", "2019.1.1f1c1").should.equal(0);
-    });
-    it("test 2019.2 > 2019.1", function () {
-      compareEditorVersion("2019.2", "2019.1").should.equal(1);
-    });
-    it("test 2020.2 > 2019.1", function () {
-      compareEditorVersion("2020.1", "2019.1").should.equal(1);
-    });
-    it("test 2019.1 < 2019.2", function () {
-      compareEditorVersion("2019.1", "2019.2").should.equal(-1);
-    });
-    it("test 2019.1 < 2020.1", function () {
-      compareEditorVersion("2019.1", "2020.1").should.equal(-1);
-    });
-    it("test 2019.1 < 2019.1.1", function () {
-      compareEditorVersion("2019.1", "2019.1.1").should.equal(-1);
-    });
-    it("test 2019.1.1 < 2019.1.1f1", function () {
-      compareEditorVersion("2019.1.1", "2019.1.1f1").should.equal(-1);
-    });
-    it("test 2019.1.1a1 < 2020.1.1b1", function () {
-      compareEditorVersion("2019.1.1a1", "2020.1.1b1").should.equal(-1);
-    });
-    it("test 2019.1.1b1 < 2020.1.1f1", function () {
-      compareEditorVersion("2019.1.1b1", "2020.1.1f1").should.equal(-1);
-    });
-    it("test 2019.1.1f1 < 2020.1.1f1c1", function () {
-      compareEditorVersion("2019.1.1f1", "2020.1.1f1c1").should.equal(-1);
-    });
+    Array.of<[string, string]>(
+      ["2019.1", "2019.1"],
+      ["2019.1.1", "2019.1.1"],
+      ["2019.1.1f1", "2019.1.1f1"],
+      ["2019.1.1f1c1", "2019.1.1f1c1"]
+    ).forEach(([a, b]) =>
+      it(`${a} == ${b}`, function () {
+        should(tryCompareEditorVersion(a, b)).equal(0);
+      })
+    );
+    Array.of<[string, string]>(
+      ["2019.2", "2019.1"],
+      ["2020.1", "2019.1"]
+    ).forEach(([a, b]) =>
+      it(`${a} > ${b}`, function () {
+        should(tryCompareEditorVersion(a, b)).equal(1);
+      })
+    );
+    Array.of<[string, string]>(
+      ["2019.1", "2019.2"],
+      ["2019.1", "2020.1"],
+      ["2019.1", "2019.1.1"],
+      ["2019.1.1", "2019.1.1f1"],
+      ["2019.1.1a1", "2020.1.1b1"],
+      ["2019.1.1b1", "2020.1.1f1"],
+      ["2019.1.1f1", "2020.1.1f1c1"]
+    ).forEach(([a, b]) =>
+      it(`${a} < ${b}`, function () {
+        should(tryCompareEditorVersion(a, b)).equal(-1);
+      })
+    );
+
+    Array.of<[string, string]>(
+      ["2019.1", "not-a-version"],
+      ["not-a-version", "2020.1"]
+    ).forEach(([a, b]) =>
+      it(`should not be able to compare ${a} and ${b}`, function () {
+        should(tryCompareEditorVersion(a, b)).be.null();
+      })
+    );
   });
 });

--- a/test/test-upm-config.ts
+++ b/test/test-upm-config.ts
@@ -1,6 +1,6 @@
 import { describe } from "mocha";
 import {
-  decodeBasicAuth,
+  tryDecodeBasicAuth,
   encodeBasicAuth,
   isBasicAuth,
   isTokenAuth,
@@ -37,9 +37,14 @@ describe("upm-config", function () {
         const expectedUsername = "my-name";
         const expectedPassword = "123pass";
         const encoded = encodeBasicAuth(expectedUsername, expectedPassword);
-        const [actualUsername, actualPassword] = decodeBasicAuth(encoded);
+        const [actualUsername, actualPassword] = tryDecodeBasicAuth(encoded)!;
         should(actualUsername).be.equal(expectedUsername);
         should(actualPassword).be.equal(expectedPassword);
+      });
+      it("should not decode invalid data", () => {
+        const encoded = "This is not valid data" as Base64;
+        const decoded = tryDecodeBasicAuth(encoded)!;
+        should(decoded).be.null();
       });
     });
     describe("always-auth", function () {


### PR DESCRIPTION
Refactor functions which throw only one kind of error into functions that return `null` on failure instead. That way the client code can handle the issue without `try/catch`.