### PR TITLE
refactor: make project-manifest type readonly

### DIFF
--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -45,7 +45,7 @@ export const remove = async function (
       return { code: 1, dirty };
     }
     // load manifest
-    const manifest = await loadProjectManifest(env.cwd);
+    let manifest = await loadProjectManifest(env.cwd);
     if (manifest === null) return { code: 1, dirty };
     // not found array
     const pkgsNotFound = Array.of<PackageReference>();
@@ -55,7 +55,7 @@ export const remove = async function (
         "manifest",
         `removed ${packageReference(pkg, versionInManifest)}`
       );
-      removeDependency(manifest, pkg);
+      manifest = removeDependency(manifest, pkg);
       dirty = true;
     } else pkgsNotFound.push(pkg);
 

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -5,6 +5,7 @@ import { ScopedRegistry } from "./scoped-registry";
 import { RegistryUrl } from "./registry-url";
 import path from "path";
 import { removeTrailingSlash } from "../utils/string-utils";
+import { removeRecordKey } from "../utils/record-utils";
 
 /**
  * The content of the project-manifest (manifest.json) of a Unity project.
@@ -16,7 +17,7 @@ export type UnityProjectManifest = {
    * direct dependencies. Each entry maps the package name to the minimum
    * version required for the project.
    */
-  dependencies: Record<DomainName, SemanticVersion | PackageUrl>;
+  dependencies: Readonly<Record<DomainName, SemanticVersion | PackageUrl>>;
   /**
    * Enables a lock file to ensure that dependencies are resolved in a
    * deterministic manner.
@@ -58,7 +59,7 @@ export function addDependency(
   version: SemanticVersion | PackageUrl
 ) {
   if (manifest.dependencies === undefined) manifest.dependencies = {};
-  manifest.dependencies[name] = version;
+  manifest.dependencies = { ...manifest.dependencies, [name]: version };
 }
 
 /**
@@ -71,7 +72,8 @@ export function removeDependency(
   name: DomainName
 ) {
   if (manifest.dependencies === undefined) return;
-  delete manifest.dependencies[name];
+
+  manifest.dependencies = removeRecordKey(manifest.dependencies, name);
 }
 
 /**

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -30,7 +30,7 @@ export type UnityProjectManifest = {
    * Specify custom registries in addition to the default registry.
    * This allows you to host your own packages.
    */
-  scopedRegistries?: ScopedRegistry[];
+  scopedRegistries?: ReadonlyArray<ScopedRegistry>;
   /**
    * Lists the names of packages whose tests you want to load in the
    * Unity Test Framework.
@@ -101,8 +101,12 @@ export function addScopedRegistry(
   manifest: UnityProjectManifest,
   scopedRegistry: ScopedRegistry
 ) {
-  if (manifest.scopedRegistries === undefined) manifest.scopedRegistries = [];
-  manifest.scopedRegistries.push(scopedRegistry);
+  if (manifest.scopedRegistries === undefined) {
+    manifest.scopedRegistries = [scopedRegistry];
+    return;
+  }
+
+  manifest.scopedRegistries = [...manifest.scopedRegistries, scopedRegistry];
 }
 
 /**
@@ -116,12 +120,9 @@ export function removeScopedRegistry(
 ) {
   if (manifest.scopedRegistries === undefined) return;
 
-  const removeIndex = manifest.scopedRegistries.findIndex(
-    (registry) => registry.name === name
+  manifest.scopedRegistries = manifest.scopedRegistries.filter(
+    (it) => it.name !== name
   );
-  if (removeIndex === -1) return;
-
-  manifest.scopedRegistries.splice(removeIndex, 1);
 }
 
 /**

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -35,7 +35,7 @@ export type UnityProjectManifest = {
    * Lists the names of packages whose tests you want to load in the
    * Unity Test Framework.
    */
