### PR TITLE
refactor: clean up editor-version

### DIFF
--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -33,12 +33,16 @@ export type EditorVersion = {
    * A flag describing a specific locale build.
    */
   loc?: LocaleCode;
-  locValue?: number;
   /**
    * The specific build for a locale.
    */
   locBuild?: number;
 };
+
+function localeValue(loc: LocaleCode) {
+  if (loc === "c") return 1;
+  throw new Error("Unknown locale");
+}
 
 /**
  * Compares two editor versions for ordering.
@@ -56,7 +60,7 @@ export const compareEditorVersion = function (
     ver.patch || 0,
     ver.flagValue || 0,
     ver.build || 0,
-    ver.locValue || 0,
+    ver.loc !== undefined ? localeValue(ver.loc) : 0,
     ver.locBuild || 0,
   ];
   const arrA = editorVersionToArray(verA);
@@ -121,7 +125,6 @@ export const tryParseEditorVersion = function (
 
   if (groups.loc) {
     result.loc = groups.loc;
-    if (result.loc == "c") result.locValue = 1;
     if (groups.locBuild) result.locBuild = parseInt(groups.locBuild);
   }
   return result;

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -2,12 +2,7 @@ type LocaleCode = "c";
 
 type ReleaseFlag = "a" | "b" | "f" | "c";
 
-/**
- * Describes a version of a Unity editor. Mostly this follows calendar-versioning,
- * with some extra rules for chinese releases.
- * @see https://calver.org/
- */
-export type EditorVersion = {
+type RegularVersion = {
   /**
    * The major version. This is the release year.
    */
@@ -16,27 +11,43 @@ export type EditorVersion = {
    * The minor version. This is usually a number from 1 to 3.
    */
   minor: number;
+};
+
+type PatchVersion = RegularVersion & {
   /**
-   * An optional patch.
+   * A patch.
    */
-  patch?: number;
+  patch: number;
+};
+
+type ReleaseVersion = PatchVersion & {
   /**
    * A flag describing a specific release.
    */
-  flag?: ReleaseFlag;
+  flag: ReleaseFlag;
   /**
    * A specific build.
    */
-  build?: number;
+  build: number;
+};
+
+type LocalVersion = ReleaseVersion & {
   /**
    * A flag describing a specific locale build.
    */
-  loc?: LocaleCode;
+  loc: LocaleCode;
   /**
    * The specific build for a locale.
    */
-  locBuild?: number;
+  locBuild: number;
 };
+
+/**
+ * Describes a version of a Unity editor. Mostly this follows calendar-versioning,
+ * with some extra rules for chinese releases.
+ * @see https://calver.org/
+ */
+export type EditorVersion = RegularVersion | PatchVersion | LocalVersion;
 
 function localeValue(loc: LocaleCode) {
   if (loc === "c") return 1;
@@ -47,6 +58,18 @@ function releaseValue(flag: ReleaseFlag): number {
   if (flag === "b") return 1;
   if (flag === "f") return 2;
   return 0;
+}
+
+function isPatch(version: EditorVersion): version is PatchVersion {
+  return "patch" in version;
+}
+
+function isRelease(version: EditorVersion): version is ReleaseVersion {
+  return isPatch(version) && "flag" in version;
+}
+
+function isLocal(version: EditorVersion): version is LocalVersion {
+  return isRelease(version) && "loc" in version;
 }
 
 /**
@@ -62,11 +85,11 @@ export const compareEditorVersion = function (
   const editorVersionToArray = (ver: EditorVersion) => [
     ver.major,
     ver.minor,
-    ver.patch || 0,
-    ver.flag !== undefined ? releaseValue(ver.flag) : 0,
-    ver.build || 0,
-    ver.loc !== undefined ? localeValue(ver.loc) : 0,
-    ver.locBuild || 0,
+    isPatch(ver) ? ver.patch : 0,
+    ...(isRelease(ver) ? [releaseValue(ver.flag), ver.build] : [0, 0]),
+    ...(isLocal(ver)
+      ? [ver.build, localeValue(ver.loc), ver.locBuild]
+      : [0, 0, 0]),
   ];
   const arrA = editorVersionToArray(verA);
   const arrB = editorVersionToArray(verB);
@@ -115,19 +138,29 @@ export const tryParseEditorVersion = function (
   const match = regex.exec(version);
   if (!match) return null;
   const groups = <RegexMatchGroups>match.groups;
-  const result: EditorVersion = {
+
+  const regular: RegularVersion = {
     major: parseInt(groups.major),
     minor: parseInt(groups.minor),
   };
-  if (groups.patch) result.patch = parseInt(groups.patch);
-  if (groups.flag) {
-    result.flag = groups.flag;
-    if (groups.build) result.build = parseInt(groups.build);
-  }
 
-  if (groups.loc) {
-    result.loc = groups.loc;
-    if (groups.locBuild) result.locBuild = parseInt(groups.locBuild);
-  }
-  return result;
+  if (!groups.patch) return regular;
+  const patch: PatchVersion = {
+    ...regular,
+    patch: parseInt(groups.patch),
+  };
+
+  if (!(groups.flag && groups.build)) return patch;
+  const release: ReleaseVersion = {
+    ...patch,
+    flag: groups.flag,
+    build: parseInt(groups.build),
+  };
+
+  if (!(groups.loc && groups.locBuild)) return release;
+  return {
+    ...release,
+    loc: groups.loc,
+    locBuild: parseInt(groups.locBuild),
+  } satisfies LocalVersion;
 };

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -10,7 +10,7 @@ type RegularVersion = {
   /**
    * The minor version. This is usually a number from 1 to 3.
    */
-  minor: number;
+  minor: 1 | 2 | 3 | 4;
 };
 
 type PatchVersion = RegularVersion & {
@@ -134,14 +134,14 @@ export const tryParseEditorVersion = function (
     locBuild?: `${number}`;
   };
   const regex =
-    /^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+)((?<flag>a|b|f|c)(?<build>\d+)((?<loc>c)(?<locBuild>\d+))?)?)?/;
+    /^(?<major>\d+)\.(?<minor>[1234])(\.(?<patch>\d+)((?<flag>a|b|f|c)(?<build>\d+)((?<loc>c)(?<locBuild>\d+))?)?)?/;
   const match = regex.exec(version);
   if (!match) return null;
   const groups = <RegexMatchGroups>match.groups;
 
   const regular: RegularVersion = {
     major: parseInt(groups.major),
-    minor: parseInt(groups.minor),
+    minor: parseInt(groups.minor) as ReleaseVersion["minor"],
   };
 
   if (!groups.patch) return regular;

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -10,7 +10,7 @@ type RegularVersion = {
   /**
    * The minor version. This is usually a number from 1 to 3.
    */
-  minor: 1 | 2 | 3 | 4;
+  minor: number;
 };
 
 type PatchVersion = RegularVersion & {
@@ -141,7 +141,7 @@ export const tryParseEditorVersion = function (
 
   const regular: RegularVersion = {
     major: parseInt(groups.major),
-    minor: parseInt(groups.minor) as ReleaseVersion["minor"],
+    minor: parseInt(groups.minor),
   };
 
   if (!groups.patch) return regular;

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -1,3 +1,7 @@
+type LocaleCode = "c";
+
+type ReleaseFlag = "a" | "b" | "f" | "c";
+
 /**
  * Describes a version of a Unity editor. Mostly this follows calendar-versioning,
  * with some extra rules for chinese releases.
@@ -19,7 +23,7 @@ export type EditorVersion = {
   /**
    * A flag describing a specific release.
    */
-  flag?: "a" | "b" | "f" | "c";
+  flag?: ReleaseFlag;
   flagValue?: 0 | 1 | 2;
   /**
    * A specific build.
@@ -28,7 +32,7 @@ export type EditorVersion = {
   /**
    * A flag describing a specific locale build.
    */
-  loc?: "c";
+  loc?: LocaleCode;
   locValue?: number;
   /**
    * The specific build for a locale.

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -28,13 +28,14 @@ export type EditorVersion = {
   /**
    * A flag describing a specific locale build.
    */
-  loc?: string;
+  loc?: "c";
   locValue?: number;
   /**
    * The specific build for a locale.
    */
   locBuild?: number;
 };
+
 /**
  * Compares two editor versions for ordering.
  * @param verA The first version.
@@ -115,7 +116,7 @@ export const tryParseEditorVersion = function (
   }
 
   if (groups.loc) {
-    result.loc = groups.loc.toLowerCase();
+    result.loc = groups.loc;
     if (result.loc == "c") result.locValue = 1;
     if (groups.locBuild) result.locBuild = parseInt(groups.locBuild);
   }

--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -24,7 +24,6 @@ export type EditorVersion = {
    * A flag describing a specific release.
    */
   flag?: ReleaseFlag;
-  flagValue?: 0 | 1 | 2;
   /**
    * A specific build.
    */
@@ -44,6 +43,12 @@ function localeValue(loc: LocaleCode) {
   throw new Error("Unknown locale");
 }
 
+function releaseValue(flag: ReleaseFlag): number {
+  if (flag === "b") return 1;
+  if (flag === "f") return 2;
+  return 0;
+}
+
 /**
  * Compares two editor versions for ordering.
  * @param verA The first version.
@@ -58,7 +63,7 @@ export const compareEditorVersion = function (
     ver.major,
     ver.minor,
     ver.patch || 0,
-    ver.flagValue || 0,
+    ver.flag !== undefined ? releaseValue(ver.flag) : 0,
     ver.build || 0,
     ver.loc !== undefined ? localeValue(ver.loc) : 0,
     ver.locBuild || 0,
@@ -117,9 +122,6 @@ export const tryParseEditorVersion = function (
   if (groups.patch) result.patch = parseInt(groups.patch);
   if (groups.flag) {
     result.flag = groups.flag;
-    if (result.flag == "a") result.flagValue = 0;
-    if (result.flag == "b") result.flagValue = 1;
-    if (result.flag == "f") result.flagValue = 2;
     if (groups.build) result.build = parseInt(groups.build);
   }
 

--- a/test/test-editor-version.ts
+++ b/test/test-editor-version.ts
@@ -31,7 +31,6 @@ describe("editor-version", function () {
         minor: 2,
         patch: 1,
         flag: "a",
-        flagValue: 0,
         build: 5,
       });
     });
@@ -43,7 +42,6 @@ describe("editor-version", function () {
         minor: 2,
         patch: 1,
         flag: "b",
-        flagValue: 1,
         build: 5,
       });
     });
@@ -55,7 +53,6 @@ describe("editor-version", function () {
         minor: 2,
         patch: 1,
         flag: "f",
-        flagValue: 2,
         build: 5,
       });
     });
@@ -67,7 +64,6 @@ describe("editor-version", function () {
         minor: 2,
         patch: 1,
         flag: "f",
-        flagValue: 2,
         build: 1,
         loc: "c",
         locBuild: 5,

--- a/test/test-editor-version.ts
+++ b/test/test-editor-version.ts
@@ -70,7 +70,6 @@ describe("editor-version", function () {
         flagValue: 2,
         build: 1,
         loc: "c",
-        locValue: 1,
         locBuild: 5,
       });
     });


### PR DESCRIPTION
A few small refactors to improve the `EditorVersion` type.