### PR TITLE
refactor: extract cache

### DIFF
--- a/src/packument-cache.ts
+++ b/src/packument-cache.ts
@@ -1,10 +1,30 @@
 import { DomainName } from "./types/domain-name";
 import { UnityPackument } from "./types/packument";
 
-type CachedPackument = { packument: UnityPackument; upstream: boolean };
+/**
+ * Represents a cached packument.
+ */
+type CachedPackument = {
+  /**
+   * The packument.
+   */
+  packument: UnityPackument;
+  /**
+   * Whether it was originally resolved from the upstream registry.
+   */
+  upstream: boolean;
+};
 
+/**
+ * A cache that contains packuments that were already resolved.
+ */
 export type PackumentCache = Record<DomainName, CachedPackument>;
 
+/**
+ * Attempts to get a cached packument from a cache.
+ * @param packageName The name of the packument.
+ * @param cache The cache.
+ */
 export function tryGetFromCache(
   packageName: DomainName,
   cache: PackumentCache
@@ -12,6 +32,14 @@ export function tryGetFromCache(
   return cache[packageName] ?? null;
 }
 
+/**
+ * Caches a packument.
+ * @param packageName The packuments name.
+ * @param packument The packument.
+ * @param upstream Whether the packument was resolved from the upstream registry.
+ * @param cache The current state of the cache.
+ * @returns The new state of the cache.
+ */
 export function addToCache(
   packageName: DomainName,
   packument: UnityPackument,

--- a/src/packument-cache.ts
+++ b/src/packument-cache.ts
@@ -27,27 +27,27 @@ export const emptyPackumentCache: PackumentCache = {};
 
 /**
  * Attempts to get a cached packument from a cache.
- * @param packageName The name of the packument.
  * @param cache The cache.
+ * @param packageName The name of the packument.
  */
 export function tryGetFromCache(
-  packageName: DomainName,
-  cache: PackumentCache
+  cache: PackumentCache,
+  packageName: DomainName
 ): CachedPackument | null {
   return cache[packageName] ?? null;
 }
 
 /**
  * Caches a packument.
+ * @param cache The current state of the cache.
  * @param packument The packument.
  * @param upstream Whether the packument was resolved from the upstream registry.
- * @param cache The current state of the cache.
  * @returns The new state of the cache.
  */
 export function addToCache(
+  cache: PackumentCache,
   packument: UnityPackument,
-  upstream: boolean,
-  cache: PackumentCache
+  upstream: boolean
 ): PackumentCache {
   return { ...cache, [packument.name]: { packument, upstream } };
 }

--- a/src/packument-cache.ts
+++ b/src/packument-cache.ts
@@ -34,17 +34,15 @@ export function tryGetFromCache(
 
 /**
  * Caches a packument.
- * @param packageName The packuments name.
  * @param packument The packument.
  * @param upstream Whether the packument was resolved from the upstream registry.
  * @param cache The current state of the cache.
  * @returns The new state of the cache.
  */
 export function addToCache(
-  packageName: DomainName,
   packument: UnityPackument,
   upstream: boolean,
   cache: PackumentCache
 ): PackumentCache {
-  return { ...cache, [packageName]: { packument, upstream } };
+  return { ...cache, [packument.name]: { packument, upstream } };
 }

--- a/src/packument-cache.ts
+++ b/src/packument-cache.ts
@@ -21,6 +21,11 @@ type CachedPackument = {
 export type PackumentCache = Record<DomainName, CachedPackument>;
 
 /**
+ * An empty packument cache.
+ */
+export const emptyPackumentCache: PackumentCache = {};
+
+/**
  * Attempts to get a cached packument from a cache.
  * @param packageName The name of the packument.
  * @param cache The cache.

--- a/src/packument-cache.ts
+++ b/src/packument-cache.ts
@@ -1,0 +1,22 @@
+import { DomainName } from "./types/domain-name";
+import { UnityPackument } from "./types/packument";
+
+type CachedPackument = { packument: UnityPackument; upstream: boolean };
+
+export type PackumentCache = Record<DomainName, CachedPackument>;
+
+export function tryGetFromCache(
+  packageName: DomainName,
+  cache: PackumentCache
+): CachedPackument | null {
+  return cache[packageName] ?? null;
+}
+
+export function addToCache(
+  packageName: DomainName,
+  packument: UnityPackument,
+  upstream: boolean,
+  cache: PackumentCache
+): PackumentCache {
+  return { ...cache, [packageName]: { packument, upstream } };
+}

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -197,12 +197,7 @@ export const fetchPackageDependencies = async function (
             (await fetchPackument(registry, entry.name, client)) ?? null;
           if (packument) {
             depObj.upstream = false;
-            packageCache = addToCache(
-              entry.name,
-              packument,
-              false,
-              packageCache
-            );
+            packageCache = addToCache(packument, false, packageCache);
           }
         }
         // try fetching package info from the upstream registry
@@ -212,12 +207,7 @@ export const fetchPackageDependencies = async function (
             null;
           if (packument) {
             depObj.upstream = true;
-            packageCache = addToCache(
-              entry.name,
-              packument,
-              true,
-              packageCache
-            );
+            packageCache = addToCache(packument, true, packageCache);
           }
         }
         // handle package not exist

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -15,7 +15,12 @@ import { SemanticVersion } from "./types/semantic-version";
 import { packageReference } from "./types/package-reference";
 import { RegistryUrl } from "./types/registry-url";
 import { recordEntries, recordKeys } from "./utils/record-utils";
-import { addToCache, PackumentCache, tryGetFromCache } from "./packument-cache";
+import {
+  addToCache,
+  emptyPackumentCache,
+  PackumentCache,
+  tryGetFromCache,
+} from "./packument-cache";
 
 export type NpmClient = {
   /**
@@ -160,7 +165,7 @@ export const fetchPackageDependencies = async function (
   // a list of dependency entry doesn't exist on the registry
   const depsInvalid = Array.of<Dependency>();
   // cached dict
-  let packageCache: PackumentCache = {};
+  let packageCache = emptyPackumentCache;
   while (pendingList.length > 0) {
     // NOTE: Guaranteed defined because of while loop logic
     const entry = pendingList.shift() as NameVersionPair;

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -191,7 +191,7 @@ export const fetchPackageDependencies = async function (
       };
       if (!depObj.internal) {
         // try fetching package info from cache
-        const cachedPackument = tryGetFromCache(entry.name, packumentCache);
+        const cachedPackument = tryGetFromCache(packumentCache, entry.name);
         let packument = cachedPackument?.packument ?? null;
         if (packument !== null) {
           depObj.upstream = cachedPackument!.upstream;
@@ -202,7 +202,7 @@ export const fetchPackageDependencies = async function (
             (await fetchPackument(registry, entry.name, client)) ?? null;
           if (packument) {
             depObj.upstream = false;
-            packumentCache = addToCache(packument, false, packumentCache);
+            packumentCache = addToCache(packumentCache, packument, false);
           }
         }
         // try fetching package info from the upstream registry
@@ -212,7 +212,7 @@ export const fetchPackageDependencies = async function (
             null;
           if (packument) {
             depObj.upstream = true;
-            packumentCache = addToCache(packument, true, packumentCache);
+            packumentCache = addToCache(packumentCache, packument, true);
           }
         }
         // handle package not exist

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -165,7 +165,7 @@ export const fetchPackageDependencies = async function (
   // a list of dependency entry doesn't exist on the registry
   const depsInvalid = Array.of<Dependency>();
   // cached dict
-  let packageCache = emptyPackumentCache;
+  let packumentCache = emptyPackumentCache;
   while (pendingList.length > 0) {
     // NOTE: Guaranteed defined because of while loop logic
     const entry = pendingList.shift() as NameVersionPair;
@@ -191,7 +191,7 @@ export const fetchPackageDependencies = async function (
       };
       if (!depObj.internal) {
         // try fetching package info from cache
-        const cachedPackument = tryGetFromCache(entry.name, packageCache);
+        const cachedPackument = tryGetFromCache(entry.name, packumentCache);
         let packument = cachedPackument?.packument ?? null;
         if (packument !== null) {
           depObj.upstream = cachedPackument!.upstream;
@@ -202,7 +202,7 @@ export const fetchPackageDependencies = async function (
             (await fetchPackument(registry, entry.name, client)) ?? null;
           if (packument) {
             depObj.upstream = false;
-            packageCache = addToCache(packument, false, packageCache);
+            packumentCache = addToCache(packument, false, packumentCache);
           }
         }
         // try fetching package info from the upstream registry
@@ -212,7 +212,7 @@ export const fetchPackageDependencies = async function (
             null;
           if (packument) {
             depObj.upstream = true;
-            packageCache = addToCache(packument, true, packageCache);
+            packumentCache = addToCache(packument, true, packumentCache);
           }
         }
         // handle package not exist

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -15,6 +15,7 @@ import { SemanticVersion } from "./types/semantic-version";
 import { packageReference } from "./types/package-reference";
 import { RegistryUrl } from "./types/registry-url";
 import { recordEntries, recordKeys } from "./utils/record-utils";
+import { addToCache, PackumentCache, tryGetFromCache } from "./packument-cache";
 
 export type NpmClient = {
   /**
@@ -128,26 +129,6 @@ export const fetchPackument = async function (
     /* empty */
   }
 };
-
-type CachedPackument = { packument: UnityPackument; upstream: boolean };
-
-type PackumentCache = Record<DomainName, CachedPackument>;
-
-function tryGetFromCache(
-  packageName: DomainName,
-  cache: PackumentCache
-): CachedPackument | null {
-  return cache[packageName] ?? null;
-}
-
-function addToCache(
-  packageName: DomainName,
-  packument: UnityPackument,
-  upstream: boolean,
-  cache: PackumentCache
-): PackumentCache {
-  return { ...cache, [packageName]: { packument, upstream } };
-}
 
 /**
  * Fetch package dependencies.


### PR DESCRIPTION
Extract the packument caching logic into its own module in preparation for also using it in the `cmd-add`.