### PR TITLE
Fix make not create scopedRegistry when scopes are empty

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -210,7 +210,7 @@ export const add = async function (
       // Log the existed package
       log.notice("manifest", `existed ${packageReference(name, version)}`);
     }
-    if (!isUpstreamPackage) {
+    if (!isUpstreamPackage && pkgsInScope.length > 0) {
       // add to scopedRegistries
       if (!manifest.scopedRegistries) {
         manifest.scopedRegistries = Array.of<ScopedRegistry>();

--- a/test/project-manifest-assertions.ts
+++ b/test/project-manifest-assertions.ts
@@ -35,3 +35,9 @@ export function shouldHaveRegistryWithScopes(
     )
     .should.be.true("At least one scope was missing");
 }
+
+export function shouldNotHaveRegistries(
+  manifest: UnityProjectManifest
+) {
+  should(manifest.scopedRegistries).be.undefined();
+}

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -9,7 +9,7 @@ import {
   stopMockRegistry,
 } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
-import { shouldHaveDependency } from "./project-manifest-assertions";
+import { shouldHaveDependency, shouldNotHaveRegistries } from "./project-manifest-assertions";
 import { buildPackument } from "./data-packument";
 import { buildProjectManifest } from "./data-project-manifest";
 import { domainName } from "../src/types/domain-name";
@@ -261,6 +261,9 @@ describe("cmd-add.ts", function () {
       retCode.should.equal(0);
       await mockProject.tryAssertManifest((manifest) =>
         shouldHaveDependency(manifest, packageA, fileUrl)
+      );
+      await mockProject.tryAssertManifest((manifest) =>
+        shouldNotHaveRegistries(manifest)
       );
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();

--- a/test/test-cmd-add.ts
+++ b/test/test-cmd-add.ts
@@ -242,6 +242,9 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         shouldHaveDependency(manifest, packageA, gitUrl)
       );
+      await mockProject.tryAssertManifest((manifest) =>
+        shouldNotHaveRegistries(manifest)
+      );
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
     });
@@ -251,6 +254,9 @@ describe("cmd-add.ts", function () {
       retCode.should.equal(0);
       await mockProject.tryAssertManifest((manifest) =>
         shouldHaveDependency(manifest, packageA, gitUrl)
+      );
+      await mockProject.tryAssertManifest((manifest) =>
+        shouldNotHaveRegistries(manifest)
       );
       mockConsole.hasLineIncluding("out", "added").should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();


### PR DESCRIPTION
### Changes
Not create scopedRegistry when scopes are empty.
Possible when specified `@git`, `@htts`, and `@file` with `add` subcommand.

fixed #134