### PR TITLE
refactor: normalize equality operator

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -171,7 +171,7 @@ export const add = async function (
           .forEach((name) => pkgsInScope.push(name));
         // print suggestion for depsInvalid
         depsInvalid.forEach((depObj) => {
-          if (depObj.reason == "package404" || depObj.reason == "version404") {
+          if (depObj.reason === "package404" || depObj.reason === "version404") {
             const resolvedVersion = manifest.dependencies[depObj.name];
             depObj.resolved = Boolean(resolvedVersion);
             if (!depObj.resolved)
@@ -202,7 +202,7 @@ export const add = async function (
       // Log the added package
       log.notice("manifest", `added ${packageReference(name, version)}`);
       dirty = true;
-    } else if (oldVersion != version) {
+    } else if (oldVersion !== version) {
       // Log the modified package version
       log.notice("manifest", `modified ${name} ${oldVersion} => ${version}`);
       dirty = true;
@@ -242,7 +242,7 @@ export const add = async function (
   const results = Array.of<AddResult>();
   for (const pkg of pkgs) results.push(await addSingle(pkg));
   const result: AddResult = {
-    code: results.filter((x) => x.code != 0).length > 0 ? 1 : 0,
+    code: results.filter((x) => x.code !== 0).length > 0 ? 1 : 0,
     dirty: results.filter((x) => x.dirty).length > 0,
   };
   // print manifest notice

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -171,7 +171,10 @@ export const add = async function (
           .forEach((name) => pkgsInScope.push(name));
         // print suggestion for depsInvalid
         depsInvalid.forEach((depObj) => {
-          if (depObj.reason === "package404" || depObj.reason === "version404") {
+          if (
+            depObj.reason === "package404" ||
+            depObj.reason === "version404"
+          ) {
             const resolvedVersion = manifest.dependencies[depObj.name];
             depObj.resolved = Boolean(resolvedVersion);
             if (!depObj.resolved)

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -55,7 +55,7 @@ export const login = async function (
   } else {
     // npm login
     const result = await npmLogin(username, password, email, loginRegistry);
-    if (result.code == 1) return result.code;
+    if (result.code === 1) return result.code;
     if (!result.token) {
       log.error("auth", "can not find token from server response");
       return 1;
@@ -112,7 +112,7 @@ const npmLogin = async function (
   } catch (err) {
     assertIsNpmClientError(err);
 
-    if (err.response.statusCode == 401) {
+    if (err.response.statusCode === 401) {
       log.warn("401", "Incorrect username or password");
       return { code: 1 };
     } else {

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -83,7 +83,7 @@ export const remove = async function (
   const results = Array.of<RemoveResult>();
   for (const pkg of pkgs) results.push(await removeSingle(pkg));
   const result: RemoveResult = {
-    code: results.filter((x) => x.code != 0).length > 0 ? 1 : 0,
+    code: results.filter((x) => x.code !== 0).length > 0 ? 1 : 0,
     dirty: results.filter((x) => x.dirty).length > 0,
   };
   // print manifest notice

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import npmlog from "npmlog";
 
-if (process.env.NODE_ENV == "test") {
+if (process.env.NODE_ENV === "test") {
   npmlog.stream = process.stdout;
   npmlog.disableColor();
 }

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -200,7 +200,7 @@ export const fetchPackageDependencies = async function (
         version: entry.version as SemanticVersion,
         internal: isInternalPackage(entry.name),
         upstream: false,
-        self: entry.name == name,
+        self: entry.name === name,
         reason: null,
       };
       if (!depObj.internal) {
@@ -248,13 +248,13 @@ export const fetchPackageDependencies = async function (
         }
         // verify version
         const versions = recordKeys(packument.versions);
-        if (!entry.version || entry.version == "latest") {
+        if (!entry.version || entry.version === "latest") {
           const latestVersion = tryGetLatestVersion(packument);
           assert(latestVersion !== undefined);
           depObj.version = entry.version = latestVersion;
         }
         // handle version not exist
-        if (!versions.find((x) => x == entry.version)) {
+        if (!versions.find((x) => x === entry.version)) {
           log.warn(
             "404",
             `package ${packageReference(

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -71,5 +71,5 @@ export function removeScope(
 ): boolean {
   const prevCount = registry.scopes.length;
   registry.scopes = registry.scopes.filter((it) => it !== scope);
-  return registry.scopes.length != prevCount;
+  return registry.scopes.length !== prevCount;
 }

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -21,7 +21,7 @@ export const loadProjectManifest = async function (
     return JSON.parse(text);
   } catch (err) {
     assertIsError(err);
-    if (err.code == "ENOENT")
+    if (err.code === "ENOENT")
       log.error("manifest", `manifest at ${manifestPath} does not exist`);
     else {
       log.error("manifest", `failed to parse manifest at ${manifestPath}`);


### PR DESCRIPTION
Use `===` everywhere to avoid undwanted type coersion.