### PR TITLE
refactor: rename function params

### DIFF
--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -117,10 +117,9 @@ export function addTestable(manifest: UnityProjectManifest, name: DomainName) {
 }
 
 /**
- * Determines the path to the package manifest based on the working
- * directory (Root of Unity project).
- * @param workingDirectory The working directory
+ * Determines the path to the package manifest based on the project directory.
+ * @param projectPath The root path of the Unity project
  */
-export function manifestPathFor(workingDirectory: string): string {
-  return path.join(workingDirectory, "Packages/manifest.json");
+export function manifestPathFor(projectPath: string): string {
+  return path.join(projectPath, "Packages/manifest.json");
 }

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -9,13 +9,13 @@ import fse from "fs-extra";
 import path from "path";
 
 /**
- * Attempts to load the manifest from the path specified in env
- * @param workingDirectory The working directory
+ * Attempts to load the manifest for a Unity project
+ * @param projectPath The path to the root of the project
  */
 export const loadProjectManifest = function (
-  workingDirectory: string
+  projectPath: string
 ): UnityProjectManifest | null {
-  const manifestPath = manifestPathFor(workingDirectory);
+  const manifestPath = manifestPathFor(projectPath);
   try {
     const text = fs.readFileSync(manifestPath, { encoding: "utf8" });
     return JSON.parse(text);
@@ -32,15 +32,15 @@ export const loadProjectManifest = function (
 };
 
 /**
- * Save manifest json file to the path specified in env
- * @param workingDirectory The working directory
+ * Saves a Unity project manifest.
+ * @param projectPath The path to the projects root directory
  * @param data The manifest to save
  */
 export const saveProjectManifest = function (
-  workingDirectory: string,
+  projectPath: string,
   data: UnityProjectManifest
 ) {
-  const manifestPath = manifestPathFor(workingDirectory);
+  const manifestPath = manifestPathFor(projectPath);
   const json = JSON.stringify(data, null, 2);
   try {
     fse.ensureDirSync(path.dirname(manifestPath));


### PR DESCRIPTION
The functions responsible for ProjectManifest io took the path to the projects root directory, but always called it "work directory" or similar. Renamed the parameters to "projectPath" to better reflect their actual meaning. Also adjusted a few corresponding js-docs.