### PR TITLE
refactor: reuse function

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -23,7 +23,7 @@ import {
   PackageReference,
   splitPackageReference,
 } from "./types/package-reference";
-import { scopedRegistry } from "./types/scoped-registry";
+import { addScope, scopedRegistry } from "./types/scoped-registry";
 import {
   addDependency,
   addScopedRegistry,
@@ -219,15 +219,10 @@ export const add = async function (
         addScopedRegistry(manifest, entry);
         dirty = true;
       }
-      // apply pkgsInScope
-      const scopesSet = new Set(entry.scopes || []);
       pkgsInScope.forEach((name) => {
-        if (!scopesSet.has(name)) {
-          scopesSet.add(name);
-          dirty = true;
-        }
+        const wasAdded = addScope(entry!, name);
+        if (wasAdded) dirty = true;
       });
-      entry.scopes = Array.from(scopesSet).sort();
     }
     if (options.test) addTestable(manifest, name);
     // save manifest

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -36,13 +36,18 @@ export function scopedRegistry(
 }
 
 /**
- * Adds a scope to a registry. The list will be sorted alphabetically.
+ * Adds a scope to a registry if it is not already in the list. The scopes will
+ * also be sorted alphabetically.
  * @param registry The registry.
  * @param scope The scope.
+ * @returns Boolean whether the scope was added successfully.
  */
-export function addScope(registry: ScopedRegistry, scope: DomainName) {
+export function addScope(registry: ScopedRegistry, scope: DomainName): boolean {
+  if (registry.scopes.includes(scope)) return false;
+
   registry.scopes.push(scope);
   registry.scopes.sort();
+  return true;
 }
 
 /**

--- a/test/test-scoped-registry.ts
+++ b/test/test-scoped-registry.ts
@@ -19,9 +19,15 @@ describe("scoped-registry", function () {
   describe("add scope", function () {
     it("should keep scope-list alphabetical", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      addScope(registry, domainName("b"));
-      addScope(registry, domainName("a"));
+      should(addScope(registry, domainName("b"))).be.true();
+      should(addScope(registry, domainName("a"))).be.true();
       should(registry.scopes).be.deepEqual(["a", "b"]);
+    });
+    it("should filter duplicates", () => {
+      const registry = scopedRegistry("test", exampleRegistryUrl);
+      should(addScope(registry, domainName("a"))).be.true();
+      should(addScope(registry, domainName("a"))).be.false();
+      should(registry.scopes).be.deepEqual(["a"]);
     });
   });
   describe("has scope", function () {


### PR DESCRIPTION
Logic for adding scope to scoped registry was somewhat duplicated. Partly it was inside `scoped-registry/addScope` and then also replicated in `cmd-add`. Refactored so `cmd-add` also used the `addScope` function.