-  testables?: DomainName[];
+  testables?: ReadonlyArray<DomainName>;
 };
 
 /**
@@ -130,9 +130,14 @@ export function removeScopedRegistry(
  * @param name The testable name.
  */
 export function addTestable(manifest: UnityProjectManifest, name: DomainName) {
-  if (!manifest.testables) manifest.testables = [];
-  if (manifest.testables.indexOf(name) === -1) manifest.testables.push(name);
-  manifest.testables.sort();
+  if (!manifest.testables) {
+    manifest.testables = [name];
+    return;
+  }
+
+  if (manifest.testables.indexOf(name) !== -1) return;
+
+  manifest.testables = [...manifest.testables, name].sort();
 }
 
 /**

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -42,8 +42,7 @@ export const saveProjectManifest = async function (
   manifest: UnityProjectManifest
 ) {
   const manifestPath = manifestPathFor(projectPath);
-  // NOTE: This modifies the manifest that was passed to the function!
-  pruneManifest(manifest);
+  manifest = pruneManifest(manifest);
   const json = JSON.stringify(manifest, null, 2);
   try {
     await fse.ensureDir(path.dirname(manifestPath));

--- a/src/utils/record-utils.ts
+++ b/src/utils/record-utils.ts
@@ -17,3 +17,22 @@ export function recordKeys<TKey extends string | number | symbol>(
 ): TKey[] {
   return Object.keys(record) as unknown as TKey[];
 }
+
+/**
+ * Removes the property with a specific key from a record.
+ * @param record The record.
+ * @param key The key.
+ * @returns A new record without the key.
+ */
+export function removeRecordKey<
+  TKey extends string | number | symbol,
+  TValue,
+  TKeyToRemove extends TKey
+>(
+  record: Record<TKey, TValue>,
+  key: TKeyToRemove
+): Record<Exclude<TKey, TKeyToRemove>, TValue> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { [key]: _, ...withOutKey } = record;
+  return withOutKey;
+}

