### PR TITLE
conf: idea exclude lib folder

### DIFF
--- a/.idea/openupm-cli.iml
+++ b/.idea/openupm-cli.iml
@@ -5,6 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/lib" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
Configuration for jetbrains IDEs to exlude `lib` folder from indexing etc.