### PR TITLE
fix: manifest save crash

### DIFF
--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -5,6 +5,8 @@ import {
   manifestPathFor,
   UnityProjectManifest,
 } from "../types/project-manifest";
+import fse from "fs-extra";
+import path from "path";
 
 /**
  * Attempts to load the manifest from the path specified in env
@@ -41,6 +43,7 @@ export const saveProjectManifest = function (
   const manifestPath = manifestPathFor(workingDirectory);
   const json = JSON.stringify(data, null, 2);
   try {
+    fse.ensureDirSync(path.dirname(manifestPath));
     fs.writeFileSync(manifestPath, json);
     return true;
   } catch (err) {


### PR DESCRIPTION
Currently the app crashes when trying to save the project-manifest if the target folder does not exist. This can be annyoing in test scenarios.

This fix creates the [Project]/Packages folder if it does not exist.