### PR TITLE
fix: path issues on windows

### DIFF
--- a/test/test-cmd-login.ts
+++ b/test/test-cmd-login.ts
@@ -3,6 +3,7 @@ import { generateNpmrcLines, getNpmrcPath } from "../src/cmd-login";
 import { registryUrl } from "../src/types/registry-url";
 import { runWithEnv } from "./mock-env";
 import should from "should";
+import path from "path";
 
 describe("cmd-login.ts", function () {
   describe("generateNpmrcLines", function () {
@@ -57,12 +58,14 @@ describe("cmd-login.ts", function () {
 
   describe("getNpmrcPath", function () {
     it("should be USERPROFILE if defined", function () {
-      const path = runWithEnv({ USERPROFILE: "/user/dir" }, getNpmrcPath);
-      should(path).be.equal("/user/dir/.npmrc");
+      const actual = runWithEnv({ USERPROFILE: "/user/dir" }, getNpmrcPath);
+      const expected = path.join(path.sep, "user", "dir", ".npmrc");
+      should(actual).be.equal(expected);
     });
     it("should be HOME if USERPROFILE is not defined", function () {
-      const path = runWithEnv({ HOME: "/user/dir" }, getNpmrcPath);
-      should(path).be.equal("/user/dir/.npmrc");
+      const actual = runWithEnv({ HOME: "/user/dir" }, getNpmrcPath);
+      const expected = path.join(path.sep, "user", "dir", ".npmrc");
+      should(actual).be.equal(expected);
     });
     it("should fail if HOME and USERPROFILE are not defined", function () {
       should(() => runWithEnv({}, getNpmrcPath)).throw();

--- a/test/test-project-manifest-io.ts
+++ b/test/test-project-manifest-io.ts
@@ -12,6 +12,7 @@ import { addDependency, manifestPathFor } from "../src/types/project-manifest";
 import should from "should";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import fse from "fs-extra";
+import path from "path";
 
 describe("project-manifest io", function () {
   let mockConsole: MockConsole = null!;
@@ -61,6 +62,7 @@ describe("project-manifest io", function () {
   });
   it("manifest-path is correct", function () {
     const manifestPath = manifestPathFor("test-openupm-cli");
-    should(manifestPath).be.equal("test-openupm-cli/Packages/manifest.json");
+    const expected = path.join("test-openupm-cli", "Packages", "manifest.json");
+    should(manifestPath).be.equal(expected);
   });
 });


### PR DESCRIPTION
Tests would fail on Windows, because of the different path-separators to Linux. Adjusted tests to take os into account.