### PR TITLE
refactor: make project-version io async

### DIFF
--- a/src/utils/project-version-io.ts
+++ b/src/utils/project-version-io.ts
@@ -7,12 +7,15 @@ import fse from "fs-extra";
  * @param projectDirPath The projects root folder.
  * @param version The editor-version to use.
  */
-export function createProjectVersionTxt(
+export async function createProjectVersionTxt(
   projectDirPath: string,
   version: string
 ) {
   const projectSettingsDir = path.join(projectDirPath, "ProjectSettings");
-  fse.mkdirpSync(projectSettingsDir);
+  await fse.mkdirp(projectSettingsDir);
   const data = `m_EditorVersion: ${version}`;
-  fse.writeFileSync(path.join(projectSettingsDir, "ProjectVersion.txt"), data);
+  await fse.writeFile(
+    path.join(projectSettingsDir, "ProjectVersion.txt"),
+    data
+  );
 }

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -108,7 +108,7 @@ export async function setupUnityProject(
 
     // Editor-version
     const version = config.version ?? defaultVersion;
-    createProjectVersionTxt(projectPath, version);
+    await createProjectVersionTxt(projectPath, version);
 
     // Project manifest
     if (config.manifest !== false) {


### PR DESCRIPTION
Refactor the `createProjectVersionTxt` function async. Long running functions should be made async to avoid blocking.