### PR TITLE
refactor: use npm types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@babel/core": "^7.18.6",
         "@babel/eslint-parser": "^7.17.0",
         "@commander-js/extra-typings": "^9.5.0",
+        "@npm/types": "^1.0.2",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@types/cli-table": "^0.3.2",
@@ -912,6 +913,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@npm/types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@npm/types/-/types-1.0.2.tgz",
+      "integrity": "sha512-KXZccTDEnWqNrrx6JjpJKU/wJvNeg9BDgjS0XhmlZab7br921HtyVbsYzJr4L+xIvjdJ20Wh9dgxgCI2a5CEQw==",
+      "dev": true
     },
     "node_modules/@npmcli/fs": {
       "version": "2.1.0",
@@ -10891,6 +10898,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@npm/types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@npm/types/-/types-1.0.2.tgz",
+      "integrity": "sha512-KXZccTDEnWqNrrx6JjpJKU/wJvNeg9BDgjS0XhmlZab7br921HtyVbsYzJr4L+xIvjdJ20Wh9dgxgCI2a5CEQw==",
+      "dev": true
     },
     "@npmcli/fs": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.17.0",
     "@commander-js/extra-typings": "^9.5.0",
+    "@npm/types": "^1.0.2",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/cli-table": "^0.3.2",

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -1,5 +1,0 @@
-export type Contact = {
-  name: string;
-  email?: string;
-  url?: string;
-};

--- a/src/types/pkg-version-info.ts
+++ b/src/types/pkg-version-info.ts
@@ -1,7 +1,7 @@
 import { PackageId } from "./package-id";
 import { SemanticVersion } from "./semantic-version";
 import { DomainName } from "./domain-name";
-import { Contact } from "./contact";
+import { Maintainer } from "@npm/types";
 
 /**
  * Distribution information
@@ -75,7 +75,7 @@ export type PkgVersionInfo = {
   /**
    * The author of the package.
    */
-  author?: Contact;
-  contributors?: Contact[];
+  author?: Maintainer;
+  contributors?: Maintainer[];
   dist?: Dist;
 };

--- a/src/types/pkg-version-info.ts
+++ b/src/types/pkg-version-info.ts
@@ -1,16 +1,7 @@
 import { PackageId } from "./package-id";
 import { SemanticVersion } from "./semantic-version";
 import { DomainName } from "./domain-name";
-import { Maintainer } from "@npm/types";
-
-/**
- * Distribution information
- */
-type Dist = {
-  tarball: string;
-  shasum: string;
-  integrity: string;
-};
+import { Dist, Maintainer } from "@npm/types";
 
 /**
  * Contains information about a specific version of a package. This is based on

--- a/test/test-cmd-search.ts
+++ b/test/test-cmd-search.ts
@@ -45,8 +45,8 @@ describe("cmd-search.ts", function () {
             date: "2019-10-02T04:02:38.335Z",
             links: {},
             author: { name: "yo", url: "https://github.com/yo" },
-            publisher: { username: "yo", email: "yo@example.com" },
-            maintainers: [{ username: "yo", email: "yo@example.com" }],
+            publisher: { name: "yo", email: "yo@example.com" },
+            maintainers: [{ name: "yo", email: "yo@example.com" }],
           },
           flags: { unstable: true },
           score: {

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,8 +1,6 @@
-import { Contact } from "../src/types/contact";
 import { DomainName } from "../src/types/domain-name";
 import { SemanticVersion } from "../src/types/semantic-version";
-
-type Maintainer = { username: string; email: string };
+import { Maintainer } from "@npm/types";
 
 export type SearchEndpointResult = {
   objects: Array<{
@@ -13,7 +11,7 @@ export type SearchEndpointResult = {
       scope: "unscoped";
       version: SemanticVersion;
       links: Record<string, unknown>;
-      author: Contact;
+      author: Maintainer;
       publisher: Maintainer;
       maintainers: Maintainer[];
     };


### PR DESCRIPTION
Uses premade npm-types where applicable instead of creating copies of them.