### PR TITLE
refactor: deduplicate scope-remove logic

### DIFF
--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -64,8 +64,8 @@ export const remove = async function (
 
     const entry = tryGetScopedRegistryByUrl(manifest, env.registry.url);
     if (entry !== null) {
-      removeScope(entry, name);
-      dirty = true;
+      const scopeWasRemoved = removeScope(entry, name);
+      if (scopeWasRemoved) dirty = true;
     }
     // save manifest
     if (dirty) {

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -9,7 +9,7 @@ import {
   PackageReference,
   splitPackageReference,
 } from "./types/package-reference";
-import { hasScope, removeScope } from "./types/scoped-registry";
+import { removeScope } from "./types/scoped-registry";
 import {
   removeDependency,
   tryGetScopedRegistryByUrl,
@@ -64,12 +64,8 @@ export const remove = async function (
 
     const entry = tryGetScopedRegistryByUrl(manifest, env.registry.url);
     if (entry !== null) {
-      if (hasScope(entry, name)) {
-        removeScope(entry, name);
-        const scopesSet = new Set(entry.scopes);
-        entry.scopes = Array.from(scopesSet).sort();
-        dirty = true;
-      }
+      removeScope(entry, name);
+      dirty = true;
     }
     // save manifest
     if (dirty) {

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -60,6 +60,5 @@ export function hasScope(registry: ScopedRegistry, scope: DomainName): boolean {
  * @param scope The scope.
  */
 export function removeScope(registry: ScopedRegistry, scope: DomainName) {
-  const index = registry.scopes.indexOf(scope);
-  if (index >= 0) registry.scopes.splice(index, 1);
+  registry.scopes = registry.scopes.filter((it) => it !== scope);
 }

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -58,7 +58,13 @@ export function hasScope(registry: ScopedRegistry, scope: DomainName): boolean {
  * Removes a scope from a registry.
  * @param registry The registry.
  * @param scope The scope.
+ * @returns Boolean indicating whether a scope was actually removed.
  */
-export function removeScope(registry: ScopedRegistry, scope: DomainName) {
+export function removeScope(
+  registry: ScopedRegistry,
+  scope: DomainName
+): boolean {
+  const prevCount = registry.scopes.length;
   registry.scopes = registry.scopes.filter((it) => it !== scope);
+  return registry.scopes.length != prevCount;
 }

--- a/test/test-scoped-registry.ts
+++ b/test/test-scoped-registry.ts
@@ -43,5 +43,13 @@ describe("scoped-registry", function () {
       removeScope(registry, domainName("a"));
       should(hasScope(registry, domainName("a"))).be.false();
     });
+    it("should remove duplicate scopes", () => {
+      const registry = scopedRegistry("test", exampleRegistryUrl, [
+        domainName("a"),
+        domainName("a"),
+      ]);
+      removeScope(registry, domainName("a"));
+      should(registry.scopes).be.empty();
+    });
   });
 });

--- a/test/test-scoped-registry.ts
+++ b/test/test-scoped-registry.ts
@@ -40,15 +40,22 @@ describe("scoped-registry", function () {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
       ]);
-      removeScope(registry, domainName("a"));
+      should(removeScope(registry, domainName("a"))).be.true();
       should(hasScope(registry, domainName("a"))).be.false();
+    });
+    it("should not do nothing if scope does not exist", () => {
+      const registry = scopedRegistry("test", exampleRegistryUrl, [
+        domainName("a"),
+      ]);
+      should(removeScope(registry, domainName("b"))).be.false();
+      should(hasScope(registry, domainName("a"))).be.true();
     });
     it("should remove duplicate scopes", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
         domainName("a"),
       ]);
-      removeScope(registry, domainName("a"));
+      should(removeScope(registry, domainName("a"))).be.true();
       should(registry.scopes).be.empty();
     });
   });


### PR DESCRIPTION
Some logic related to removing scopes from a scoped registry was still inside `cmd-remove`. Moved this logic into `scoped-registry/removeScope` and added tests for it.