### PR TITLE
refactor: add record utility functions

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -31,6 +31,7 @@ import {
   tryGetScopedRegistryByUrl,
 } from "./types/project-manifest";
 import { CmdOptions } from "./types/options";
+import { recordKeys } from "./utils/record-utils";
 
 export type AddOptions = CmdOptions<{
   test?: boolean;
@@ -85,7 +86,7 @@ export const add = async function (
         return { code: 1, dirty };
       }
       // verify version
-      const versions = Object.keys(packument.versions) as SemanticVersion[];
+      const versions = recordKeys(packument.versions);
       if (!version || version === "latest")
         version = tryGetLatestVersion(packument);
       if (versions.filter((x) => x === version).length <= 0) {

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -11,6 +11,7 @@ import {
   splitPackageReference,
 } from "./types/package-reference";
 import { CmdOptions } from "./types/options";
+import { recordKeys } from "./utils/record-utils";
 
 export type ViewOptions = CmdOptions;
 
@@ -48,7 +49,7 @@ export const view = async function (
 };
 
 const printInfo = function (packument: UnityPackument) {
-  const versionCount = Object.keys(packument.versions).length;
+  const versionCount = recordKeys(packument.versions).length;
   const ver = tryGetLatestVersion(packument);
   assert(ver !== undefined);
   const verInfo = packument.versions[ver]!;
@@ -90,10 +91,10 @@ const printInfo = function (packument: UnityPackument) {
       console.log(".integrity: " + chalk.yellow(dist.integrity));
   }
 
-  if (dependencies && Object.keys(dependencies).length > 0) {
+  if (dependencies && recordKeys(dependencies).length > 0) {
     console.log();
     console.log("dependencies");
-    (Object.keys(dependencies) as DomainName[])
+    recordKeys(dependencies)
       .sort()
       .forEach((n) => console.log(chalk.yellow(n) + ` ${dependencies[n]}`));
   }

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -14,7 +14,7 @@ import { DomainName, isInternalPackage } from "./types/domain-name";
 import { SemanticVersion } from "./types/semantic-version";
 import { packageReference } from "./types/package-reference";
 import { RegistryUrl } from "./types/registry-url";
-import { recordEntries } from "./utils/record-utils";
+import { recordEntries, recordKeys } from "./utils/record-utils";
 
 export type NpmClient = {
   rawClient: RegClient.Instance;
@@ -233,7 +233,7 @@ export const fetchPackageDependencies = async function (
           continue;
         }
         // verify version
-        const versions = Object.keys(packument.versions);
+        const versions = recordKeys(packument.versions);
         if (!entry.version || entry.version == "latest") {
           const latestVersion = tryGetLatestVersion(packument);
           assert(latestVersion !== undefined);

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -14,6 +14,7 @@ import { DomainName, isInternalPackage } from "./types/domain-name";
 import { SemanticVersion } from "./types/semantic-version";
 import { packageReference } from "./types/package-reference";
 import { RegistryUrl } from "./types/registry-url";
+import { recordEntries } from "./utils/record-utils";
 
 export type NpmClient = {
   rawClient: RegClient.Instance;
@@ -253,10 +254,8 @@ export const fetchPackageDependencies = async function (
         }
         // add dependencies to pending list
         if (depObj.self || deep) {
-          const deps: NameVersionPair[] = (
-            Object.entries(
-              packument.versions[entry.version]!["dependencies"] || {}
-            ) as [DomainName, SemanticVersion][]
+          const deps = recordEntries(
+            packument.versions[entry.version]!["dependencies"] || {}
           ).map((x): NameVersionPair => {
             return {
               name: x[0],

--- a/src/utils/record-utils.ts
+++ b/src/utils/record-utils.ts
@@ -7,3 +7,13 @@ export function recordEntries<TKey extends string | number | symbol, TValue>(
 ): [TKey, TValue][] {
   return Object.entries(record) as unknown as [TKey, TValue][];
 }
+
+/**
+ * Same as {@link Object.keys} but preserves key type.
+ * @param record The record to get keys for.
+ */
+export function recordKeys<TKey extends string | number | symbol>(
+  record: Record<TKey, unknown>
+): TKey[] {
+  return Object.keys(record) as unknown as TKey[];
+}

--- a/src/utils/record-utils.ts
+++ b/src/utils/record-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Same as {@link Object.entries} but preserves key type.
+ * @param record The record to get entries for.
+ */
+export function recordEntries<TKey extends string | number | symbol, TValue>(
+  record: Record<TKey, TValue>
+): [TKey, TValue][] {
+  return Object.entries(record) as unknown as [TKey, TValue][];
+}


### PR DESCRIPTION
Add eqivalents for `Object.entries` and `Object.keys` that preserve key types.