### PR TITLE
fix: empty scoped-registry after remove

### DIFF
--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -106,6 +106,25 @@ export function addScopedRegistry(
 }
 
 /**
+ * Removes a scoped-registry to the manifest.
+ * @param manifest The manifest.
+ * @param name The name of the scoped-registry to remove.
+ */
+export function removeScopedRegistry(
+  manifest: UnityProjectManifest,
+  name: string
+) {
+  if (manifest.scopedRegistries === undefined) return;
+
+  const removeIndex = manifest.scopedRegistries.findIndex(
+    (registry) => registry.name === name
+  );
+  if (removeIndex === -1) return;
+
+  manifest.scopedRegistries.splice(removeIndex, 1);
+}
+
+/**
  * Adds a testable to the manifest, if it is not already added.
  * @param manifest The manifest.
  * @param name The testable name.
@@ -123,4 +142,18 @@ export function addTestable(manifest: UnityProjectManifest, name: DomainName) {
  */
 export function manifestPathFor(projectPath: string): string {
   return path.join(projectPath, "Packages/manifest.json");
+}
+
+/**
+ * Prunes the manifest by performing the following operations:
+ *  - Remove scoped-registries without scopes.
+ * @param manifest The manifest to prune.
+ */
+export function pruneManifest(manifest: UnityProjectManifest) {
+  if (manifest.scopedRegistries !== undefined) {
+    manifest.scopedRegistries.forEach((registry) => {
+      if (registry.scopes.length === 0)
+        removeScopedRegistry(manifest, registry.name);
+    });
+  }
 }

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -3,6 +3,7 @@ import { assertIsError } from "./error-type-guards";
 import log from "../logger";
 import {
   manifestPathFor,
+  pruneManifest,
   UnityProjectManifest,
 } from "../types/project-manifest";
 import fse from "fs-extra";
@@ -34,14 +35,16 @@ export const loadProjectManifest = async function (
 /**
  * Saves a Unity project manifest.
  * @param projectPath The path to the projects root directory.
- * @param data The manifest to save.
+ * @param manifest The manifest to save.
  */
 export const saveProjectManifest = async function (
   projectPath: string,
-  data: UnityProjectManifest
+  manifest: UnityProjectManifest
 ) {
   const manifestPath = manifestPathFor(projectPath);
-  const json = JSON.stringify(data, null, 2);
+  // NOTE: This modifies the manifest that was passed to the function!
+  pruneManifest(manifest);
+  const json = JSON.stringify(manifest, null, 2);
   try {
     await fse.ensureDir(path.dirname(manifestPath));
     await fs.writeFile(manifestPath, json);

--- a/test/test-cmd-remove.ts
+++ b/test/test-cmd-remove.ts
@@ -12,6 +12,7 @@ import { semanticVersion } from "../src/types/semantic-version";
 import { packageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import { after } from "mocha";
+import should from "should";
 
 const packageA = domainName("com.example.package-a");
 const packageB = domainName("com.example.package-b");
@@ -109,6 +110,19 @@ describe("cmd-remove.ts", function () {
         .hasLineIncluding("out", "removed com.example.package-b")
         .should.be.ok();
       mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+    });
+    it("should delete scoped-registry after removing all packages", async () => {
+      const options = {
+        _global: {
+          registry: exampleRegistryUrl,
+        },
+      };
+      const retCode = await remove([packageA, packageB], options);
+      retCode.should.equal(0);
+
+      await mockProject.tryAssertManifest((manifest) => {
+        should(manifest.scopedRegistries).be.empty();
+      });
     });
   });
 });


### PR DESCRIPTION
This addresses #153.

Now we prune empty scoped-registries before saving the manifest. 