### PR TITLE
refactor: split dependency

### DIFF
--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -1,9 +1,9 @@
 import log from "./logger";
 import { parseEnv } from "./utils/env";
 import {
-  Dependency,
   fetchPackageDependencies,
   getNpmClient,
+  InvalidDependency,
 } from "./registry-client";
 import { isPackageUrl } from "./types/package-url";
 import {
@@ -19,7 +19,7 @@ export type DepsOptions = CmdOptions<{
   deep?: boolean;
 }>;
 
-function errorPrefixForError(errorReason: Dependency["reason"]): string {
+function errorPrefixForError(errorReason: InvalidDependency["reason"]): string {
   if (errorReason === "package404") return "missing dependency";
   else if (errorReason === "version404") return "missing dependency version";
   return "unknown";

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -74,7 +74,7 @@ export interface ValidDependency extends DependencyBase {
   /**
    * The requested version.
    */
-  readonly version: SemanticVersion | "latest" | undefined;
+  readonly version: SemanticVersion;
 }
 
 /**
@@ -311,7 +311,9 @@ export const fetchPackageDependencies = async function (
       }
       depsValid.push({
         name: entry.name,
-        version: entry.version,
+        // We can safely cast here, because code-logic ensures that we only
+        // get here with valid semantic versions.
+        version: entry.version as SemanticVersion,
         internal: isInternal,
         upstream: isUpstream,
         self: isSelf,

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -48,25 +48,68 @@ export class NpmClientError extends Error {
 }
 
 export type DependencyBase = {
+  /**
+   * The package name of the dependency.
+   */
   readonly name: DomainName;
+  /**
+   * Whether this dependency is the root package for which dependencies were
+   * requested.
+   */
   readonly self: boolean;
 };
 
+/**
+ * A dependency that was resolved successfully.
+ */
 export interface ValidDependency extends DependencyBase {
+  /**
+   * Whether this dependency was found on the upstream registry.
+   */
   readonly upstream: boolean;
+  /**
+   * Whether this dependency is an internal package.
+   */
   readonly internal: boolean;
+  /**
+   * The requested version.
+   */
   readonly version: SemanticVersion | "latest" | undefined;
 }
 
+/**
+ * A dependency that could not be resolved because a package was not
+ * found in any registry.
+ */
 interface PackageNotFoundDependency extends DependencyBase {
+  /**
+   * The requested version.
+   */
   readonly version: SemanticVersion | "latest" | undefined;
+  /**
+   * Indicates the reason why the dependency could not be resolved.
+   */
   readonly reason: "package404";
 }
+
+/**
+ * A dependency that could not be resolved because a specific version was
+ * requested but not found.
+ */
 interface VersionNotFoundDependency extends DependencyBase {
+  /**
+   * The requested version.
+   */
   readonly version: SemanticVersion;
+  /**
+   * Indicates the reason why the dependency could not be resolved.
+   */
   readonly reason: "version404";
 }
 
+/**
+ * A dependency that could not be resolved.
+ */
 export type InvalidDependency =
   | PackageNotFoundDependency
   | VersionNotFoundDependency;


### PR DESCRIPTION
This refactor splits the `Dependency` type into multiple sub-types to ensure no properties are shared needlessly. This is in preparation for more changes in packument and dependency resolution.