### PR TITLE
refactor: move npm functionality into npm-client

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -92,7 +92,7 @@ const npmLogin = async function (
 ): Promise<LoginResult> {
   const client = getNpmClient();
   try {
-    const data = await client.adduser(registry, {
+    const data = await client.addUser(registry, {
       auth: {
         username,
         password,

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { assertIsNpmClientError, getNpmClient } from "./registry-client";
+import { getNpmClient } from "./registry-client";
 import log from "./logger";
 import { storeUpmAuth, getUpmConfigDir } from "./utils/upm-config-io";
 import { parseEnv } from "./utils/env";
@@ -91,30 +91,19 @@ const npmLogin = async function (
   registry: RegistryUrl
 ): Promise<LoginResult> {
   const client = getNpmClient();
-  try {
-    const data = await client.addUser(registry, {
-      auth: {
-        username,
-        password,
-        email,
-      },
-    });
-    if (data.ok) {
-      log.notice("auth", `you are authenticated as '${username}'`);
-      const token = data.token;
-      return { code: 0, token };
-    }
-    return { code: 1 };
-  } catch (err) {
-    assertIsNpmClientError(err);
+  const result = await client.addUser(registry, username, password, email);
 
-    if (err.response.statusCode === 401) {
-      log.warn("401", "Incorrect username or password");
-      return { code: 1 };
-    } else {
-      log.error(err.response.statusCode.toString(), err.message);
-      return { code: 1 };
-    }
+  if (result.isSuccess) {
+    log.notice("auth", `you are authenticated as '${username}'`);
+    return { code: 0, token: result.token };
+  }
+
+  if (result.status === 401) {
+    log.warn("401", "Incorrect username or password");
+    return { code: 1 };
+  } else {
+    log.error(result.status.toString(), result.message);
+    return { code: 1 };
   }
 };
 

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -1,93 +1,53 @@
-import npmSearch, { Options } from "libnpmsearch";
-import npmFetch from "npm-registry-fetch";
 import log from "./logger";
-import { is404Error, isHttpError } from "./utils/error-type-guards";
 import * as os from "os";
-import { UnityPackument } from "./types/packument";
 import { parseEnv } from "./utils/env";
-import { DomainName } from "./types/domain-name";
-import { SemanticVersion } from "./types/semantic-version";
 import { CmdOptions } from "./types/options";
-import { Registry } from "./registry-client";
+import {
+  getNpmClient,
+  NpmClient,
+  Registry,
+  SearchedPackument,
+} from "./registry-client";
 import { formatAsTable } from "./output-formatting";
 
 type SearchResultCode = 0 | 1;
 
 export type SearchOptions = CmdOptions;
 
-type SearchedPackument = Omit<UnityPackument, "versions"> & {
-  versions: Record<SemanticVersion, "latest">;
-};
-
-type OldSearchResult =
-  | SearchedPackument[]
-  | Record<DomainName, SearchedPackument>;
-
-/**
- * Get npm fetch options.
- * @param registry The registry for which to get the options.
- */
-const getNpmFetchOptions = function (registry: Registry): Options {
-  const opts: Options = {
-    log,
-    registry: registry.url,
-  };
-  const auth = registry.auth;
-  if (auth !== null) Object.assign(opts, auth);
-  return opts;
-};
-
 const searchEndpoint = async function (
+  npmClient: NpmClient,
   registry: Registry,
   keyword: string
-): Promise<SearchedPackument[] | undefined> {
-  try {
-    // NOTE: The results of the search will be Packument objects so we can change the type
-    const results = <SearchedPackument[]>(
-      await npmSearch(keyword, getNpmFetchOptions(registry))
-    );
-    log.verbose("npmsearch", results.join(os.EOL));
-    return results;
-  } catch (err) {
-    if (isHttpError(err) && !is404Error(err)) {
-      log.error("", err.message);
-    }
-    log.warn("", "fast search endpoint is not available, using old search.");
-  }
+): Promise<SearchedPackument[] | null> {
+  const results = await npmClient.trySearch(registry, keyword);
+
+  if (results !== null) log.verbose("npmsearch", results.join(os.EOL));
+
+  return results;
 };
 
 const searchOld = async function (
+  npmClient: NpmClient,
   registry: Registry,
   keyword: string
-): Promise<SearchedPackument[] | undefined> {
-  // all endpoint
-  try {
-    const results = <OldSearchResult | undefined>(
-      await npmFetch.json("/-/all", getNpmFetchOptions(registry))
-    );
-    let packuments = Array.of<SearchedPackument>();
-    if (results) {
-      if (Array.isArray(results)) {
-        // results is an array of objects
-        packuments = results;
-      } else {
-        // results is an object
-        if ("_updated" in results) delete results["_updated"];
-        packuments = Object.values(results);
-      }
-    }
-    log.verbose("endpoint.all", packuments.join(os.EOL));
-    // filter keyword
-    const klc = keyword.toLowerCase();
-    return packuments.filter((packument) =>
-      packument.name.toLowerCase().includes(klc)
-    );
-  } catch (err) {
-    if (isHttpError(err) && !is404Error(err)) {
-      log.error("", err.message);
-    }
-    log.warn("", "/-/all endpoint is not available");
-  }
+): Promise<SearchedPackument[] | null> {
+  const results = await npmClient.getAll(registry);
+  let packuments = Array.of<SearchedPackument>();
+
+  if (results === null) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { _updated, ...packumentEntries } = results;
+  packuments = Object.values(packumentEntries);
+
+  log.verbose("endpoint.all", packuments.join(os.EOL));
+
+  // filter keyword
+  const klc = keyword.toLowerCase();
+
+  return packuments.filter((packument) =>
+    packument.name.toLowerCase().includes(klc)
+  );
 };
 
 export async function search(
@@ -98,15 +58,24 @@ export async function search(
   const env = await parseEnv(options, false);
   if (env === null) return 1;
 
+  const npmClient = getNpmClient();
+
   // search endpoint
-  let results = await searchEndpoint(env.registry, keyword);
+  let results = await searchEndpoint(npmClient, env.registry, keyword);
+
   // search old search
-  if (results === undefined) {
-    results = await searchOld(env.registry, keyword);
+  if (results === null) {
+    log.warn("", "fast search endpoint is not available, using old search.");
+    results = await searchOld(npmClient, env.registry, keyword);
   }
-  // search upstream
-  if (results !== undefined && results.length > 0) {
-    console.log(formatAsTable(results));
-  } else log.notice("", `No matches found for "${keyword}"`);
+
+  if (results === null) log.warn("", "/-/all endpoint is not available");
+
+  if (results === null || results.length === 0) {
+    log.notice("", `No matches found for "${keyword}"`);
+    return 0;
+  }
+
+  console.log(formatAsTable(results));
   return 0;
 }

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -31,7 +31,7 @@ const searchOld = async function (
   registry: Registry,
   keyword: string
 ): Promise<SearchedPackument[] | null> {
-  const results = await npmClient.getAll(registry);
+  const results = await npmClient.tryGetAll(registry);
   let packuments = Array.of<SearchedPackument>();
 
   if (results === null) return null;

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -3,7 +3,7 @@ import log from "./logger";
 import assert from "assert";
 import { tryGetLatestVersion, UnityPackument } from "./types/packument";
 import { parseEnv } from "./utils/env";
-import { fetchPackument, getNpmClient } from "./registry-client";
+import { getNpmClient } from "./registry-client";
 import {
   packageReference,
   PackageReference,
@@ -35,10 +35,10 @@ export const view = async function (
     return 1;
   }
   // verify name
-  let packument = await fetchPackument(env.registry, name, client);
-  if (!packument && env.upstream)
-    packument = await fetchPackument(env.upstreamRegistry, name, client);
-  if (!packument) {
+  let packument = await client.get(name, env.registry);
+  if (packument === null && env.upstream)
+    packument = await client.get(name, env.upstreamRegistry);
+  if (packument === null) {
     log.error("404", `package not found: ${name}`);
     return 1;
   }

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -35,9 +35,9 @@ export const view = async function (
     return 1;
   }
   // verify name
-  let packument = await client.get(name, env.registry);
+  let packument = await client.tryFetchPackument(name, env.registry);
   if (packument === null && env.upstream)
-    packument = await client.get(name, env.upstreamRegistry);
+    packument = await client.tryFetchPackument(name, env.upstreamRegistry);
   if (packument === null) {
     log.error("404", `package not found: ${name}`);
     return 1;

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -35,9 +35,9 @@ export const view = async function (
     return 1;
   }
   // verify name
-  let packument = await client.tryFetchPackument(name, env.registry);
+  let packument = await client.tryFetchPackument(env.registry, name);
   if (packument === null && env.upstream)
-    packument = await client.tryFetchPackument(name, env.upstreamRegistry);
+    packument = await client.tryFetchPackument(env.upstreamRegistry, name);
   if (packument === null) {
     log.error("404", `package not found: ${name}`);
     return 1;

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -144,7 +144,7 @@ export async function tryResolve(
   requestedVersion: ResolvableVersion,
   source: Registry
 ): Promise<ResolveResult> {
-  const packument = await npmClient.get(packageName, source);
+  const packument = await npmClient.tryFetchPackument(packageName, source);
   if (packument === null)
     return { isSuccess: false, issue: "PackumentNotFound" };
 

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -144,7 +144,7 @@ export async function tryResolve(
   requestedVersion: ResolvableVersion,
   source: Registry
 ): Promise<ResolveResult> {
-  const packument = await npmClient.tryFetchPackument(packageName, source);
+  const packument = await npmClient.tryFetchPackument(source, packageName);
   if (packument === null)
     return { isSuccess: false, issue: "PackumentNotFound" };
 

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -1,5 +1,5 @@
 import { VersionReference } from "./types/package-reference";
-import { fetchPackument, NpmClient, Registry } from "./registry-client";
+import { NpmClient, Registry } from "./registry-client";
 import { DomainName } from "./types/domain-name";
 import { SemanticVersion } from "./types/semantic-version";
 import { UnityPackument, UnityPackumentVersion } from "./types/packument";
@@ -144,8 +144,8 @@ export async function tryResolve(
   requestedVersion: ResolvableVersion,
   source: Registry
 ): Promise<ResolveResult> {
-  const packument = await fetchPackument(source, packageName, npmClient);
-  if (packument === undefined)
+  const packument = await npmClient.get(packageName, source);
+  if (packument === null)
     return { isSuccess: false, issue: "PackumentNotFound" };
 
   return tryResolveFromPackument(packument, requestedVersion, source.url);

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -32,7 +32,7 @@ export type NpmClient = {
   /**
    * @throws {NpmClientError}
    */
-  adduser(uri: string, options: AddUserParams): Promise<AddUserResponse>;
+  addUser(uri: string, options: AddUserParams): Promise<AddUserResponse>;
 };
 
 export class NpmClientError extends Error {
@@ -141,7 +141,7 @@ export const getNpmClient = (): NpmClient => {
   return {
     // Promisified methods
     get: normalizeClientFunction(client, client.get),
-    adduser: normalizeClientFunction(client, client.adduser),
+    addUser: normalizeClientFunction(client, client.adduser),
   };
 };
 

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -32,7 +32,10 @@ export interface NpmClient {
    * @param name The name of the packument to get.
    * @param registry The registry to get the packument from.
    */
-  get(name: DomainName, registry: Registry): Promise<UnityPackument | null>;
+  tryFetchPackument(
+    name: DomainName,
+    registry: Registry
+  ): Promise<UnityPackument | null>;
 
   /**
    * Attempts to add a user to a registry.
@@ -147,7 +150,7 @@ export const getNpmClient = (): NpmClient => {
   // create client
   const registryClient = new RegClient({ log });
   return {
-    get(name, registry) {
+    tryFetchPackument(name, registry) {
       const url = `${registry.url}/${name}`;
       return new Promise((resolve) => {
         return registryClient.get(

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -24,13 +24,22 @@ import {
   tryResolveFromCache,
 } from "./packument-resolving";
 
+/**
+ * Abstraction over a regular npm client which is specialized for UPM purposes.
+ */
 export interface NpmClient {
   /**
+   * Attempts to get a packument from a registry.
+   * @param uri The registry url.
+   * @param options Options to get a packument.
    * @throws {NpmClientError}
    */
   get(uri: string, options: GetParams): Promise<UnityPackument>;
 
   /**
+   * Attempts to add a user to a registry.
+   * @param uri The registry url.
+   * @param options Options to add a user.
    * @throws {NpmClientError}
    */
   addUser(uri: string, options: AddUserParams): Promise<AddUserResponse>;

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -24,16 +24,17 @@ import {
   tryResolveFromCache,
 } from "./packument-resolving";
 
-export type NpmClient = {
+export interface NpmClient {
   /**
    * @throws {NpmClientError}
    */
   get(uri: string, options: GetParams): Promise<UnityPackument>;
+
   /**
    * @throws {NpmClientError}
    */
   addUser(uri: string, options: AddUserParams): Promise<AddUserResponse>;
-};
+}
 
 export class NpmClientError extends Error {
   cause: Error;

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -69,7 +69,7 @@ export interface NpmClient {
     keyword: string
   ): Promise<SearchedPackument[] | null>;
 
-  getAll(registry: Registry): Promise<AllPackumentsResult | null>;
+  tryGetAll(registry: Registry): Promise<AllPackumentsResult | null>;
 }
 
 export type DependencyBase = {
@@ -188,7 +188,7 @@ export const getNpmClient = (): NpmClient => {
       }
     },
 
-    async getAll(registry: Registry): Promise<AllPackumentsResult | null> {
+    async tryGetAll(registry: Registry): Promise<AllPackumentsResult | null> {
       try {
         return (await npmFetch.json(
           "/-/all",

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -19,17 +19,46 @@ import npmSearch from "libnpmsearch";
 import { is404Error, isHttpError } from "./utils/error-type-guards";
 import npmFetch from "npm-registry-fetch";
 
+/**
+ * The result of adding a user.
+ */
 type AddUserResult =
   | {
+      /**
+       * Indicates success.
+       */
       isSuccess: true;
+      /**
+       * The authentication token retrieved by adding the user.
+       */
       token: string;
     }
-  | { isSuccess: false; status: number; message: string };
+  | {
+      /**
+       * Indicates failure.
+       */
+      isSuccess: false;
+      /**
+       * The http status code returned by the server.
+       */
+      status: number;
+      /**
+       * The message returned by the server.
+       */
+      message: string;
+    };
 
+/**
+ * A type representing a searched packument. Instead of having all versions
+ * this type only includes the latest version.
+ */
 export type SearchedPackument = Omit<UnityPackument, "versions"> & {
   versions: Record<SemanticVersion, "latest">;
 };
 
+/**
+ * The result of querying the /-/all endpoint.
+ */
 type AllPackumentsResult = {
   _updated: number;
   [name: DomainName]: SearchedPackument;
@@ -64,11 +93,20 @@ export interface NpmClient {
     password: string
   ): Promise<AddUserResult>;
 
+  /**
+   * Attempts to search a npm registry.
+   * @param registry The registry to search.
+   * @param keyword The keyword to search.
+   */
   trySearch(
     registry: Registry,
     keyword: string
   ): Promise<SearchedPackument[] | null>;
 
+  /**
+   * Attempts to query the /-/all endpoint.
+   * @param registry The registry to query.
+   */
   tryGetAll(registry: Registry): Promise<AllPackumentsResult | null>;
 }
 

--- a/src/registry-client.ts
+++ b/src/registry-client.ts
@@ -29,12 +29,12 @@ import {
 export interface NpmClient {
   /**
    * Attempts to get a packument from a registry.
-   * @param name The name of the packument to get.
    * @param registry The registry to get the packument from.
+   * @param name The name of the packument to get.
    */
   tryFetchPackument(
-    name: DomainName,
-    registry: Registry
+    registry: Registry,
+    name: DomainName
   ): Promise<UnityPackument | null>;
 
   /**
@@ -150,7 +150,7 @@ export const getNpmClient = (): NpmClient => {
   // create client
   const registryClient = new RegClient({ log });
   return {
-    tryFetchPackument(name, registry) {
+    tryFetchPackument(registry, name) {
       const url = `${registry.url}/${name}`;
       return new Promise((resolve) => {
         return registryClient.get(

--- a/test/test-registry-client.ts
+++ b/test/test-registry-client.ts
@@ -33,7 +33,7 @@ describe("registry-client", function () {
       should(env).not.be.null();
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
-      const info = await client.get(packageA, env!.registry);
+      const info = await client.tryFetchPackument(packageA, env!.registry);
       should(info).deepEqual(packumentRemote);
     });
     it("404", async function () {
@@ -43,7 +43,7 @@ describe("registry-client", function () {
       );
       should(env).not.be.null();
       registerMissingPackument(packageA);
-      const info = await client.get(packageA, env!.registry);
+      const info = await client.tryFetchPackument(packageA, env!.registry);
       should(info).be.null();
     });
   });

--- a/test/test-registry-client.ts
+++ b/test/test-registry-client.ts
@@ -1,7 +1,6 @@
 import "assert";
 import "should";
 import { parseEnv } from "../src/utils/env";
-import { fetchPackument, getNpmClient } from "../src/registry-client";
 import {
   exampleRegistryUrl,
   registerMissingPackument,
@@ -12,6 +11,7 @@ import {
 import should from "should";
 import { buildPackument } from "./data-packument";
 import { domainName } from "../src/types/domain-name";
+import { getNpmClient } from "../src/registry-client";
 
 const packageA = domainName("package-a");
 
@@ -33,7 +33,7 @@ describe("registry-client", function () {
       should(env).not.be.null();
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
-      const info = await fetchPackument(env!.registry, packageA, client);
+      const info = await client.get(packageA, env!.registry);
       should(info).deepEqual(packumentRemote);
     });
     it("404", async function () {
@@ -43,8 +43,8 @@ describe("registry-client", function () {
       );
       should(env).not.be.null();
       registerMissingPackument(packageA);
-      const info = await fetchPackument(env!.registry, packageA, client);
-      (info === undefined).should.be.ok();
+      const info = await client.get(packageA, env!.registry);
+      should(info).be.null();
     });
   });
 });

--- a/test/test-registry-client.ts
+++ b/test/test-registry-client.ts
@@ -33,7 +33,7 @@ describe("registry-client", function () {
       should(env).not.be.null();
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
-      const info = await client.tryFetchPackument(packageA, env!.registry);
+      const info = await client.tryFetchPackument(env!.registry, packageA);
       should(info).deepEqual(packumentRemote);
     });
     it("404", async function () {
@@ -43,7 +43,7 @@ describe("registry-client", function () {
       );
       should(env).not.be.null();
       registerMissingPackument(packageA);
-      const info = await client.tryFetchPackument(packageA, env!.registry);
+      const info = await client.tryFetchPackument(env!.registry, packageA);
       should(info).be.null();
     });
   });


### PR DESCRIPTION
The `NpmClient` type now has the task of abstracting all communication with npm registries. It builds and sends requests and interprets responses.