### PR TITLE
refactor: make options type readonly

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -39,9 +39,9 @@ export const login = async function (
   const env = await parseEnv(options, false);
   if (env === null) return 1;
   // query parameters
-  if (!options.username) options.username = await promptUsername();
-  if (!options.password) options.password = await promptPassword();
-  if (!options.email) options.email = await promptEmail();
+  const username = options.username ?? (await promptUsername());
+  const password = options.password ?? (await promptPassword());
+  const email = options.email ?? (await promptEmail());
 
   const loginRegistry =
     options._global.registry !== undefined
@@ -51,15 +51,10 @@ export const login = async function (
   let _auth: Base64 | null = null;
   if (options.basicAuth) {
     // basic auth
-    _auth = encodeBasicAuth(options.username, options.password);
+    _auth = encodeBasicAuth(username, password);
   } else {
     // npm login
-    const result = await npmLogin(
-      options.username,
-      options.password,
-      options.email,
-      loginRegistry
-    );
+    const result = await npmLogin(username, password, email, loginRegistry);
     if (result.code == 1) return result.code;
     if (!result.token) {
       log.error("auth", "can not find token from server response");
@@ -77,7 +72,7 @@ export const login = async function (
     _auth,
     options.alwaysAuth || false,
     options.basicAuth || false,
-    options.email,
+    email,
     loginRegistry,
     token
   );

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -10,7 +10,7 @@ import {
 import { parseEnv } from "./utils/env";
 import { encodeBasicAuth } from "./types/upm-config";
 import { Base64 } from "./types/base64";
-import { RegistryUrl } from "./types/registry-url";
+import { coerceRegistryUrl, RegistryUrl } from "./types/registry-url";
 import {
   promptEmail,
   promptPassword,
@@ -42,8 +42,11 @@ export const login = async function (
   if (!options.username) options.username = await promptUsername();
   if (!options.password) options.password = await promptPassword();
   if (!options.email) options.email = await promptEmail();
-  if (!options._global.registry)
-    options._global.registry = await promptRegistryUrl();
+
+  const loginRegistry =
+    options._global.registry !== undefined
+      ? coerceRegistryUrl(options._global.registry)
+      : await promptRegistryUrl();
   let token: string | null = null;
   let _auth: Base64 | null = null;
   if (options.basicAuth) {
@@ -55,7 +58,7 @@ export const login = async function (
       options.username,
       options.password,
       options.email,
-      options._global.registry as RegistryUrl
+      loginRegistry
     );
     if (result.code == 1) return result.code;
     if (!result.token) {
@@ -64,7 +67,7 @@ export const login = async function (
     }
     token = result.token;
     // write npm token
-    await writeNpmToken(options._global.registry as RegistryUrl, result.token);
+    await writeNpmToken(loginRegistry, result.token);
   }
 
   // write unity token
@@ -75,7 +78,7 @@ export const login = async function (
     options.alwaysAuth || false,
     options.basicAuth || false,
     options.email,
-    options._global.registry as RegistryUrl,
+    loginRegistry,
     token
   );
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -42,6 +42,8 @@ type GlobalOptions = Readonly<{
  */
 export type CmdOptions<
   TOptions extends Record<string, unknown> = Record<string, unknown>
-> = TOptions & {
-  _global: GlobalOptions;
-};
+> = Readonly<
+  TOptions & {
+    _global: GlobalOptions;
+  }
+>;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,7 +1,7 @@
 /**
  * Options which are shared between commands.
  */
-type GlobalOptions = {
+type GlobalOptions = Readonly<{
   /**
    * Override package registry to use.
    */
@@ -34,7 +34,7 @@ type GlobalOptions = {
    * Override working directory.
    */
   chdir?: string;
-};
+}>;
 
 /**
  * Command-options. Extends the given record with a _global property


### PR DESCRIPTION
Refactor to make `CmdOptions` and related types readonly/immutable.