### PR TITLE
refactor: make unity-packument type readonly

### DIFF
--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -21,7 +21,7 @@ export type UnityPackumentVersion = UnityPackageManifest & {
   category?: string;
   gitHead?: string;
   readmeFilename?: string;
-  contributors?: Maintainer[];
+  contributors?: ReadonlyArray<Maintainer>;
   dist?: Dist;
 };
 
@@ -49,7 +49,7 @@ export type UnityPackument = {
    */
   "dist-tags"?: { latest?: SemanticVersion };
   /**
-   * May contain the latest version. Legacy property, use {@link dist-tags} 
+   * May contain the latest version. Legacy property, use {@link dist-tags}
    * instead.
    */
   version?: SemanticVersion;
@@ -89,7 +89,7 @@ const hasLatestDistTag = <T extends VersionedPackument>(
 
 /**
  * Attempt to get the latest version from a package.
- * @param packument The package. All properties are assumed to be potentially 
+ * @param packument The package. All properties are assumed to be potentially
  * missing.
  */
 export const tryGetLatestVersion = function (

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -72,7 +72,7 @@ export type UnityPackument = {
     modified?: string;
   }>;
   date?: Date;
-  users?: Record<string, unknown>;
+  users?: Readonly<Record<string, unknown>>;
 };
 
 /**

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -66,11 +66,11 @@ export type UnityPackument = {
   /**
    * Information about package and version creation/modification times.
    */
-  time: {
+  time: Readonly<{
     [key: SemanticVersion]: string;
     created?: string;
     modified?: string;
-  };
+  }>;
   date?: Date;
   users?: Record<string, unknown>;
 };

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -22,7 +22,7 @@ export type UnityPackumentVersion = UnityPackageManifest & {
   gitHead?: string;
   readmeFilename?: string;
   contributors?: ReadonlyArray<Maintainer>;
-  dist?: Dist;
+  dist?: Readonly<Dist>;
 };
 
 /**

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -30,7 +30,7 @@ export type UnityPackumentVersion = Readonly<
 /**
  * Describes a package.
  */
-export type UnityPackument = {
+export type UnityPackument = Readonly<{
   /**
    * The packages name.
    */
@@ -73,7 +73,7 @@ export type UnityPackument = {
   }>;
   date?: Date;
   users?: Readonly<Record<string, unknown>>;
-};
+}>;
 
 /**
  * The minimum properties a Packument must have in order for it's version

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -49,7 +49,7 @@ export type UnityPackument = {
   /**
    * Dist-tags. Only includes information about the latest version.
    */
-  "dist-tags"?: { latest?: SemanticVersion };
+  "dist-tags"?: Readonly<{ latest?: SemanticVersion }>;
   /**
    * May contain the latest version. Legacy property, use {@link dist-tags}
    * instead.

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -40,7 +40,7 @@ export type UnityPackument = {
    */
   _id?: DomainName;
   _rev?: string;
-  _attachments?: Record<string, unknown>;
+  _attachments?: Readonly<Record<string, unknown>>;
   readme?: string;
   /**
    * The packages versions, organized by their version.

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -9,21 +9,23 @@ import { Dist, Maintainer } from "@npm/types";
  * the information contained inside a Unity package manifest, with some
  * additions.
  */
-export type UnityPackumentVersion = UnityPackageManifest & {
-  /**
-   * Same as {@link name}.
-   */
-  _id?: PackageId;
-  _nodeVersion?: string;
-  _npmVersion?: string;
-  _rev?: string;
-  homepage?: string;
-  category?: string;
-  gitHead?: string;
-  readmeFilename?: string;
-  contributors?: ReadonlyArray<Maintainer>;
-  dist?: Readonly<Dist>;
-};
+export type UnityPackumentVersion = Readonly<
+  UnityPackageManifest & {
+    /**
+     * Same as {@link name}.
+     */
+    _id?: PackageId;
+    _nodeVersion?: string;
+    _npmVersion?: string;
+    _rev?: string;
+    homepage?: string;
+    category?: string;
+    gitHead?: string;
+    readmeFilename?: string;
+    contributors?: ReadonlyArray<Maintainer>;
+    dist?: Readonly<Dist>;
+  }
+>;
 
 /**
  * Describes a package.

--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -45,7 +45,7 @@ export type UnityPackument = {
   /**
    * The packages versions, organized by their version.
    */
-  versions: Record<SemanticVersion, UnityPackumentVersion>;
+  versions: Readonly<Record<SemanticVersion, UnityPackumentVersion>>;
   /**
    * Dist-tags. Only includes information about the latest version.
    */

--- a/test/data-packument.ts
+++ b/test/data-packument.ts
@@ -11,7 +11,7 @@ import { UnityPackument, UnityPackumentVersion } from "../src/types/packument";
  * Builder class for {@link UnityPackumentVersion}.
  */
 class UnityPackumentVersionBuilder {
-  readonly version: UnityPackumentVersion;
+  version: UnityPackumentVersion;
 
   constructor(name: DomainName, version: SemanticVersion) {
     this.version = {
@@ -49,7 +49,7 @@ class UnityPackumentVersionBuilder {
     key: TKey,
     value: UnityPackumentVersion[TKey]
   ): UnityPackumentVersionBuilder {
-    this.version[key] = value;
+    this.version = { ...this.version, [key]: value };
     return this;
   }
 }

--- a/test/data-packument.ts
+++ b/test/data-packument.ts
@@ -92,9 +92,9 @@ class UnityPackumentBuilder {
         ...this.packument.versions,
         [version]: builder.version,
       },
-    };
-    this.packument["dist-tags"] = {
-      latest: version,
+      "dist-tags": {
+        latest: version,
+      },
     };
     return this;
   }
@@ -105,7 +105,7 @@ class UnityPackumentBuilder {
       "name" | "version" | "versions" | "dist-tags" | "_id"
     >
   >(key: TKey, value: UnityPackument[TKey]): UnityPackumentBuilder {
-    this.packument[key] = value;
+    this.packument = { ...this.packument, [key]: value };
     return this;
   }
 }

--- a/test/data-packument.ts
+++ b/test/data-packument.ts
@@ -58,7 +58,7 @@ class UnityPackumentVersionBuilder {
  * Builder class for {@link UnityPackument}.
  */
 class UnityPackumentBuilder {
-  readonly packument: UnityPackument;
+  packument: UnityPackument;
 
   constructor(name: DomainName) {
     this.packument = {
@@ -86,7 +86,13 @@ class UnityPackumentBuilder {
       version
     );
     if (build !== undefined) build(builder);
-    this.packument.versions[version] = builder.version;
+    this.packument = {
+      ...this.packument,
+      versions: {
+        ...this.packument.versions,
+        [version]: builder.version,
+      },
+    };
     this.packument["dist-tags"] = {
       latest: version,
     };


### PR DESCRIPTION
Refactor to make `UnityPackument` and related types readonly/immutable.