### PR TITLE
refactor: no const functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
+    "func-style": ["error", "declaration", { allowArrowFunctions: true }],
   },
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -43,7 +43,7 @@ type AddResult = {
 /**
  * @throws Error An unhandled error occurred
  */
-export const add = async function (
+export async function add(
   pkgs: PackageReference | PackageReference[],
   options: AddOptions
 ): Promise<AddResultCode> {
@@ -52,7 +52,7 @@ export const add = async function (
   const env = await parseEnv(options, true);
   if (env === null) return 1;
 
-  const addSingle = async function (pkg: PackageReference): Promise<AddResult> {
+  const addSingle = async (pkg: PackageReference): Promise<AddResult> => {
     // dirty flag
     let dirty = false;
     // is upstream package flag
@@ -241,4 +241,4 @@ export const add = async function (
   if (result.dirty)
     log.notice("", "please open Unity project to apply changes");
   return result.code;
-};
+}

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -18,7 +18,7 @@ export type DepsOptions = CmdOptions<{
 /**
  * @throws Error An unhandled error occurred
  */
-export const deps = async function (
+export async function deps(
   pkg: PackageReference,
   options: DepsOptions
 ): Promise<DepsResultCode> {
@@ -53,4 +53,4 @@ export const deps = async function (
     });
 
   return 0;
-};
+}

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -33,9 +33,7 @@ type LoginResultCode = 0 | 1;
 /**
  * @throws Error An unhandled error occurred
  */
-export const login = async function (
-  options: LoginOptions
-): Promise<LoginResultCode> {
+export async function login(options: LoginOptions): Promise<LoginResultCode> {
   // parse env
   const env = await parseEnv(options, false);
   if (env === null) return 1;
@@ -81,12 +79,12 @@ export const login = async function (
   );
 
   return 0;
-};
+}
 
 /**
  * Return npm login token
  */
-const npmLogin = async function (
+async function npmLogin(
   username: string,
   password: string,
   email: string,
@@ -119,13 +117,13 @@ const npmLogin = async function (
       return { code: 1 };
     }
   }
-};
+}
 
 /**
  * Write npm token to .npmrc
  * @throws Error An unhandled error occurred
  */
-const writeNpmToken = async function (registry: RegistryUrl, token: string) {
+async function writeNpmToken(registry: RegistryUrl, token: string) {
   const configPath = getNpmrcPath();
   // read config
   let content = "";
@@ -137,19 +135,19 @@ const writeNpmToken = async function (registry: RegistryUrl, token: string) {
   const newContent = lines.join("\n") + "\n";
   fs.writeFileSync(configPath, newContent);
   log.notice("config", `saved to npm config: ${configPath}`);
-};
+}
 
 /**
  * Return .npmrc config file path
  * @throws Error Home-path could not be determined
  */
-export const getNpmrcPath = function () {
+export function getNpmrcPath() {
   const dirPath = process.env.USERPROFILE
     ? process.env.USERPROFILE
     : process.env.HOME;
   if (dirPath === undefined) throw new Error("Could not determine home path");
   return path.join(dirPath, ".npmrc");
-};
+}
 
 /**
  * Generate .npmrc file content lines
@@ -157,7 +155,7 @@ export const getNpmrcPath = function () {
  * @param {*} registry
  * @param {*} token
  */
-export const generateNpmrcLines = function (
+export function generateNpmrcLines(
   content: string,
   registry: RegistryUrl,
   token: string
@@ -186,13 +184,13 @@ export const generateNpmrcLines = function (
   // Remove empty lines
   lines = lines.filter((l) => l);
   return lines;
-};
+}
 
 /**
  * Write npm token to Unity
  * @throws Error The specified authentication information was missing
  */
-const writeUnityToken = async function (
+async function writeUnityToken(
   configDir: string,
   _auth: Base64 | null,
   alwaysAuth: boolean,
@@ -222,4 +220,4 @@ const writeUnityToken = async function (
   }
   // Write config file
   await saveUpmConfig(config, configDir);
-};
+}

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -25,7 +25,7 @@ type RemoveResult = {
   dirty: boolean;
 };
 
-export const remove = async function (
+export async function remove(
   pkgs: PackageReference[] | PackageReference,
   options: RemoveOptions
 ): Promise<RemoveResultCode> {
@@ -34,9 +34,7 @@ export const remove = async function (
   const env = await parseEnv(options, true);
   if (env === null) return 1;
 
-  const removeSingle = async function (
-    pkg: PackageReference
-  ): Promise<RemoveResult> {
+  const removeSingle = async (pkg: PackageReference): Promise<RemoveResult> => {
     // dirty flag
     let dirty = false;
     // parse name
@@ -93,4 +91,4 @@ export const remove = async function (
   if (result.dirty)
     log.notice("", "please open Unity project to apply changes");
   return result.code;
-};
+}

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -32,7 +32,7 @@ export type OldSearchResult =
  * Get npm fetch options
  * @param registry The registry for which to get the options
  */
-const getNpmFetchOptions = function (registry: Registry): Options {
+function getNpmFetchOptions(registry: Registry): Options {
   const opts: Options = {
     log,
     registry: registry.url,
@@ -40,9 +40,9 @@ const getNpmFetchOptions = function (registry: Registry): Options {
   const auth = registry.auth;
   if (auth !== null) Object.assign(opts, auth);
   return opts;
-};
+}
 
-const searchEndpoint = async function (
+async function searchEndpoint(
   registry: Registry,
   keyword: string
 ): Promise<TableRow[] | undefined> {
@@ -59,9 +59,9 @@ const searchEndpoint = async function (
     }
     log.warn("", "fast search endpoint is not available, using old search.");
   }
-};
+}
 
-const searchOld = async function (
+async function searchOld(
   registry: Registry,
   keyword: string
 ): Promise<TableRow[] | undefined> {
@@ -97,16 +97,16 @@ const searchOld = async function (
     }
     log.warn("", "/-/all endpoint is not available");
   }
-};
+}
 
-const getTable = function () {
+function getTable() {
   return new Table({
     head: ["Name", "Version", "Date"],
     colWidths: [42, 20, 12],
   });
-};
+}
 
-const getTableRow = function (packument: SearchedPackument): TableRow {
+function getTableRow(packument: SearchedPackument): TableRow {
   const name = packument.name;
   const version = tryGetLatestVersion(packument);
   let date = "";
@@ -117,7 +117,7 @@ const getTableRow = function (packument: SearchedPackument): TableRow {
   }
   assert(version !== undefined);
   return [name, version, date, ""];
-};
+}
 
 export async function search(
   keyword: string,

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -16,7 +16,7 @@ export type ViewOptions = CmdOptions;
 
 type ViewResultCode = 0 | 1;
 
-export const view = async function (
+export async function view(
   pkg: PackageReference,
   options: ViewOptions
 ): Promise<ViewResultCode> {
@@ -43,9 +43,9 @@ export const view = async function (
   // print info
   printInfo(packument);
   return 0;
-};
+}
 
-const printInfo = function (packument: UnityPackument) {
+function printInfo(packument: UnityPackument) {
   const versionCount = Object.keys(packument.versions).length;
   const ver = tryGetLatestVersion(packument);
   assert(ver !== undefined);
@@ -107,4 +107,4 @@ const printInfo = function (packument: UnityPackument) {
   for (const version in packument.versions) {
     console.log("  " + chalk.greenBright(version));
   }
-};
+}

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -86,22 +86,24 @@ function normalizeClientFunction<TParam, TData>(
   fn: (uri: string, params: TParam, cb: ClientCallback<TData>) => void
 ): (uri: string, params: TParam) => Promise<TData> {
   const bound = fn.bind(client);
-  const withNormalizedError = (
+
+  function withNormalizedError(
     uri: string,
     params: TParam,
     cb: (error: NpmClientError | null, data: TData) => void
-  ) => {
+  ) {
     return bound(uri, params, (error, data, raw, res) => {
       cb(error !== null ? new NpmClientError(error, res) : null, data);
     });
-  };
+  }
+
   return promisify(withNormalizedError);
 }
 
 /**
  * Return npm client
  */
-export const getNpmClient = (): NpmClient => {
+export function getNpmClient(): NpmClient {
   // create client
   const client = new RegClient({ log });
   return {
@@ -111,9 +113,10 @@ export const getNpmClient = (): NpmClient => {
     get: normalizeClientFunction(client, client.get),
     adduser: normalizeClientFunction(client, client.adduser),
   };
-};
+}
+
 // Fetch package info json from registry
-export const fetchPackument = async function (
+export async function fetchPackument(
   registry: Registry,
   name: DomainName
 ): Promise<UnityPackument | undefined> {
@@ -124,10 +127,10 @@ export const fetchPackument = async function (
   } catch (err) {
     /* empty */
   }
-};
+}
 
 // Fetch package dependencies
-export const fetchPackageDependencies = async function (
+export async function fetchPackageDependencies(
   registry: Registry,
   upstreamRegistry: Registry,
   name: DomainName,
@@ -258,4 +261,4 @@ export const fetchPackageDependencies = async function (
     }
   }
   return [depsValid, depsInvalid];
-};
+}

--- a/src/types/domain-name.ts
+++ b/src/types/domain-name.ts
@@ -59,7 +59,7 @@ export function isDomainName(s: string): s is DomainName {
  * Detect if the given package name is an internal package
  * @param name The name of the package
  */
-export const isInternalPackage = (name: DomainName): boolean => {
+export function isInternalPackage(name: DomainName): boolean {
   const internals = [
     "com.unity.ugui",
     "com.unity.2d.sprite",
@@ -68,7 +68,7 @@ export const isInternalPackage = (name: DomainName): boolean => {
     "com.unity.ugui",
   ];
   return /com.unity.modules/i.test(name) || internals.includes(name);
-};
+}
 
 /**
  * Constructs a domain-name from a string.

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -35,25 +35,29 @@ export type EditorVersion = {
    */
   locBuild?: number;
 };
+
 /**
  * Compares two editor versions for ordering
  * @param verA The first version
  * @param verB The second version
  * @returns A number indicating the ordering
  */
-export const compareEditorVersion = function (
+export function compareEditorVersion(
   verA: EditorVersion,
   verB: EditorVersion
 ): -1 | 0 | 1 {
-  const editorVersionToArray = (ver: EditorVersion) => [
-    ver.major,
-    ver.minor,
-    ver.patch || 0,
-    ver.flagValue || 0,
-    ver.build || 0,
-    ver.locValue || 0,
-    ver.locBuild || 0,
-  ];
+  function editorVersionToArray(ver: EditorVersion) {
+    return [
+      ver.major,
+      ver.minor,
+      ver.patch || 0,
+      ver.flagValue || 0,
+      ver.build || 0,
+      ver.locValue || 0,
+      ver.locBuild || 0,
+    ];
+  }
+
   const arrA = editorVersionToArray(verA);
   const arrB = editorVersionToArray(verB);
   for (let i = 0; i < arrA.length; i++) {
@@ -63,7 +67,8 @@ export const compareEditorVersion = function (
     else if (valA < valB) return -1;
   }
   return 0;
-};
+}
+
 /**
  * Attempts to compare two unparsed editor versions for ordering
  * @param a The first version
@@ -71,7 +76,7 @@ export const compareEditorVersion = function (
  * @returns A number indicating the ordering or null if either version could
  * not be parsed
  */
-export const tryCompareEditorVersion = function (
+export function tryCompareEditorVersion(
   a: string,
   b: string
 ): -1 | 0 | 1 | null {
@@ -79,14 +84,12 @@ export const tryCompareEditorVersion = function (
   const verB = tryParseEditorVersion(b);
   if (verA === null || verB === null) return null;
   return compareEditorVersion(verA, verB);
-};
+}
 
 /**
  * Attempts to parse editor version string to groups
  */
-export const tryParseEditorVersion = function (
-  version: string
-): EditorVersion | null {
+export function tryParseEditorVersion(version: string): EditorVersion | null {
   type RegexMatchGroups = {
     major: `${number}`;
     minor: `${number}`;
@@ -120,4 +123,4 @@ export const tryParseEditorVersion = function (
     if (groups.locBuild) result.locBuild = parseInt(groups.locBuild);
   }
   return result;
-};
+}

--- a/src/types/package-url.ts
+++ b/src/types/package-url.ts
@@ -5,15 +5,22 @@ import { Brand } from "ts-brand";
  */
 export type PackageUrl = Brand<string, "PackageUrl">;
 
-const isGit = (version: string): boolean => version.startsWith("git");
+function isGit(version: string): boolean {
+  return version.startsWith("git");
+}
 
-const isHttp = (version: string): boolean => version.startsWith("http");
+function isHttp(version: string): boolean {
+  return version.startsWith("http");
+}
 
-const isLocal = (version: string): boolean => version.startsWith("file");
+function isLocal(version: string): boolean {
+  return version.startsWith("file");
+}
 
 /**
  * Checks if a version is a package-url
  * @param version The version
  */
-export const isPackageUrl = (version: string): version is PackageUrl =>
-  isGit(version) || isHttp(version) || isLocal(version);
+export function isPackageUrl(version: string): version is PackageUrl {
+  return isGit(version) || isHttp(version) || isLocal(version);
+}

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -72,22 +72,22 @@ export type UnityPackument = {
   users?: Record<string, unknown>;
 };
 
-const hasLatestDistTag = (
+function hasLatestDistTag(
   packument: Partial<UnityPackument>
 ): packument is Partial<UnityPackument> & {
   "dist-tags": { latest: SemanticVersion };
-} => {
+} {
   return packument["dist-tags"]?.["latest"] !== undefined;
-};
+}
 
 /**
  * Attempt to get the latest version from a package
  * @param packument The package. All properties are assumed to be potentially missing
  */
-export const tryGetLatestVersion = function (packument: {
+export function tryGetLatestVersion(packument: {
   "dist-tags"?: { latest?: SemanticVersion };
   version?: SemanticVersion;
 }): SemanticVersion | undefined {
   if (hasLatestDistTag(packument)) return packument["dist-tags"].latest;
   else if (packument.version) return packument.version;
-};
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -24,7 +24,7 @@ export type Env = {
  * Parse env
  * @throws Error An unhandled error occurred
  */
-export const parseEnv = async function (
+export async function parseEnv(
   options: CmdOptions,
   checkPath: boolean
 ): Promise<Env | null> {
@@ -125,4 +125,4 @@ export const parseEnv = async function (
   }
   // return
   return env;
-};
+}

--- a/src/utils/error-type-guards.ts
+++ b/src/utils/error-type-guards.ts
@@ -19,9 +19,10 @@ export function assertIsError(x: unknown): asserts x is ErrnoException {
     });
 }
 
-export const isHttpError = (x: unknown): x is HttpErrorBase => {
+export function isHttpError(x: unknown): x is HttpErrorBase {
   return x instanceof Error && "statusCode" in x;
-};
+}
 
-export const is404Error = (err: HttpErrorBase): boolean =>
-  err.statusCode === 404 || err.message.includes("404");
+export function is404Error(err: HttpErrorBase): boolean {
+  return err.statusCode === 404 || err.message.includes("404");
+}

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -12,7 +12,7 @@ import path from "path";
  * Attempts to load the manifest from the path specified in env
  * @param workingDirectory The working directory
  */
-export const loadProjectManifest = function (
+export function loadProjectManifest(
   workingDirectory: string
 ): UnityProjectManifest | null {
   const manifestPath = manifestPathFor(workingDirectory);
@@ -29,14 +29,14 @@ export const loadProjectManifest = function (
     }
     return null;
   }
-};
+}
 
 /**
  * Save manifest json file to the path specified in env
  * @param workingDirectory The working directory
  * @param data The manifest to save
  */
-export const saveProjectManifest = function (
+export function saveProjectManifest(
   workingDirectory: string,
   data: UnityProjectManifest
 ) {
@@ -52,4 +52,4 @@ export const saveProjectManifest = function (
     log.error("manifest", err.message);
     return false;
   }
-};
+}

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -15,10 +15,10 @@ const configFileName = ".upmconfig.toml";
  * @param systemUser Whether to authenticate as a Windows system-user
  * @throws Error Could not determine upm config directory
  */
-export const getUpmConfigDir = async (
+export async function getUpmConfigDir(
   wsl: boolean,
   systemUser: boolean
-): Promise<string> => {
+): Promise<string> {
   let dirPath: string | undefined = "";
   const systemUserSubPath = "Unity/config/ServiceAccounts";
   if (wsl) {
@@ -50,15 +50,15 @@ export const getUpmConfigDir = async (
   if (dirPath === undefined)
     throw new Error("Could not resolve upm-config dir-path");
   return dirPath;
-};
+}
 
 /**
  * Attempts to load the upm config
  * @param configDir The directory from which to load the config
  */
-export const loadUpmConfig = async (
+export async function loadUpmConfig(
   configDir: string
-): Promise<UPMConfig | undefined> => {
+): Promise<UPMConfig | undefined> {
   const configPath = path.join(configDir, configFileName);
   if (fs.existsSync(configPath)) {
     const content = fs.readFileSync(configPath, "utf8");
@@ -67,14 +67,14 @@ export const loadUpmConfig = async (
     // NOTE: We assume correct format
     return config as UPMConfig;
   }
-};
+}
 
 /**
  * Save the upm config
  * @param config The config to save
  * @param configDir The directory in which to save the config
  */
-export const saveUpmConfig = async (config: UPMConfig, configDir: string) => {
+export async function saveUpmConfig(config: UPMConfig, configDir: string) {
   try {
     mkdirp.sync(configDir);
   } catch {
@@ -84,4 +84,4 @@ export const saveUpmConfig = async (config: UPMConfig, configDir: string) => {
   const content = TOML.stringify(config);
   fs.writeFileSync(configPath, content, "utf8");
   log.notice("config", "saved unity config at " + configPath);
-};
+}

--- a/test/mock-work-dir.ts
+++ b/test/mock-work-dir.ts
@@ -11,10 +11,12 @@ export type ManifestCreationOptions = {
   manifest: boolean | UnityProjectManifest;
   editorVersion?: string;
 };
-export const getWorkDir = function (pathToTmp: string): string {
+
+export function getWorkDir(pathToTmp: string): string {
   return path.join(os.tmpdir(), pathToTmp);
-};
-export const createWorkDir = function (
+}
+
+export function createWorkDir(
   pathToTmp: string,
   { manifest, editorVersion }: ManifestCreationOptions
 ): string {
@@ -37,8 +39,9 @@ export const createWorkDir = function (
     );
   }
   return workDir;
-};
-export const removeWorkDir = function (pathToTmp: string) {
+}
+
+export function removeWorkDir(pathToTmp: string) {
   const cwd = getWorkDir(pathToTmp);
   fse.removeSync(cwd);
-};
+}


### PR DESCRIPTION
This is an opinionated change, to only allow function declarations in the project. That means no `const x = function() { }`, only `function x() { }`. Arrow functions are still allowed, since that sometimes has an effect on functionality.

This is done for consistency across the project. We could also convert all functions to the expression syntax instead. Either way is fine.