### PR TITLE
fix: dependency was dev-dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.19.3",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@commander-js/extra-typings": "^9.5.0",
         "@iarna/toml": "^2.2.5",
         "another-npm-registry-client": "^8.7.0",
         "chalk": "^4.1.2",
@@ -36,7 +37,6 @@
       "devDependencies": {
         "@babel/core": "^7.18.6",
         "@babel/eslint-parser": "^7.17.0",
-        "@commander-js/extra-typings": "^9.5.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@types/cli-table": "^0.3.2",
@@ -609,7 +609,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-9.5.0.tgz",
       "integrity": "sha512-OdIzg8hLlFyiV3BOEd7yRMtrqZ+L+bjAjGILpeG0LKUlE+N68tjp65JqKhapqWMHS6nDGGt+KjDf1y+eOQjwfw==",
-      "dev": true,
       "peerDependencies": {
         "commander": "9.5.x"
       }
@@ -10698,7 +10697,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-9.5.0.tgz",
       "integrity": "sha512-OdIzg8hLlFyiV3BOEd7yRMtrqZ+L+bjAjGILpeG0LKUlE+N68tjp65JqKhapqWMHS6nDGGt+KjDf1y+eOQjwfw==",
-      "dev": true,
       "requires": {}
     },
     "@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.17.0",
-    "@commander-js/extra-typings": "^9.5.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/cli-table": "^0.3.2",
@@ -69,6 +68,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^9.5.0",
     "@iarna/toml": "^2.2.5",
     "another-npm-registry-client": "^8.7.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
Because `@commander-js/extra-typings` had typings in the name I incorrectly thought it was a dev-only dependency, but it needs to be a regular dependency instead.

See https://github.com/openupm/openupm-cli/issues/87