### PR TITLE
refactor: make upm-config types readonly

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -8,7 +8,7 @@ import {
   saveUpmConfig,
 } from "./utils/upm-config-io";
 import { parseEnv } from "./utils/env";
-import { encodeBasicAuth } from "./types/upm-config";
+import { addAuth, encodeBasicAuth, UPMConfig } from "./types/upm-config";
 import { Base64 } from "./types/base64";
 import { RegistryUrl } from "./types/registry-url";
 import {
@@ -202,23 +202,30 @@ const writeUnityToken = async function (
   token: string | null
 ) {
   // Read config file
-  const config = (await loadUpmConfig(configDir)) || {};
-  if (!config.npmAuth) config.npmAuth = {};
+  let config: UPMConfig = (await loadUpmConfig(configDir)) || {};
 
   if (basicAuth) {
     if (_auth === null) throw new Error("Auth is null");
-    config["npmAuth"][registry] = {
-      email,
-      alwaysAuth,
-      _auth,
-    };
+    config = addAuth(
+      registry,
+      {
+        email,
+        alwaysAuth,
+        _auth,
+      },
+      config
+    );
   } else {
     if (token === null) throw new Error("Token is null");
-    config["npmAuth"][registry] = {
-      email,
-      alwaysAuth,
-      token,
-    };
+    config = addAuth(
+      registry,
+      {
+        email,
+        alwaysAuth,
+        token,
+      },
+      config
+    );
   }
   // Write config file
   await saveUpmConfig(config, configDir);

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -51,12 +51,12 @@ export type UpmAuth = BasicAuth | TokenAuth;
  * Content of .upmconfig.toml. Used to authenticate with package registries.
  * @see https://medium.com/openupm/how-to-authenticate-with-a-upm-scoped-registry-using-cli-afc29c13a2f8
  */
-export type UPMConfig = {
+export type UPMConfig = Readonly<{
   /**
    * Authentication information organized by the registry they should be used on.
    */
   npmAuth?: Record<string, UpmAuth>;
-};
+}>;
 
 /**
  * Checks if an auth-object uses basic authentication.
@@ -103,7 +103,12 @@ export function shouldAlwaysAuth(auth: UpmAuth): boolean {
   return auth.alwaysAuth || false;
 }
 
-function tryToNpmAuth(upmAuth: UpmAuth): NpmAuth | null {
+/**
+ * Attempts to convert a {@link UpmAuth} object to a {@link NpmAuth} object.
+ * @param upmAuth The auth-object to convert.
+ * @returns The converted object or null, if conversion failed.
+ */
+export function tryToNpmAuth(upmAuth: UpmAuth): NpmAuth | null {
   if (isTokenAuth(upmAuth)) {
     return {
       token: upmAuth.token,
@@ -148,4 +153,20 @@ export function tryGetAuthForRegistry(
     );
   }
   return npmAuth;
+}
+
+/**
+ * Adds authentication information to a {@link UPMConfig} object.
+ * @param registry The registry under which to add the auth-information.
+ * @param auth The auth-information.
+ * @param config The config object that should be extended.
+ * @returns An extended {@link UPMConfig} object.
+ */
+export function addAuth(
+  registry: RegistryUrl,
+  auth: UpmAuth,
+  config: UPMConfig
+): UPMConfig {
+  const authContainer = config.npmAuth || {};
+  return { npmAuth: { ...authContainer, [registry]: auth } };
 }

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -55,7 +55,7 @@ export type UPMConfig = Readonly<{
   /**
    * Authentication information organized by the registry they should be used on.
    */
-  npmAuth?: Record<string, UpmAuth>;
+  npmAuth?: Readonly<Record<string, UpmAuth>>;
 }>;
 
 /**

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -7,7 +7,7 @@ import { NpmAuth } from "another-npm-registry-client";
 /**
  * Authentication information that is shared between different authentication methods.
  */
-type AuthBase = {
+type AuthBase = Readonly<{
   /**
    * The email to use.
    */
@@ -16,7 +16,7 @@ type AuthBase = {
    * Whether to always authenticate.
    */
   alwaysAuth?: boolean;
-};
+}>;
 
 /**
  * Authenticates using encoded username and password.

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -33,12 +33,14 @@ export type BasicAuth = Readonly<
 /**
  * Authenticates using token.
  */
-export type TokenAuth = AuthBase & {
-  /**
-   * A token to authenticate with.
-   */
-  token: string;
-};
+export type TokenAuth = Readonly<
+  AuthBase & {
+    /**
+     * A token to authenticate with.
+     */
+    token: string;
+  }
+>;
 
 /**
  * Authentication information for a registry.

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -21,12 +21,14 @@ type AuthBase = Readonly<{
 /**
  * Authenticates using encoded username and password.
  */
-export type BasicAuth = AuthBase & {
-  /**
-   * Base64 encoded username and password to authenticate with.
-   */
-  _auth: Base64;
-};
+export type BasicAuth = Readonly<
+  AuthBase & {
+    /**
+     * Base64 encoded username and password to authenticate with.
+     */
+    _auth: Base64;
+  }
+>;
 
 /**
  * Authenticates using token.

--- a/test/test-upm-config.ts
+++ b/test/test-upm-config.ts
@@ -1,11 +1,14 @@
 import { describe } from "mocha";
 import {
+  addAuth,
+  BasicAuth,
   encodeBasicAuth,
   isBasicAuth,
   isTokenAuth,
   shouldAlwaysAuth,
   tryDecodeBasicAuth,
   tryGetAuthForRegistry,
+  tryToNpmAuth,
   UpmAuth,
   UPMConfig,
 } from "../src/types/upm-config";
@@ -13,9 +16,23 @@ import should from "should";
 import { Base64 } from "../src/types/base64";
 import { registryUrl, RegistryUrl } from "../src/types/registry-url";
 import { NpmAuth } from "another-npm-registry-client";
+import { exampleRegistryUrl } from "./mock-registry";
 
 describe("upm-config", function () {
   describe("auth", function () {
+    describe("add", function () {
+      it("should have registry after adding", function () {
+        const registry = exampleRegistryUrl;
+        const auth: BasicAuth = {
+          email: "email@wow.com",
+          _auth: encodeBasicAuth("user", "pass"),
+        };
+        const config = addAuth(registry, auth, {});
+        should(tryGetAuthForRegistry(config, registry)).be.deepEqual(
+          tryToNpmAuth(auth)
+        );
+      });
+    });
     describe("classification", function () {
       it("should be basic auth if it has _auth property", () => {
         const auth: UpmAuth = {


### PR DESCRIPTION
Refactor `UPMConfig` and related types to be immutable/readonly. Adjusted usages accordingly and add tests.