### PR TITLE
refactor: type empty arrays

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -23,7 +23,11 @@ import {
   PackageReference,
   splitPackageReference,
 } from "./types/package-reference";
-import { addScope, scopedRegistry } from "./types/scoped-registry";
+import {
+  addScope,
+  ScopedRegistry,
+  scopedRegistry,
+} from "./types/scoped-registry";
 import {
   addDependency,
   addScopedRegistry,
@@ -72,7 +76,7 @@ export const add = async function (
     const manifest = loadProjectManifest(env.cwd);
     if (manifest === null) return { code: 1, dirty };
     // packages that added to scope registry
-    const pkgsInScope: DomainName[] = [];
+    const pkgsInScope = Array.of<DomainName>();
     if (version === undefined || !isPackageUrl(version)) {
       // verify name
       let packument = await fetchPackument(env.registry, name, client);
@@ -208,7 +212,7 @@ export const add = async function (
     if (!isUpstreamPackage) {
       // add to scopedRegistries
       if (!manifest.scopedRegistries) {
-        manifest.scopedRegistries = [];
+        manifest.scopedRegistries = Array.of<ScopedRegistry>();
         dirty = true;
       }
       let entry = tryGetScopedRegistryByUrl(manifest, env.registry.url);
@@ -233,7 +237,7 @@ export const add = async function (
   };
 
   // add
-  const results = [];
+  const results = Array.of<AddResult>();
   for (const pkg of pkgs) results.push(await addSingle(pkg));
   const result: AddResult = {
     code: results.filter((x) => x.code != 0).length > 0 ? 1 : 0,

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -54,7 +54,7 @@ export const remove = async function (
     const manifest = loadProjectManifest(env.cwd);
     if (manifest === null) return { code: 1, dirty };
     // not found array
-    const pkgsNotFound = [];
+    const pkgsNotFound = Array.of<PackageReference>();
     version = manifest.dependencies[name];
     if (version) {
       log.notice("manifest", `removed ${packageReference(name, version)}`);
@@ -79,7 +79,7 @@ export const remove = async function (
   };
 
   // remove
-  const results = [];
+  const results = Array.of<RemoveResult>();
   for (const pkg of pkgs) results.push(await removeSingle(pkg));
   const result: RemoveResult = {
     code: results.filter((x) => x.code != 0).length > 0 ? 1 : 0,

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -65,7 +65,7 @@ const searchOld = async function (
     const results = <OldSearchResult | undefined>(
       await npmFetch.json("/-/all", getNpmFetchOptions(registry))
     );
-    let packuments: SearchedPackument[] = [];
+    let packuments = Array.of<SearchedPackument>();
     if (results) {
       if (Array.isArray(results)) {
         // results is an array of objects

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -157,9 +157,9 @@ export const fetchPackageDependencies = async function (
   // a list of processed dependency {name, version}
   const processedList = Array.of<NameVersionPair>();
   // a list of dependency entry exists on the registry
-  const depsValid = [];
+  const depsValid = Array.of<Dependency>();
   // a list of dependency entry doesn't exist on the registry
-  const depsInvalid = [];
+  const depsInvalid = Array.of<Dependency>();
   // cached dict
   const cachedPackageInfoDict: Record<
     DomainName,


### PR DESCRIPTION
Type array variables which are initialized to empty arrays, so they don't default to `any[]`