### PR TITLE
chore: suppress warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,9 @@ You may need to set both http_proxy and https_proxy environment variables at the
 <table>
   <tbody>
     <tr>
+      <!--suppress HtmlDeprecatedAttribute -->
       <td align="center" valign="top" width="14.28%"><a href="http://littlebigfun.com"><img src="https://avatars.githubusercontent.com/u/125390?v=4?s=100" width="100px;" alt="Favo Yang"/><br /><sub><b>Favo Yang</b></sub></a><br /><a href="https://github.com/openupm/openupm-cli/commits?author=favoyang" title="Code">💻</a> <a href="#maintenance-favoyang" title="Maintenance">🚧</a></td>
+      <!--suppress HtmlDeprecatedAttribute -->
       <td align="center" valign="top" width="14.28%"><a href="https://comradevanti.itch.io"><img src="https://avatars.githubusercontent.com/u/31240807?v=4?s=100" width="100px;" alt="Ramon Brullo"/><br /><sub><b>Ramon Brullo</b></sub></a><br /><a href="https://github.com/openupm/openupm-cli/commits?author=ComradeVanti" title="Code">💻</a></td>
     </tr>
   </tbody>


### PR DESCRIPTION
Autogenerated HTML code in Readme has some obsolete attributes. I don't think we care about that right now, so the warning was disabled.