### PR TITLE
deps: bump yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "semver": "^7.5.4",
         "ts-brand": "^0.0.2",
         "update-notifier": "^5.1.0",
-        "yaml": "^2.0.1"
+        "yaml": "^2.2.2"
       },
       "bin": {
         "openupm": "lib/index.js",
@@ -10040,8 +10040,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.1.0",
-      "license": "ISC",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "engines": {
         "node": ">= 14"
       }
@@ -16697,7 +16698,9 @@
       "version": "4.0.0"
     },
     "yaml": {
-      "version": "2.1.0"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "semver": "^7.5.4",
     "ts-brand": "^0.0.2",
     "update-notifier": "^5.1.0",
-    "yaml": "^2.0.1"
+    "yaml": "^2.2.2"
   },
   "volta": {
     "node": "16.20.2"


### PR DESCRIPTION
Webstorm was marking version 2.0.1 as a security risk. Bumped to fix warning.