### PR TITLE
refactor: clean-up registry-client cache logic

### DIFF
--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -135,6 +135,13 @@ type CachedPackument = { packument: UnityPackument; upstream: boolean };
 
 type PackumentCache = Record<DomainName, CachedPackument>;
 
+function tryGetFromCache(
+  packageName: DomainName,
+  cache: PackumentCache
+): CachedPackument | null {
+  return cache[packageName] ?? null;
+}
+
 /**
  * Fetch package dependencies
  * @param registry The registry in which to search the dependencies
@@ -191,7 +198,10 @@ export const fetchPackageDependencies = async function (
       };
       if (!depObj.internal) {
         // try fetching package info from cache
-        const cachedPackument = cachedPackageInfoDict[entry.name] ?? null;
+        const cachedPackument = tryGetFromCache(
+          entry.name,
+          cachedPackageInfoDict
+        );
         let packument = cachedPackument?.packument ?? null;
         if (packument !== null) {
           depObj.upstream = cachedPackument!.upstream;

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -195,9 +195,8 @@ export const fetchPackageDependencies = async function (
           upstream: false,
         };
         let packument = getResult.packument;
-        const upstream = getResult.upstream;
         if (packument !== null) {
-          depObj.upstream = upstream;
+          depObj.upstream = getResult.upstream;
         }
         // try fetching package info from the default registry
         if (packument === null) {

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -181,7 +181,7 @@ export const fetchPackageDependencies = async function (
   // a list of dependency entry doesn't exist on the registry
   const depsInvalid = [];
   // cached dict
-  let cachedPackageInfoDict: PackumentCache = {};
+  let packageCache: PackumentCache = {};
   while (pendingList.length > 0) {
     // NOTE: Guaranteed defined because of while loop logic
     const entry = pendingList.shift() as NameVersionPair;
@@ -207,10 +207,7 @@ export const fetchPackageDependencies = async function (
       };
       if (!depObj.internal) {
         // try fetching package info from cache
-        const cachedPackument = tryGetFromCache(
-          entry.name,
-          cachedPackageInfoDict
-        );
+        const cachedPackument = tryGetFromCache(entry.name, packageCache);
         let packument = cachedPackument?.packument ?? null;
         if (packument !== null) {
           depObj.upstream = cachedPackument!.upstream;
@@ -221,11 +218,11 @@ export const fetchPackageDependencies = async function (
             (await fetchPackument(registry, entry.name, client)) ?? null;
           if (packument) {
             depObj.upstream = false;
-            cachedPackageInfoDict = addToCache(
+            packageCache = addToCache(
               entry.name,
               packument,
               false,
-              cachedPackageInfoDict
+              packageCache
             );
           }
         }
@@ -236,11 +233,11 @@ export const fetchPackageDependencies = async function (
             null;
           if (packument) {
             depObj.upstream = true;
-            cachedPackageInfoDict = addToCache(
+            packageCache = addToCache(
               entry.name,
               packument,
               true,
-              cachedPackageInfoDict
+              packageCache
             );
           }
         }

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -191,13 +191,10 @@ export const fetchPackageDependencies = async function (
       };
       if (!depObj.internal) {
         // try fetching package info from cache
-        const getResult = cachedPackageInfoDict[entry.name] ?? {
-          packument: null,
-          upstream: false,
-        };
-        let packument = getResult.packument;
+        const cachedPackument = cachedPackageInfoDict[entry.name] ?? null;
+        let packument = cachedPackument?.packument ?? null;
         if (packument !== null) {
-          depObj.upstream = getResult.upstream;
+          depObj.upstream = cachedPackument!.upstream;
         }
         // try fetching package info from the default registry
         if (packument === null) {

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -131,6 +131,10 @@ export const fetchPackument = async function (
   }
 };
 
+type CachedPackument = { packument: UnityPackument; upstream: boolean };
+
+type PackumentCache = Record<DomainName, CachedPackument>;
+
 /**
  * Fetch package dependencies
  * @param registry The registry in which to search the dependencies
@@ -161,10 +165,7 @@ export const fetchPackageDependencies = async function (
   // a list of dependency entry doesn't exist on the registry
   const depsInvalid = [];
   // cached dict
-  const cachedPackageInfoDict: Record<
-    DomainName,
-    { packument: UnityPackument; upstream: boolean }
-  > = {};
+  const cachedPackageInfoDict: PackumentCache = {};
   while (pendingList.length > 0) {
     // NOTE: Guaranteed defined because of while loop logic
     const entry = pendingList.shift() as NameVersionPair;


### PR DESCRIPTION
Extracted a few utility types and functions to clean up the registry-client cache logic.