--- a/test/data-project-manifest.ts
+++ b/test/data-project-manifest.ts
@@ -5,6 +5,7 @@ import { isSemanticVersion } from "../src/types/semantic-version";
 import { addScope, scopedRegistry } from "../src/types/scoped-registry";
 import {
   addDependency,
+  addScopedRegistry,
   addTestable,
   emptyProjectManifest,
   UnityProjectManifest,
@@ -14,10 +15,10 @@ import {
  * Builder class for {@link UnityProjectManifest}.
  */
 class UnityProjectManifestBuilder {
-  readonly manifest: UnityProjectManifest;
+  manifest: UnityProjectManifest;
 
   constructor() {
-    this.manifest = emptyProjectManifest();
+    this.manifest = emptyProjectManifest;
   }
 
   /**
@@ -28,9 +29,10 @@ class UnityProjectManifestBuilder {
     assert(isDomainName(name), `${name} is domain name`);
 
     if (this.manifest.scopedRegistries === undefined)
-      this.manifest.scopedRegistries = [
-        scopedRegistry("example.com", exampleRegistryUrl),
-      ];
+      this.manifest = addScopedRegistry(
+        this.manifest,
+        scopedRegistry("example.com", exampleRegistryUrl)
+      );
 
     const registry = this.manifest.scopedRegistries![0]!;
     addScope(registry, name);
@@ -44,7 +46,7 @@ class UnityProjectManifestBuilder {
    */
   addTestable(name: string): UnityProjectManifestBuilder {
     assert(isDomainName(name), `${name} is domain name`);
-    addTestable(this.manifest, name);
+    this.manifest = addTestable(this.manifest, name);
     return this;
   }
 
@@ -65,7 +67,7 @@ class UnityProjectManifestBuilder {
     assert(isSemanticVersion(version), `${version} is semantic version`);
     if (withScope) this.addScope(name);
     if (testable) this.addTestable(name);
-    addDependency(this.manifest, name, version);
+    this.manifest = addDependency(this.manifest, name, version);
     return this;
   }
 }

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -52,7 +52,7 @@ export type MockUnityProject = {
 
 const defaultVersion = "2020.2.1f1";
 
-const defaultManifest = emptyProjectManifest();
+const defaultManifest = emptyProjectManifest;
 
 const defaultUpmConfig = {} satisfies UPMConfig;
 

--- a/test/test-project-manifest-io.ts
+++ b/test/test-project-manifest-io.ts
@@ -60,9 +60,13 @@ describe("project-manifest io", function () {
     mockConsole.hasLineIncluding("out", "failed to parse").should.be.ok();
   });
   it("saveManifest", async function () {
-    const manifest = (await loadProjectManifest(mockProject.projectPath))!;
+    let manifest = (await loadProjectManifest(mockProject.projectPath))!;
     shouldNotHaveAnyDependencies(manifest);
-    addDependency(manifest, domainName("some-pack"), semanticVersion("1.0.0"));
+    manifest = addDependency(
+      manifest,
+      domainName("some-pack"),
+      semanticVersion("1.0.0")
+    );
     (
       await saveProjectManifest(mockProject.projectPath, manifest)
     ).should.be.ok();

--- a/test/test-project-manifest.ts
+++ b/test/test-project-manifest.ts
@@ -16,55 +16,87 @@ import { registryUrl } from "../src/types/registry-url";
 describe("project-manifest", function () {
   describe("dependency", function () {
     it("should add dependency when adding first time", () => {
-      const manifest = emptyProjectManifest();
-      addDependency(manifest, domainName("test"), semanticVersion("1.2.3"));
+      let manifest = emptyProjectManifest;
+
+      manifest = addDependency(
+        manifest,
+        domainName("test"),
+        semanticVersion("1.2.3")
+      );
+
       should(manifest.dependencies).deepEqual({ test: "1.2.3" });
     });
     it("should overwrite dependency when adding second time", () => {
-      const manifest = emptyProjectManifest();
-      addDependency(manifest, domainName("test"), semanticVersion("1.2.3"));
-      addDependency(manifest, domainName("test"), semanticVersion("2.3.4"));
+      let manifest = emptyProjectManifest;
+
+      manifest = addDependency(
+        manifest,
+        domainName("test"),
+        semanticVersion("1.2.3")
+      );
+      manifest = addDependency(
+        manifest,
+        domainName("test"),
+        semanticVersion("2.3.4")
+      );
+
       should(manifest.dependencies).deepEqual({ test: "2.3.4" });
     });
     it("should remove existing dependency", () => {
-      const manifest = emptyProjectManifest();
-      addDependency(manifest, domainName("test"), semanticVersion("1.2.3"));
-      removeDependency(manifest, domainName("test"));
+      let manifest = emptyProjectManifest;
+
+      manifest = addDependency(
+        manifest,
+        domainName("test"),
+        semanticVersion("1.2.3")
+      );
+      manifest = removeDependency(manifest, domainName("test"));
+
       should(manifest.dependencies).deepEqual({});
     });
     it("should do nothing when dependency does not exist", () => {
-      const manifest = emptyProjectManifest();
-      removeDependency(manifest, domainName("test"));
+      let manifest = emptyProjectManifest;
+
+      manifest = removeDependency(manifest, domainName("test"));
+
       should(manifest.dependencies).deepEqual({});
     });
   });
   describe("scoped-registry", function () {
     it("should should find scoped-registry with url if present", () => {
-      const manifest = emptyProjectManifest();
+      let manifest = emptyProjectManifest;
       const url = registryUrl("https://test.com");
       const expected = scopedRegistry("test", url);
-      addScopedRegistry(manifest, expected);
+
+      manifest = addScopedRegistry(manifest, expected);
+
       should(tryGetScopedRegistryByUrl(manifest, url)).be.deepEqual(expected);
     });
     it("should should not find scoped-registry with incorrect url", () => {
-      const manifest = emptyProjectManifest();
+      let manifest = emptyProjectManifest;
       const url = registryUrl("https://test.com");
       const expected = scopedRegistry("test", registryUrl("https://test2.com"));
-      addScopedRegistry(manifest, expected);
+
+      manifest = addScopedRegistry(manifest, expected);
+
       should(tryGetScopedRegistryByUrl(manifest, url)).be.null();
     });
   });
   describe("testables", function () {
     it("should not add testables which already exist", () => {
-      const manifest = emptyProjectManifest();
-      addTestable(manifest, domainName("a"));
-      addTestable(manifest, domainName("a"));
+      let manifest = emptyProjectManifest;
+
+      manifest = addTestable(manifest, domainName("a"));
+      manifest = addTestable(manifest, domainName("a"));
+
       should(manifest.testables).deepEqual(["a"]);
     });
     it("should add testables in alphabetical order", () => {
-      const manifest = emptyProjectManifest();
-      addTestable(manifest, domainName("b"));
-      addTestable(manifest, domainName("a"));
+      let manifest = emptyProjectManifest;
+
+      manifest = addTestable(manifest, domainName("b"));
+      manifest = addTestable(manifest, domainName("a"));
+
       should(manifest.testables).deepEqual(["a", "b"]);
     });
   });


### PR DESCRIPTION
This PR makes all properties and property types of the `ProjectManifest` type readonly. This way it is more in line with other immutable object types in the project.