### PR TITLE
refactor: use jest for assertion

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   verbose: true,
+  setupFilesAfterEnv: [
+      "./test/mock-console-assertions.ts"
+  ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: "node",
   verbose: true,
   setupFilesAfterEnv: [
-      "./test/mock-console-assertions.ts"
+      "./test/mock-console-assertions.ts",
+      "./test/project-manifest-assertions.ts"
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "prettier": "^2.8.8",
         "rimraf": "^5.0.5",
         "semantic-release": "^19.0.3",
-        "should": "^13.2.3",
         "test-console": "^2.0.0",
         "ts-jest": "^29.1.2",
         "typescript": "^5.2.2"
@@ -11101,54 +11100,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/should": {
-      "version": "13.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-equal": "^2.0.0",
-        "should-format": "^3.0.3",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-equal": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.4.0"
-      }
-    },
-    "node_modules/should-format": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "node_modules/should-type": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/should-type-adaptors": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-util": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "license": "ISC"
@@ -19782,48 +19733,6 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "dev": true
-    },
-    "should": {
-      "version": "13.2.3",
-      "dev": true,
-      "requires": {
-        "should-equal": "^2.0.0",
-        "should-format": "^3.0.3",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "should-equal": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.4.0"
-      }
-    },
-    "should-format": {
-      "version": "3.0.3",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "should-type": {
-      "version": "1.4.0",
-      "dev": true
-    },
-    "should-type-adaptors": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "should-util": {
-      "version": "1.0.1",
       "dev": true
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "prettier": "^2.8.8",
     "rimraf": "^5.0.5",
     "semantic-release": "^19.0.3",
-    "should": "^13.2.3",
     "test-console": "^2.0.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.2.2"

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -165,8 +165,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestA)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@1.0.0", async function () {
       const retCode = await add(
@@ -177,8 +177,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestA)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@latest", async function () {
       const retCode = await add(packageReference(packageA, "latest"), options);
@@ -186,8 +186,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestA)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@0.1.0 then pkg@1.0.0", async function () {
       const retCode1 = await add(
@@ -203,8 +203,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestA)
       );
-      mockConsole.hasLineIncluding("out", "modified ").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "modified ");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add exited pkg version", async function () {
       const retCode1 = await add(
@@ -220,8 +220,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestA)
       );
-      mockConsole.hasLineIncluding("out", "existed ").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "existed ");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@not-exist-version", async function () {
       const retCode = await add(
@@ -232,10 +232,12 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(defaultManifest)
       );
-      mockConsole
-        .hasLineIncluding("out", "version 2.0.0 is not a valid choice")
-        .should.be.ok();
-      mockConsole.hasLineIncluding("out", "1.0.0").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "version 2.0.0 is not a valid choice"
+      );
+
+      expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
     });
     it("add pkg@http", async function () {
       const gitUrl = "https://github.com/yo/com.base.package-a" as PackageUrl;
@@ -247,8 +249,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         shouldNotHaveRegistries(manifest)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@git", async function () {
       const gitUrl = "git@github.com:yo/com.base.package-a" as PackageUrl;
@@ -260,8 +262,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         shouldNotHaveRegistries(manifest)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@file", async function () {
       const fileUrl = "file../yo/com.base.package-a" as PackageUrl;
@@ -273,8 +275,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         shouldNotHaveRegistries(manifest)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg-not-exist", async function () {
       const retCode = await add(packageMissing, options);
@@ -282,7 +284,7 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(defaultManifest)
       );
-      mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("add more than one pkgs", async function () {
       const retCode = await add([packageA, packageB], options);
@@ -290,13 +292,15 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestAB)
       );
-      mockConsole
-        .hasLineIncluding("out", "added com.base.package-a")
-        .should.be.ok();
-      mockConsole
-        .hasLineIncluding("out", "added com.base.package-b")
-        .should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "added com.base.package-a"
+      );
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "added com.base.package-b"
+      );
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg from upstream", async function () {
       const retCode = await add(packageUp, upstreamOptions);
@@ -304,10 +308,11 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestUpstream)
       );
-      mockConsole
-        .hasLineIncluding("out", "added com.upstream.package-up")
-        .should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "added com.upstream.package-up"
+      );
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg-not-exist from upstream", async function () {
       const retCode = await add(packageMissing, upstreamOptions);
@@ -315,7 +320,7 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(defaultManifest)
       );
-      mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("add pkg with nested dependencies", async function () {
       const retCode = await add(
@@ -326,8 +331,8 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestC)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with tests", async function () {
       const retCode = await add(packageA, testableOptions);
@@ -335,38 +340,40 @@ describe("cmd-add.ts", function () {
       await mockProject.tryAssertManifest((manifest) =>
         manifest.should.deepEqual(expectedManifestTestable)
       );
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with lower editor version", async function () {
       const retCode = await add(packageLowerEditor, testableOptions);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", "added").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "added");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with higher editor version", async function () {
       const retCode = await add(packageHigherEditor, testableOptions);
       retCode.should.equal(1);
-      mockConsole
-        .hasLineIncluding("out", "requires 2020.2 but found 2019.2.13f1")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "requires 2020.2 but found 2019.2.13f1"
+      );
     });
     it("force add pkg with higher editor version", async function () {
       const retCode = await add(packageHigherEditor, forceOptions);
       retCode.should.equal(0);
-      mockConsole
-        .hasLineIncluding("out", "requires 2020.2 but found 2019.2.13f1")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "requires 2020.2 but found 2019.2.13f1"
+      );
     });
     it("add pkg with wrong editor version", async function () {
       const retCode = await add(packageWrongEditor, testableOptions);
       retCode.should.equal(1);
-      mockConsole.hasLineIncluding("out", "2020 is not valid").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
     it("force add pkg with wrong editor version", async function () {
       const retCode = await add(packageWrongEditor, forceOptions);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", "2020 is not valid").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
   });
 });

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -1,4 +1,3 @@
-import "should";
 import { add, AddOptions } from "../src/cmd-add";
 import {
   exampleRegistryUrl,

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -161,9 +161,9 @@ describe("cmd-add.ts", function () {
 
     it("add pkg", async function () {
       const retCode = await add(packageA, options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestA)
+        expect(manifest).toEqual(expectedManifestA)
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -173,18 +173,18 @@ describe("cmd-add.ts", function () {
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestA)
+        expect(manifest).toEqual(expectedManifestA)
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@latest", async function () {
       const retCode = await add(packageReference(packageA, "latest"), options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestA)
+        expect(manifest).toEqual(expectedManifestA)
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -194,14 +194,14 @@ describe("cmd-add.ts", function () {
         packageReference(packageA, semanticVersion("0.1.0")),
         options
       );
-      retCode1.should.equal(0);
+      expect(retCode1).toEqual(0);
       const retCode2 = await add(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      retCode2.should.equal(0);
+      expect(retCode2).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestA)
+        expect(manifest).toEqual(expectedManifestA)
       );
       expect(mockConsole).toHaveLineIncluding("out", "modified ");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -211,14 +211,14 @@ describe("cmd-add.ts", function () {
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      retCode1.should.equal(0);
+      expect(retCode1).toEqual(0);
       const retCode2 = await add(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      retCode2.should.equal(0);
+      expect(retCode2).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestA)
+        expect(manifest).toEqual(expectedManifestA)
       );
       expect(mockConsole).toHaveLineIncluding("out", "existed ");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -228,9 +228,9 @@ describe("cmd-add.ts", function () {
         packageReference(packageA, semanticVersion("2.0.0")),
         options
       );
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(defaultManifest)
+        expect(manifest).toEqual(defaultManifest)
       );
       expect(mockConsole).toHaveLineIncluding(
         "out",
@@ -242,7 +242,7 @@ describe("cmd-add.ts", function () {
     it("add pkg@http", async function () {
       const gitUrl = "https://github.com/yo/com.base.package-a" as PackageUrl;
       const retCode = await add(packageReference(packageA, gitUrl), options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         shouldHaveDependency(manifest, packageA, gitUrl)
       );
@@ -255,7 +255,7 @@ describe("cmd-add.ts", function () {
     it("add pkg@git", async function () {
       const gitUrl = "git@github.com:yo/com.base.package-a" as PackageUrl;
       const retCode = await add(packageReference(packageA, gitUrl), options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         shouldHaveDependency(manifest, packageA, gitUrl)
       );
@@ -268,7 +268,7 @@ describe("cmd-add.ts", function () {
     it("add pkg@file", async function () {
       const fileUrl = "file../yo/com.base.package-a" as PackageUrl;
       const retCode = await add(packageReference(packageA, fileUrl), options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         shouldHaveDependency(manifest, packageA, fileUrl)
       );
@@ -280,17 +280,17 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg-not-exist", async function () {
       const retCode = await add(packageMissing, options);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(defaultManifest)
+        expect(manifest).toEqual(defaultManifest)
       );
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("add more than one pkgs", async function () {
       const retCode = await add([packageA, packageB], options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestAB)
+        expect(manifest).toEqual(expectedManifestAB)
       );
       expect(mockConsole).toHaveLineIncluding(
         "out",
@@ -304,9 +304,9 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg from upstream", async function () {
       const retCode = await add(packageUp, upstreamOptions);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestUpstream)
+        expect(manifest).toEqual(expectedManifestUpstream)
       );
       expect(mockConsole).toHaveLineIncluding(
         "out",
@@ -316,9 +316,9 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg-not-exist from upstream", async function () {
       const retCode = await add(packageMissing, upstreamOptions);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(defaultManifest)
+        expect(manifest).toEqual(defaultManifest)
       );
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
@@ -327,31 +327,31 @@ describe("cmd-add.ts", function () {
         packageReference(packageC, "latest"),
         upstreamOptions
       );
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestC)
+        expect(manifest).toEqual(expectedManifestC)
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with tests", async function () {
       const retCode = await add(packageA, testableOptions);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        manifest.should.deepEqual(expectedManifestTestable)
+        expect(manifest).toEqual(expectedManifestTestable)
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with lower editor version", async function () {
       const retCode = await add(packageLowerEditor, testableOptions);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with higher editor version", async function () {
       const retCode = await add(packageHigherEditor, testableOptions);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "requires 2020.2 but found 2019.2.13f1"
@@ -359,7 +359,7 @@ describe("cmd-add.ts", function () {
     });
     it("force add pkg with higher editor version", async function () {
       const retCode = await add(packageHigherEditor, forceOptions);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "requires 2020.2 but found 2019.2.13f1"
@@ -367,12 +367,12 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg with wrong editor version", async function () {
       const retCode = await add(packageWrongEditor, testableOptions);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
     it("force add pkg with wrong editor version", async function () {
       const retCode = await add(packageWrongEditor, forceOptions);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
   });

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -8,10 +8,6 @@ import {
   stopMockRegistry,
 } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
-import {
-  shouldHaveDependency,
-  shouldNotHaveRegistries,
-} from "./project-manifest-assertions";
 import { buildPackument } from "./data-packument";
 import { buildProjectManifest } from "./data-project-manifest";
 import { domainName } from "../src/types/domain-name";
@@ -243,10 +239,10 @@ describe("cmd-add.ts", function () {
       const retCode = await add(packageReference(packageA, gitUrl), options);
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        shouldHaveDependency(manifest, packageA, gitUrl)
+        expect(manifest).toHaveDependency(packageA, gitUrl)
       );
       await mockProject.tryAssertManifest((manifest) =>
-        shouldNotHaveRegistries(manifest)
+        expect(manifest).not.toHaveScopedRegistries()
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -256,10 +252,10 @@ describe("cmd-add.ts", function () {
       const retCode = await add(packageReference(packageA, gitUrl), options);
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        shouldHaveDependency(manifest, packageA, gitUrl)
+        expect(manifest).toHaveDependency(packageA, gitUrl)
       );
       await mockProject.tryAssertManifest((manifest) =>
-        shouldNotHaveRegistries(manifest)
+        expect(manifest).not.toHaveScopedRegistries()
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -269,10 +265,10 @@ describe("cmd-add.ts", function () {
       const retCode = await add(packageReference(packageA, fileUrl), options);
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
-        shouldHaveDependency(manifest, packageA, fileUrl)
+        expect(manifest).toHaveDependency(packageA, fileUrl)
       );
       await mockProject.tryAssertManifest((manifest) =>
-        shouldNotHaveRegistries(manifest)
+        expect(manifest).not.toHaveScopedRegistries()
       );
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -1,4 +1,3 @@
-import "should";
 import { deps, DepsOptions } from "../src/cmd-deps";
 import {
   exampleRegistryUrl,

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -67,7 +67,7 @@ describe("cmd-deps.ts", function () {
 
     it("deps pkg", async function () {
       const retCode = await deps(remotePackumentA.name, options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg --deep", async function () {
@@ -75,7 +75,7 @@ describe("cmd-deps.ts", function () {
         ...options,
         deep: true,
       });
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentUp.name);
     });
@@ -84,7 +84,7 @@ describe("cmd-deps.ts", function () {
         packageReference(remotePackumentA.name, "latest"),
         options
       );
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg@1.0.0", async function () {
@@ -92,7 +92,7 @@ describe("cmd-deps.ts", function () {
         packageReference(remotePackumentA.name, "1.0.0"),
         options
       );
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg@not-exist-version", async function () {
@@ -100,17 +100,17 @@ describe("cmd-deps.ts", function () {
         packageReference(remotePackumentA.name, "2.0.0"),
         options
       );
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "is not a valid choice");
     });
     it("deps pkg-not-exist", async function () {
       const retCode = await deps(domainName("pkg-not-exist"), options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "not found");
     });
     it("deps pkg upstream", async function () {
       const retCode = await deps(remotePackumentUp.name, options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
     });
   });
 });

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -68,7 +68,7 @@ describe("cmd-deps.ts", function () {
     it("deps pkg", async function () {
       const retCode = await deps(remotePackumentA.name, options);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", remotePackumentB.name).should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg --deep", async function () {
       const retCode = await deps(remotePackumentA.name, {
@@ -76,10 +76,8 @@ describe("cmd-deps.ts", function () {
         deep: true,
       });
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", remotePackumentB.name).should.be.ok();
-      mockConsole
-        .hasLineIncluding("out", remotePackumentUp.name)
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
+      expect(mockConsole).toHaveLineIncluding("out", remotePackumentUp.name);
     });
     it("deps pkg@latest", async function () {
       const retCode = await deps(
@@ -87,7 +85,7 @@ describe("cmd-deps.ts", function () {
         options
       );
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", remotePackumentB.name).should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg@1.0.0", async function () {
       const retCode = await deps(
@@ -95,7 +93,7 @@ describe("cmd-deps.ts", function () {
         options
       );
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", remotePackumentB.name).should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg@not-exist-version", async function () {
       const retCode = await deps(
@@ -103,14 +101,12 @@ describe("cmd-deps.ts", function () {
         options
       );
       retCode.should.equal(0);
-      mockConsole
-        .hasLineIncluding("out", "is not a valid choice")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "is not a valid choice");
     });
     it("deps pkg-not-exist", async function () {
       const retCode = await deps(domainName("pkg-not-exist"), options);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", "not found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "not found");
     });
     it("deps pkg upstream", async function () {
       const retCode = await deps(remotePackumentUp.name, options);

--- a/test/cmd-login.test.ts
+++ b/test/cmd-login.test.ts
@@ -2,57 +2,68 @@ import "nock";
 import { generateNpmrcLines, getNpmrcPath } from "../src/cmd-login";
 import { registryUrl } from "../src/types/registry-url";
 import { runWithEnv } from "./mock-env";
-import should from "should";
 import path from "path";
 
 describe("cmd-login.ts", function () {
   describe("generateNpmrcLines", function () {
     it("should append token to empty content", async function () {
-      generateNpmrcLines(
-        "",
-        registryUrl("http://registry.npmjs.org"),
-        "123-456-789"
-      ).should.deepEqual(["//registry.npmjs.org/:_authToken=123-456-789"]);
+      expect(
+        generateNpmrcLines(
+          "",
+          registryUrl("http://registry.npmjs.org"),
+          "123-456-789"
+        )
+      ).toEqual(["//registry.npmjs.org/:_authToken=123-456-789"]);
     });
     it("should append token to exist contents", async function () {
-      generateNpmrcLines(
-        "registry=https://registry.npmjs.org/",
-        registryUrl(" registry(http://registry.npmjs.org"),
-        "123-456-789"
-      ).should.deepEqual([
+      expect(
+        generateNpmrcLines(
+          "registry=https://registry.npmjs.org/",
+          registryUrl(" registry(http://registry.npmjs.org"),
+          "123-456-789"
+        )
+      ).toEqual([
         "registry=https://registry.npmjs.org/",
         "//registry.npmjs.org/:_authToken=123-456-789",
       ]);
     });
     it("should replace token to exist contents", async function () {
-      generateNpmrcLines(
-        "registry=https://registry.npmjs.org/\n//127.0.0.1:4873/:_authToken=blar-blar-blar\n//registry.npmjs.org/:_authToken=blar-blar-blar",
-        registryUrl("http://registry.npmjs.org"),
-        "123-456-789"
-      ).should.deepEqual([
+      expect(
+        generateNpmrcLines(
+          "registry=https://registry.npmjs.org/\n//127.0.0.1:4873/:_authToken=blar-blar-blar\n//registry.npmjs.org/:_authToken=blar-blar-blar",
+          registryUrl("http://registry.npmjs.org"),
+          "123-456-789"
+        )
+      ).toEqual([
         "registry=https://registry.npmjs.org/",
         "//127.0.0.1:4873/:_authToken=blar-blar-blar",
         "//registry.npmjs.org/:_authToken=123-456-789",
       ]);
     });
     it("should handle registry without trailing slash", async function () {
-      generateNpmrcLines(
-        "",
-        registryUrl("http://registry.npmjs.org"),
-        "123-456-789"
-      ).should.deepEqual(["//registry.npmjs.org/:_authToken=123-456-789"]);
+      expect(
+        generateNpmrcLines(
+          "",
+          registryUrl("http://registry.npmjs.org"),
+          "123-456-789"
+        )
+      ).toEqual(["//registry.npmjs.org/:_authToken=123-456-789"]);
     });
     it("should quote token if necessary", async function () {
-      generateNpmrcLines(
-        "",
-        registryUrl("http://registry.npmjs.org"),
-        "=123-456-789="
-      ).should.deepEqual(['//registry.npmjs.org/:_authToken="=123-456-789="']);
-      generateNpmrcLines(
-        "",
-        registryUrl("http://registry.npmjs.org"),
-        "?123-456-789?"
-      ).should.deepEqual(['//registry.npmjs.org/:_authToken="?123-456-789?"']);
+      expect(
+        generateNpmrcLines(
+          "",
+          registryUrl("http://registry.npmjs.org"),
+          "=123-456-789="
+        )
+      ).toEqual(['//registry.npmjs.org/:_authToken="=123-456-789="']);
+      expect(
+        generateNpmrcLines(
+          "",
+          registryUrl("http://registry.npmjs.org"),
+          "?123-456-789?"
+        )
+      ).toEqual(['//registry.npmjs.org/:_authToken="?123-456-789?"']);
     });
   });
 
@@ -60,15 +71,15 @@ describe("cmd-login.ts", function () {
     it("should be USERPROFILE if defined", function () {
       const actual = runWithEnv({ USERPROFILE: "/user/dir" }, getNpmrcPath);
       const expected = path.join(path.sep, "user", "dir", ".npmrc");
-      should(actual).be.equal(expected);
+      expect(actual).toEqual(expected);
     });
     it("should be HOME if USERPROFILE is not defined", function () {
       const actual = runWithEnv({ HOME: "/user/dir" }, getNpmrcPath);
       const expected = path.join(path.sep, "user", "dir", ".npmrc");
-      should(actual).be.equal(expected);
+      expect(actual).toEqual(expected);
     });
     it("should fail if HOME and USERPROFILE are not defined", function () {
-      should(() => runWithEnv({}, getNpmrcPath)).throw();
+      expect(() => runWithEnv({}, getNpmrcPath)).toThrow();
     });
   });
 });

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -1,10 +1,6 @@
 import { remove } from "../src/cmd-remove";
 import { exampleRegistryUrl } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
-import {
-  shouldHaveRegistryWithScopes,
-  shouldNotHaveDependency,
-} from "./project-manifest-assertions";
 import { buildProjectManifest } from "./data-project-manifest";
 import { domainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
@@ -52,8 +48,8 @@ describe("cmd-remove.ts", function () {
       const retCode = await remove(packageA, options);
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) => {
-        shouldNotHaveDependency(manifest, packageA);
-        shouldHaveRegistryWithScopes(manifest, [packageB]);
+        expect(manifest).not.toHaveDependency(packageA);
+        expect(manifest).toHaveScope(packageB);
       });
       expect(mockConsole).toHaveLineIncluding("out", "removed ");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
@@ -100,8 +96,8 @@ describe("cmd-remove.ts", function () {
       expect(retCode).toEqual(0);
 
       await mockProject.tryAssertManifest((manifest) => {
-        shouldNotHaveDependency(manifest, packageA);
-        shouldNotHaveDependency(manifest, packageB);
+        expect(manifest).not.toHaveDependency(packageA);
+        expect(manifest).not.toHaveDependency(packageB);
       });
       expect(mockConsole).toHaveLineIncluding(
         "out",

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -57,8 +57,8 @@ describe("cmd-remove.ts", function () {
         shouldNotHaveDependency(manifest, packageA);
         shouldHaveRegistryWithScopes(manifest, [packageB]);
       });
-      mockConsole.hasLineIncluding("out", "removed ").should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "removed ");
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("remove pkg@1.0.0", async function () {
       const options = {
@@ -74,9 +74,10 @@ describe("cmd-remove.ts", function () {
       await mockProject.tryAssertManifest((manifest) => {
         manifest.should.deepEqual(defaultManifest);
       });
-      mockConsole
-        .hasLineIncluding("out", "do not specify a version")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "do not specify a version"
+      );
     });
     it("remove pkg-not-exist", async function () {
       const options = {
@@ -89,7 +90,7 @@ describe("cmd-remove.ts", function () {
       await mockProject.tryAssertManifest((manifest) => {
         manifest.should.deepEqual(defaultManifest);
       });
-      mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("remove more than one pkgs", async function () {
       const options = {
@@ -104,13 +105,15 @@ describe("cmd-remove.ts", function () {
         shouldNotHaveDependency(manifest, packageA);
         shouldNotHaveDependency(manifest, packageB);
       });
-      mockConsole
-        .hasLineIncluding("out", "removed com.example.package-a")
-        .should.be.ok();
-      mockConsole
-        .hasLineIncluding("out", "removed com.example.package-b")
-        .should.be.ok();
-      mockConsole.hasLineIncluding("out", "open Unity").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "removed com.example.package-a"
+      );
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "removed com.example.package-b"
+      );
+      expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("should delete scoped-registry after removing all packages", async () => {
       const options = {

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -1,4 +1,3 @@
-import "should";
 import { remove } from "../src/cmd-remove";
 import { exampleRegistryUrl } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -11,7 +11,6 @@ import { domainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import { packageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
-import should from "should";
 
 const packageA = domainName("com.example.package-a");
 const packageB = domainName("com.example.package-b");
@@ -52,7 +51,7 @@ describe("cmd-remove.ts", function () {
         },
       };
       const retCode = await remove(packageA, options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) => {
         shouldNotHaveDependency(manifest, packageA);
         shouldHaveRegistryWithScopes(manifest, [packageB]);
@@ -70,9 +69,9 @@ describe("cmd-remove.ts", function () {
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       await mockProject.tryAssertManifest((manifest) => {
-        manifest.should.deepEqual(defaultManifest);
+        expect(manifest).toEqual(defaultManifest);
       });
       expect(mockConsole).toHaveLineIncluding(
         "out",
@@ -86,9 +85,9 @@ describe("cmd-remove.ts", function () {
         },
       };
       const retCode = await remove(missingPackage, options);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       await mockProject.tryAssertManifest((manifest) => {
-        manifest.should.deepEqual(defaultManifest);
+        expect(manifest).toEqual(defaultManifest);
       });
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
@@ -99,7 +98,7 @@ describe("cmd-remove.ts", function () {
         },
       };
       const retCode = await remove([packageA, packageB], options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
 
       await mockProject.tryAssertManifest((manifest) => {
         shouldNotHaveDependency(manifest, packageA);
@@ -122,10 +121,10 @@ describe("cmd-remove.ts", function () {
         },
       };
       const retCode = await remove([packageA, packageB], options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
 
       await mockProject.tryAssertManifest((manifest) => {
-        should(manifest.scopedRegistries).be.empty();
+        expect(manifest.scopedRegistries).toHaveLength(0);
       });
     });
   });

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -86,14 +86,14 @@ describe("cmd-search.ts", function () {
     });
     it("simple", async function () {
       const retCode = await search("package-a", options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "package-a");
       expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
       expect(mockConsole).toHaveLineIncluding("out", "2019-10-02");
     });
     it("pkg not exist", async function () {
       const retCode = await search("pkg-not-exist", options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "No matches found");
     });
   });
@@ -136,7 +136,7 @@ describe("cmd-search.ts", function () {
         "Content-Type": "application/json",
       });
       const retCode = await search("package-a", options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "fast search endpoint is not available"
@@ -150,7 +150,7 @@ describe("cmd-search.ts", function () {
         "Content-Type": "application/json",
       });
       const retCode = await search("pkg-not-exist", options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "No matches found");
     });
   });

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -87,14 +87,14 @@ describe("cmd-search.ts", function () {
     it("simple", async function () {
       const retCode = await search("package-a", options);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", "package-a").should.be.ok();
-      mockConsole.hasLineIncluding("out", "1.0.0").should.be.ok();
-      mockConsole.hasLineIncluding("out", "2019-10-02").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "package-a");
+      expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
+      expect(mockConsole).toHaveLineIncluding("out", "2019-10-02");
     });
     it("pkg not exist", async function () {
       const retCode = await search("pkg-not-exist", options);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", "No matches found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "No matches found");
     });
   });
 
@@ -137,12 +137,13 @@ describe("cmd-search.ts", function () {
       });
       const retCode = await search("package-a", options);
       retCode.should.equal(0);
-      mockConsole
-        .hasLineIncluding("out", "fast search endpoint is not available")
-        .should.be.ok();
-      mockConsole.hasLineIncluding("out", "package-a").should.be.ok();
-      mockConsole.hasLineIncluding("out", "1.0.0").should.be.ok();
-      mockConsole.hasLineIncluding("out", "2019-10-02").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "fast search endpoint is not available"
+      );
+      expect(mockConsole).toHaveLineIncluding("out", "package-a");
+      expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
+      expect(mockConsole).toHaveLineIncluding("out", "2019-10-02");
     });
     it("pkg not exist", async function () {
       nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
@@ -150,7 +151,7 @@ describe("cmd-search.ts", function () {
       });
       const retCode = await search("pkg-not-exist", options);
       retCode.should.equal(0);
-      mockConsole.hasLineIncluding("out", "No matches found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "No matches found");
     });
   });
 });

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -1,5 +1,5 @@
 import nock from "nock";
-import "should";
+
 import { search, SearchOptions } from "../src/cmd-search";
 import {
   exampleRegistryUrl,

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -126,7 +126,7 @@ describe("cmd-view.ts", function () {
 
     it("view pkg", async function () {
       const retCode = await view(packageA, options);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "com.example.package-a@1.0.0"
@@ -137,7 +137,7 @@ describe("cmd-view.ts", function () {
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "do not specify a version"
@@ -145,12 +145,12 @@ describe("cmd-view.ts", function () {
     });
     it("view pkg-not-exist", async function () {
       const retCode = await view(packageMissing, options);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("view pkg from upstream", async function () {
       const retCode = await view(packageUp, upstreamOptions);
-      retCode.should.equal(0);
+      expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "com.example.package-up@1.0.0"
@@ -158,7 +158,7 @@ describe("cmd-view.ts", function () {
     });
     it("view pkg-not-exist from upstream", async function () {
       const retCode = await view(packageMissing, upstreamOptions);
-      retCode.should.equal(1);
+      expect(retCode).toEqual(1);
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
   });

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -1,4 +1,3 @@
-import "should";
 import { view, ViewOptions } from "../src/cmd-view";
 import {
   exampleRegistryUrl,

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -127,9 +127,10 @@ describe("cmd-view.ts", function () {
     it("view pkg", async function () {
       const retCode = await view(packageA, options);
       retCode.should.equal(0);
-      mockConsole
-        .hasLineIncluding("out", "com.example.package-a@1.0.0")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "com.example.package-a@1.0.0"
+      );
     });
     it("view pkg@1.0.0", async function () {
       const retCode = await view(
@@ -137,26 +138,28 @@ describe("cmd-view.ts", function () {
         options
       );
       retCode.should.equal(1);
-      mockConsole
-        .hasLineIncluding("out", "do not specify a version")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "do not specify a version"
+      );
     });
     it("view pkg-not-exist", async function () {
       const retCode = await view(packageMissing, options);
       retCode.should.equal(1);
-      mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("view pkg from upstream", async function () {
       const retCode = await view(packageUp, upstreamOptions);
       retCode.should.equal(0);
-      mockConsole
-        .hasLineIncluding("out", "com.example.package-up@1.0.0")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "com.example.package-up@1.0.0"
+      );
     });
     it("view pkg-not-exist from upstream", async function () {
       const retCode = await view(packageMissing, upstreamOptions);
       retCode.should.equal(1);
-      mockConsole.hasLineIncluding("out", "package not found").should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
   });
 });

--- a/test/domain-name.test.ts
+++ b/test/domain-name.test.ts
@@ -4,7 +4,6 @@ import {
   isInternalPackage,
   namespaceFor,
 } from "../src/types/domain-name";
-import should from "should";
 
 describe("domain-name", function () {
   describe("namespace", function () {
@@ -18,7 +17,7 @@ describe("domain-name", function () {
     ).forEach(([hostName, expected]) =>
       it(`"${hostName}" should become "${expected}"`, function () {
         const actual = namespaceFor(hostName);
-        should(actual).be.equal(expected);
+        expect(actual).toEqual(expected);
       })
     );
   });
@@ -31,7 +30,7 @@ describe("domain-name", function () {
       "dev.comradevanti123",
     ].forEach((s) =>
       it(`"${s}" should be domain-name`, () => {
-        should(isDomainName(s)).be.true();
+        expect(isDomainName(s)).toBeTruthy();
       })
     );
     [
@@ -47,19 +46,23 @@ describe("domain-name", function () {
       "com.unity-",
     ].forEach((s) =>
       it(`"${s}" should not be domain-name`, () => {
-        should(isDomainName(s)).be.false();
+        expect(isDomainName(s)).toBeFalsy();
       })
     );
   });
   describe("internal package", function () {
     it("test com.otherorg.software", function () {
-      isInternalPackage(domainName("com.otherorg.software")).should.not.be.ok();
+      expect(
+        isInternalPackage(domainName("com.otherorg.software"))
+      ).not.toBeTruthy();
     });
     it("test com.unity.ugui", function () {
-      isInternalPackage(domainName("com.unity.ugui")).should.be.ok();
+      expect(isInternalPackage(domainName("com.unity.ugui"))).toBeTruthy();
     });
     it("test com.unity.modules.tilemap", function () {
-      isInternalPackage(domainName("com.unity.modules.tilemap")).should.be.ok();
+      expect(
+        isInternalPackage(domainName("com.unity.modules.tilemap"))
+      ).toBeTruthy();
     });
   });
 });

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -4,19 +4,18 @@ import {
 } from "../src/types/editor-version";
 import "should";
 import assert from "assert";
-import should from "should";
 
 describe("editor-version", function () {
   describe("parseEditorVersion", function () {
     it("test x.y", function () {
       const version = tryParseEditorVersion("2019.2");
       assert(version !== null);
-      version.should.deepEqual({ major: 2019, minor: 2 });
+      expect(version).toEqual({ major: 2019, minor: 2 });
     });
     it("test x.y.z", function () {
       const version = tryParseEditorVersion("2019.2.1");
       assert(version !== null);
-      version.should.deepEqual({
+      expect(version).toEqual({
         major: 2019,
         minor: 2,
         patch: 1,
@@ -25,7 +24,7 @@ describe("editor-version", function () {
     it("test x.y.zan", function () {
       const version = tryParseEditorVersion("2019.2.1a5");
       assert(version !== null);
-      version.should.deepEqual({
+      expect(version).toEqual({
         major: 2019,
         minor: 2,
         patch: 1,
@@ -36,7 +35,7 @@ describe("editor-version", function () {
     it("test x.y.zbn", function () {
       const version = tryParseEditorVersion("2019.2.1b5");
       assert(version !== null);
-      version.should.deepEqual({
+      expect(version).toEqual({
         major: 2019,
         minor: 2,
         patch: 1,
@@ -47,7 +46,7 @@ describe("editor-version", function () {
     it("test x.y.zfn", function () {
       const version = tryParseEditorVersion("2019.2.1f5");
       assert(version !== null);
-      version.should.deepEqual({
+      expect(version).toEqual({
         major: 2019,
         minor: 2,
         patch: 1,
@@ -58,7 +57,7 @@ describe("editor-version", function () {
     it("test x.y.zcn", function () {
       const version = tryParseEditorVersion("2019.2.1f1c5");
       assert(version !== null);
-      version.should.deepEqual({
+      expect(version).toEqual({
         major: 2019,
         minor: 2,
         patch: 1,
@@ -69,7 +68,7 @@ describe("editor-version", function () {
       });
     });
     it("test invalid version", function () {
-      (tryParseEditorVersion("2019") === null).should.be.ok();
+      expect(tryParseEditorVersion("2019") === null).toBeTruthy();
     });
   });
 
@@ -81,7 +80,7 @@ describe("editor-version", function () {
       ["2019.1.1f1c1", "2019.1.1f1c1"]
     ).forEach(([a, b]) =>
       it(`${a} == ${b}`, function () {
-        should(tryCompareEditorVersion(a, b)).equal(0);
+        expect(tryCompareEditorVersion(a, b)).toEqual(0);
       })
     );
     Array.of<[string, string]>(
@@ -89,7 +88,7 @@ describe("editor-version", function () {
       ["2020.1", "2019.1"]
     ).forEach(([a, b]) =>
       it(`${a} > ${b}`, function () {
-        should(tryCompareEditorVersion(a, b)).equal(1);
+        expect(tryCompareEditorVersion(a, b)).toEqual(1);
       })
     );
     Array.of<[string, string]>(
@@ -102,7 +101,7 @@ describe("editor-version", function () {
       ["2019.1.1f1", "2020.1.1f1c1"]
     ).forEach(([a, b]) =>
       it(`${a} < ${b}`, function () {
-        should(tryCompareEditorVersion(a, b)).equal(-1);
+        expect(tryCompareEditorVersion(a, b)).toEqual(-1);
       })
     );
 
@@ -111,7 +110,7 @@ describe("editor-version", function () {
       ["not-a-version", "2020.1"]
     ).forEach(([a, b]) =>
       it(`should not be able to compare ${a} and ${b}`, function () {
-        should(tryCompareEditorVersion(a, b)).be.null();
+        expect(tryCompareEditorVersion(a, b)).toBeNull();
       })
     );
   });

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -2,7 +2,7 @@ import {
   tryCompareEditorVersion,
   tryParseEditorVersion,
 } from "../src/types/editor-version";
-import "should";
+
 import assert from "assert";
 
 describe("editor-version", function () {

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,4 +1,3 @@
-import "should";
 import { parseEnv } from "../src/utils/env";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { registryUrl } from "../src/types/registry-url";

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -69,9 +69,7 @@ describe("env", function () {
         true
       );
       should(env).be.null();
-      mockConsole
-        .hasLineIncluding("out", "can not resolve path")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding("out", "can not resolve path");
     });
 
     it("can not locate manifest.json", async function () {
@@ -81,9 +79,10 @@ describe("env", function () {
 
       const env = await parseEnv({ _global: {} }, true);
       should(env).be.null();
-      mockConsole
-        .hasLineIncluding("out", "can not locate manifest.json")
-        .should.be.ok();
+      expect(mockConsole).toHaveLineIncluding(
+        "out",
+        "can not locate manifest.json"
+      );
     });
     it("custom registry", async function () {
       const env = await parseEnv(

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,7 +1,6 @@
 import "should";
 import { parseEnv } from "../src/utils/env";
 import { attachMockConsole, MockConsole } from "./mock-console";
-import should from "should";
 import { registryUrl } from "../src/types/registry-url";
 import { TokenAuth, UPMConfig } from "../src/types/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
@@ -50,25 +49,25 @@ describe("env", function () {
 
     it("defaults", async function () {
       const env = await parseEnv({ _global: {} }, false);
-      should(env).not.be.null();
-      env!.registry.url.should.equal("https://package.openupm.com");
-      env!.upstream.should.be.ok();
-      env!.upstreamRegistry.url.should.equal("https://packages.unity.com");
-      env!.cwd.should.equal("");
-      (env!.editorVersion === null).should.be.ok();
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://package.openupm.com");
+      expect(env!.upstream).toBeTruthy();
+      expect(env!.upstreamRegistry.url).toEqual("https://packages.unity.com");
+      expect(env!.cwd).toEqual("");
+      expect(env!.editorVersion === null).toBeTruthy();
     });
 
     it("check path", async function () {
       const env = await parseEnv({ _global: {} }, true);
-      should(env).not.be.null();
-      env!.cwd.should.be.equal(mockProject.projectPath);
+      expect(env).not.toBeNull();
+      expect(env!.cwd).toEqual(mockProject.projectPath);
     });
     it("can not resolve path", async function () {
       const env = await parseEnv(
         { _global: { chdir: "/path-not-exist" } },
         true
       );
-      should(env).be.null();
+      expect(env).toBeNull();
       expect(mockConsole).toHaveLineIncluding("out", "can not resolve path");
     });
 
@@ -78,7 +77,7 @@ describe("env", function () {
       fse.rmSync(manifestPath);
 
       const env = await parseEnv({ _global: {} }, true);
-      should(env).be.null();
+      expect(env).toBeNull();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "can not locate manifest.json"
@@ -89,16 +88,16 @@ describe("env", function () {
         { _global: { registry: "https://registry.npmjs.org" } },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("https://registry.npmjs.org");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://registry.npmjs.org");
     });
     it("custom registry with splash", async function () {
       const env = await parseEnv(
         { _global: { registry: "https://registry.npmjs.org/" } },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("https://registry.npmjs.org");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://registry.npmjs.org");
     });
     it("custom registry with extra path", async function () {
       const env = await parseEnv(
@@ -109,8 +108,8 @@ describe("env", function () {
         },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("https://registry.npmjs.org/some");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://registry.npmjs.org/some");
     });
     it("custom registry with extra path and splash", async function () {
       const env = await parseEnv(
@@ -121,24 +120,24 @@ describe("env", function () {
         },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("https://registry.npmjs.org/some");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://registry.npmjs.org/some");
     });
     it("custom registry without http", async function () {
       const env = await parseEnv(
         { _global: { registry: "registry.npmjs.org" } },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("http://registry.npmjs.org");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("http://registry.npmjs.org");
     });
     it("custom registry with ipv4+port", async function () {
       const env = await parseEnv(
         { _global: { registry: "http://127.0.0.1:4873" } },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("http://127.0.0.1:4873");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("http://127.0.0.1:4873");
     });
     it("custom registry with ipv6+port", async function () {
       const env = await parseEnv(
@@ -147,8 +146,8 @@ describe("env", function () {
         },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("http://[1:2:3:4:5:6:7:8]:4873");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("http://[1:2:3:4:5:6:7:8]:4873");
     });
     it("should have registry auth if specified", async function () {
       const env = await parseEnv(
@@ -159,8 +158,8 @@ describe("env", function () {
         },
         true
       );
-      should(env).not.be.null();
-      should(env!.registry.auth).deepEqual(testNpmAuth);
+      expect(env).not.toBeNull();
+      expect(env!.registry.auth).toEqual(testNpmAuth);
     });
     it("should not have unspecified registry auth", async function () {
       const env = await parseEnv(
@@ -171,24 +170,24 @@ describe("env", function () {
         },
         true
       );
-      should(env).not.be.null();
-      should(env!.registry.auth).be.null();
+      expect(env).not.toBeNull();
+      expect(env!.registry.auth).toBeNull();
     });
     it("upstream", async function () {
       const env = await parseEnv({ _global: { upstream: false } }, false);
-      should(env).not.be.null();
-      env!.upstream.should.not.be.ok();
+      expect(env).not.toBeNull();
+      expect(env!.upstream).not.toBeTruthy();
     });
     it("editorVersion", async function () {
       const env = await parseEnv({ _global: {} }, true);
-      should(env).not.be.null();
-      should(env!.editorVersion).be.equal("2019.2.13f1");
+      expect(env).not.toBeNull();
+      expect(env!.editorVersion).toEqual("2019.2.13f1");
     });
     it("region cn", async function () {
       const env = await parseEnv({ _global: { cn: true } }, false);
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("https://package.openupm.cn");
-      env!.upstreamRegistry.url.should.be.equal("https://packages.unity.cn");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://package.openupm.cn");
+      expect(env!.upstreamRegistry.url).toEqual("https://packages.unity.cn");
     });
     it("region cn with a custom registry", async function () {
       const env = await parseEnv(
@@ -200,9 +199,9 @@ describe("env", function () {
         },
         false
       );
-      should(env).not.be.null();
-      env!.registry.url.should.be.equal("https://reg.custom-package.com");
-      env!.upstreamRegistry.url.should.be.equal("https://packages.unity.cn");
+      expect(env).not.toBeNull();
+      expect(env!.registry.url).toEqual("https://reg.custom-package.com");
+      expect(env!.upstreamRegistry.url).toEqual("https://packages.unity.cn");
     });
   });
 });

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -1,0 +1,11 @@
+import { Stream } from "./mock-console";
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveLineIncluding(stream: Stream, text: string): R;
+    }
+  }
+}
+
+export {};

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -1,9 +1,23 @@
 import { Stream } from "./mock-console";
+import { DomainName } from "../src/types/domain-name";
+import { SemanticVersion } from "../src/types/semantic-version";
+import { PackageUrl } from "../src/types/package-url";
 
 declare global {
   namespace jest {
     interface Matchers<R> {
       toHaveLineIncluding(stream: Stream, text: string): R;
+
+      toHaveDependency(
+        name: DomainName,
+        version?: SemanticVersion | PackageUrl
+      ): R;
+
+      toHaveDependencies(): R;
+
+      toHaveScope(scope: DomainName): R;
+
+      toHaveScopedRegistries(): R;
     }
   }
 }

--- a/test/mock-console-assertions.ts
+++ b/test/mock-console-assertions.ts
@@ -1,0 +1,12 @@
+import { MockConsole, Stream } from "./mock-console";
+
+expect.extend({
+  toHaveLineIncluding(mockConsole: MockConsole, stream: Stream, text: string) {
+    const hasLine = mockConsole.hasLineIncluding(stream, text);
+    return {
+      pass: hasLine,
+      message: () =>
+        `Expected mock-console to have "${text}" in its "${stream}" stream.`,
+    };
+  },
+});

--- a/test/mock-console.ts
+++ b/test/mock-console.ts
@@ -1,6 +1,6 @@
 import testConsole from "test-console";
 
-type Stream = "out" | "error";
+export type Stream = "out" | "error";
 
 export type MockConsole = {
   hasLineIncluding(stream: Stream, text: string): boolean;
@@ -21,3 +21,4 @@ export function attachMockConsole(): MockConsole {
     },
   };
 }
+

--- a/test/mock-console.ts
+++ b/test/mock-console.ts
@@ -21,4 +21,3 @@ export function attachMockConsole(): MockConsole {
     },
   };
 }
-

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -8,7 +8,6 @@ import {
   startMockRegistry,
   stopMockRegistry,
 } from "./mock-registry";
-import should from "should";
 import { buildPackument } from "./data-packument";
 import { domainName } from "../src/types/domain-name";
 import { makeNpmClient } from "../src/npm-client";
@@ -30,21 +29,21 @@ describe("registry-client", function () {
         { _global: { registry: exampleRegistryUrl } },
         false
       );
-      should(env).not.be.null();
+      expect(env).not.toBeNull();
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
       const info = await client.tryFetchPackument(env!.registry, packageA);
-      should(info).deepEqual(packumentRemote);
+      expect(info).toEqual(packumentRemote);
     });
     it("404", async function () {
       const env = await parseEnv(
         { _global: { registry: exampleRegistryUrl } },
         false
       );
-      should(env).not.be.null();
+      expect(env).not.toBeNull();
       registerMissingPackument(packageA);
       const info = await client.tryFetchPackument(env!.registry, packageA);
-      should(info).be.null();
+      expect(info).toBeNull();
     });
   });
 });

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -1,5 +1,5 @@
 import "assert";
-import "should";
+
 import { parseEnv } from "../src/utils/env";
 import {
   exampleRegistryUrl,

--- a/test/package-id.test.ts
+++ b/test/package-id.test.ts
@@ -1,11 +1,10 @@
-import should from "should";
 import { isPackageId } from "../src/types/package-id";
 
 describe("package-id", function () {
   describe("validate", function () {
     ["com.my-package@1.2.3"].forEach((s) =>
       it(`"${s}" should be package-id`, () => {
-        should(isPackageId(s)).be.true();
+        expect(isPackageId(s)).toBeTruthy();
       })
     );
 
@@ -19,7 +18,7 @@ describe("package-id", function () {
       "com.my-package@1.2",
     ].forEach((s) =>
       it(`"${s}" should not be package-id`, () => {
-        should(isPackageId(s)).be.false();
+        expect(isPackageId(s)).toBeFalsy();
       })
     );
   });

--- a/test/package-reference.test.ts
+++ b/test/package-reference.test.ts
@@ -1,4 +1,3 @@
-import should from "should";
 import {
   isPackageReference,
   packageReference,
@@ -14,7 +13,7 @@ describe("package-reference", function () {
       "com.abc.my-package@latest",
     ].forEach((input) =>
       it(`"${input}" should be package-reference`, function () {
-        should(isPackageReference(input)).be.true();
+        expect(isPackageReference(input)).toBeTruthy();
       })
     );
     [
@@ -22,7 +21,7 @@ describe("package-reference", function () {
       "-hello",
     ].forEach((input) =>
       it(`"${input}" should not be package-reference`, function () {
-        should(isPackageReference(input)).not.be.true();
+        expect(isPackageReference(input)).not.toBeTruthy();
       })
     );
   });
@@ -32,8 +31,8 @@ describe("package-reference", function () {
       const [actualName, actualVersion] = splitPackageReference(
         packageReference(name, version)
       );
-      should(actualName).be.equal(name);
-      should(actualVersion).be.equal(version);
+      expect(actualName).toEqual(name);
+      expect(actualVersion).toEqual(version);
     }
 
     it("should split package without version", () =>

--- a/test/package-url.test.ts
+++ b/test/package-url.test.ts
@@ -1,4 +1,3 @@
-import should from "should";
 import { isPackageUrl } from "../src/types/package-url";
 
 describe("package-url", function () {
@@ -9,13 +8,13 @@ describe("package-url", function () {
       "file../yo/com.base.package-a",
     ].forEach((url) =>
       it(`"${url}" is a package-url`, function () {
-        should(isPackageUrl(url)).be.true();
+        expect(isPackageUrl(url)).toBeTruthy();
       })
     );
 
     ["", "com.base.package.a"].forEach((url) =>
       it(`"${url}" is not a package-url`, function () {
-        should(isPackageUrl(url)).not.be.true();
+        expect(isPackageUrl(url)).not.toBeTruthy();
       })
     );
   });

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,6 +1,5 @@
 import { tryGetLatestVersion } from "../src/types/packument";
 import "should";
-import should from "should";
 import { semanticVersion } from "../src/types/semantic-version";
 
 describe("packument", function () {
@@ -9,7 +8,7 @@ describe("packument", function () {
       const version = tryGetLatestVersion({
         "dist-tags": { latest: semanticVersion("1.0.0") },
       });
-      should(version).equal("1.0.0");
+      expect(version).toEqual("1.0.0");
     });
   });
 });

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,5 +1,5 @@
 import { tryGetLatestVersion } from "../src/types/packument";
-import "should";
+
 import { semanticVersion } from "../src/types/semantic-version";
 
 describe("packument", function () {

--- a/test/project-manifest-assertions.ts
+++ b/test/project-manifest-assertions.ts
@@ -1,40 +1,54 @@
 import { DomainName } from "../src/types/domain-name";
 import { SemanticVersion } from "../src/types/semantic-version";
 import { PackageUrl } from "../src/types/package-url";
-import { hasScope } from "../src/types/scoped-registry";
 import { UnityProjectManifest } from "../src/types/project-manifest";
 
-export function shouldHaveDependency(
-  manifest: UnityProjectManifest,
-  name: DomainName,
-  version: SemanticVersion | PackageUrl
-) {
-  expect(manifest.dependencies[name]).toEqual(version);
-}
+expect.extend({
+  toHaveDependency(
+    manifest: UnityProjectManifest,
+    name: DomainName,
+    version?: SemanticVersion | PackageUrl
+  ) {
+    const dependency = manifest.dependencies[name];
+    const hasDependency =
+      dependency !== undefined &&
+      (version === undefined || dependency === version);
 
-export function shouldNotHaveAnyDependencies(manifest: UnityProjectManifest) {
-  expect(manifest.dependencies).toEqual({});
-}
+    return {
+      pass: hasDependency,
+      message: () =>
+        dependency === undefined
+          ? `Expected manifest to have dependency "${name}" but it was missing.`
+          : `Expected manifest to have dependency "${name}:${version}" but it had version "${dependency}".`,
+    };
+  },
 
-export function shouldNotHaveDependency(
-  manifest: UnityProjectManifest,
-  name: DomainName
-) {
-  expect(manifest.dependencies[name]).toBeUndefined();
-}
+  toHaveDependencies(manifest: UnityProjectManifest) {
+    const hasAnyDependency = Object.keys(manifest.dependencies).length > 0;
+    return {
+      pass: hasAnyDependency,
+      message: () => "Expected manifest to have any dependencies.",
+    };
+  },
 
-export function shouldHaveRegistryWithScopes(
-  manifest: UnityProjectManifest,
-  scopes: DomainName[]
-) {
-  expect(manifest.scopedRegistries).not.toBeUndefined();
-  expect(
-    manifest.scopedRegistries!.some((registry) =>
-      scopes.every((scope) => hasScope(registry, scope))
-    )
-  ).toBeTruthy();
-}
+  toHaveScope(manifest: UnityProjectManifest, scope: DomainName) {
+    const hasScope =
+      manifest.scopedRegistries !== undefined &&
+      manifest.scopedRegistries.some((registry) =>
+        registry.scopes.includes(scope)
+      );
+    return {
+      pass: hasScope,
+      message: () =>
+        `Expected manifest to have a scoped-registry with scope "${scope}".`,
+    };
+  },
 
-export function shouldNotHaveRegistries(manifest: UnityProjectManifest) {
-  expect(manifest.scopedRegistries).toBeUndefined();
-}
+  toHaveScopedRegistries(manifest: UnityProjectManifest) {
+    const hasScopedRegistries = manifest.scopedRegistries !== undefined;
+    return {
+      pass: hasScopedRegistries,
+      message: () => "Expected manifest to have scoped-registries.",
+    };
+  },
+});

--- a/test/project-manifest-assertions.ts
+++ b/test/project-manifest-assertions.ts
@@ -1,4 +1,3 @@
-import should from "should";
 import { DomainName } from "../src/types/domain-name";
 import { SemanticVersion } from "../src/types/semantic-version";
 import { PackageUrl } from "../src/types/package-url";
@@ -10,32 +9,32 @@ export function shouldHaveDependency(
   name: DomainName,
   version: SemanticVersion | PackageUrl
 ) {
-  should(manifest.dependencies[name]).equal(version);
+  expect(manifest.dependencies[name]).toEqual(version);
 }
 
 export function shouldNotHaveAnyDependencies(manifest: UnityProjectManifest) {
-  should(manifest.dependencies).be.empty();
+  expect(manifest.dependencies).toEqual({});
 }
 
 export function shouldNotHaveDependency(
   manifest: UnityProjectManifest,
   name: DomainName
 ) {
-  should(manifest.dependencies[name]).be.undefined();
+  expect(manifest.dependencies[name]).toBeUndefined();
 }
 
 export function shouldHaveRegistryWithScopes(
   manifest: UnityProjectManifest,
   scopes: DomainName[]
 ) {
-  should(manifest.scopedRegistries).not.be.undefined();
-  manifest
-    .scopedRegistries!.some((registry) =>
+  expect(manifest.scopedRegistries).not.toBeUndefined();
+  expect(
+    manifest.scopedRegistries!.some((registry) =>
       scopes.every((scope) => hasScope(registry, scope))
     )
-    .should.be.true("At least one scope was missing");
+  ).toBeTruthy();
 }
 
 export function shouldNotHaveRegistries(manifest: UnityProjectManifest) {
-  should(manifest.scopedRegistries).be.undefined();
+  expect(manifest.scopedRegistries).toBeUndefined();
 }

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -12,7 +12,6 @@ import {
   manifestPathFor,
   tryGetScopedRegistryByUrl,
 } from "../src/types/project-manifest";
-import should from "should";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import fse from "fs-extra";
 import path from "path";
@@ -43,11 +42,11 @@ describe("project-manifest io", () => {
 
   it("loadManifest", async () => {
     const manifest = await loadProjectManifest(mockProject.projectPath);
-    should(manifest).be.deepEqual({ dependencies: {} });
+    expect(manifest).toEqual({ dependencies: {} });
   });
   it("no manifest file", async () => {
     const manifest = await loadProjectManifest("/invalid-path");
-    should(manifest).be.null();
+    expect(manifest).toBeNull();
     expect(mockConsole).toHaveLineIncluding("out", "does not exist");
   });
   it("wrong json content", async () => {
@@ -55,7 +54,7 @@ describe("project-manifest io", () => {
     fse.writeFileSync(manifestPath, "invalid data");
 
     const manifest = await loadProjectManifest(mockProject.projectPath);
-    should(manifest).be.null();
+    expect(manifest).toBeNull();
     expect(mockConsole).toHaveLineIncluding("out", "failed to parse");
   });
   it("saveManifest", async () => {
@@ -66,16 +65,16 @@ describe("project-manifest io", () => {
       domainName("some-pack"),
       semanticVersion("1.0.0")
     );
-    (
+    expect(
       await saveProjectManifest(mockProject.projectPath, manifest)
-    ).should.be.ok();
+    ).toBeTruthy();
     const manifest2 = await loadProjectManifest(mockProject.projectPath);
-    should(manifest2).be.deepEqual(manifest);
+    expect(manifest2).toEqual(manifest);
   });
   it("manifest-path is correct", () => {
     const manifestPath = manifestPathFor("test-openupm-cli");
     const expected = path.join("test-openupm-cli", "Packages", "manifest.json");
-    should(manifestPath).be.equal(expected);
+    expect(manifestPath).toEqual(expected);
   });
   it("should not save scoped-registry with empty scopes", async () => {
     // Add and then remove a scope to force an empty scoped-registry
@@ -90,11 +89,11 @@ describe("project-manifest io", () => {
     removeScope(scopedRegistry, testDomain);
 
     // Save and load manifest
-    (
+    expect(
       await saveProjectManifest(mockProject.projectPath, initialManifest)
-    ).should.be.ok();
+    ).toBeTruthy();
     const savedManifest = await loadProjectManifest(mockProject.projectPath);
 
-    should(savedManifest?.scopedRegistries).be.empty();
+    expect(savedManifest?.scopedRegistries).toHaveLength(0);
   });
 });

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -1,5 +1,5 @@
 import { attachMockConsole, MockConsole } from "./mock-console";
-import "should";
+
 import {
   loadProjectManifest,
   saveProjectManifest,

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -48,7 +48,7 @@ describe("project-manifest io", () => {
   it("no manifest file", async () => {
     const manifest = await loadProjectManifest("/invalid-path");
     should(manifest).be.null();
-    mockConsole.hasLineIncluding("out", "does not exist").should.be.ok();
+    expect(mockConsole).toHaveLineIncluding("out", "does not exist");
   });
   it("wrong json content", async () => {
     const manifestPath = manifestPathFor(mockProject.projectPath);
@@ -56,7 +56,7 @@ describe("project-manifest io", () => {
 
     const manifest = await loadProjectManifest(mockProject.projectPath);
     should(manifest).be.null();
-    mockConsole.hasLineIncluding("out", "failed to parse").should.be.ok();
+    expect(mockConsole).toHaveLineIncluding("out", "failed to parse");
   });
   it("saveManifest", async () => {
     let manifest = (await loadProjectManifest(mockProject.projectPath))!;

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -4,7 +4,6 @@ import {
   loadProjectManifest,
   saveProjectManifest,
 } from "../src/utils/project-manifest-io";
-import { shouldNotHaveAnyDependencies } from "./project-manifest-assertions";
 import { DomainName, domainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import {
@@ -59,7 +58,7 @@ describe("project-manifest io", () => {
   });
   it("saveManifest", async () => {
     let manifest = (await loadProjectManifest(mockProject.projectPath))!;
-    shouldNotHaveAnyDependencies(manifest);
+    expect(manifest).not.toHaveDependencies();
     manifest = addDependency(
       manifest,
       domainName("some-pack"),

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -8,7 +8,6 @@ import {
 } from "../src/types/project-manifest";
 import { domainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
-import should from "should";
 import { scopedRegistry } from "../src/types/scoped-registry";
 import { registryUrl } from "../src/types/registry-url";
 
@@ -23,7 +22,7 @@ describe("project-manifest", function () {
         semanticVersion("1.2.3")
       );
 
-      should(manifest.dependencies).deepEqual({ test: "1.2.3" });
+      expect(manifest.dependencies).toEqual({ test: "1.2.3" });
     });
     it("should overwrite dependency when adding second time", () => {
       let manifest = emptyProjectManifest;
@@ -39,7 +38,7 @@ describe("project-manifest", function () {
         semanticVersion("2.3.4")
       );
 
-      should(manifest.dependencies).deepEqual({ test: "2.3.4" });
+      expect(manifest.dependencies).toEqual({ test: "2.3.4" });
     });
     it("should remove existing dependency", () => {
       let manifest = emptyProjectManifest;
@@ -51,14 +50,14 @@ describe("project-manifest", function () {
       );
       manifest = removeDependency(manifest, domainName("test"));
 
-      should(manifest.dependencies).deepEqual({});
+      expect(manifest.dependencies).toEqual({});
     });
     it("should do nothing when dependency does not exist", () => {
       let manifest = emptyProjectManifest;
 
       manifest = removeDependency(manifest, domainName("test"));
 
-      should(manifest.dependencies).deepEqual({});
+      expect(manifest.dependencies).toEqual({});
     });
   });
   describe("scoped-registry", function () {
@@ -69,7 +68,7 @@ describe("project-manifest", function () {
 
       manifest = addScopedRegistry(manifest, expected);
 
-      should(tryGetScopedRegistryByUrl(manifest, url)).be.deepEqual(expected);
+      expect(tryGetScopedRegistryByUrl(manifest, url)).toEqual(expected);
     });
     it("should should not find scoped-registry with incorrect url", () => {
       let manifest = emptyProjectManifest;
@@ -78,7 +77,7 @@ describe("project-manifest", function () {
 
       manifest = addScopedRegistry(manifest, expected);
 
-      should(tryGetScopedRegistryByUrl(manifest, url)).be.null();
+      expect(tryGetScopedRegistryByUrl(manifest, url)).toBeNull();
     });
   });
   describe("testables", function () {
@@ -88,7 +87,7 @@ describe("project-manifest", function () {
       manifest = addTestable(manifest, domainName("a"));
       manifest = addTestable(manifest, domainName("a"));
 
-      should(manifest.testables).deepEqual(["a"]);
+      expect(manifest.testables).toEqual(["a"]);
     });
     it("should add testables in alphabetical order", () => {
       let manifest = emptyProjectManifest;
@@ -96,7 +95,7 @@ describe("project-manifest", function () {
       manifest = addTestable(manifest, domainName("b"));
       manifest = addTestable(manifest, domainName("a"));
 
-      should(manifest.testables).deepEqual(["a", "b"]);
+      expect(manifest.testables).toEqual(["a", "b"]);
     });
   });
 });

--- a/test/registry-url.test.ts
+++ b/test/registry-url.test.ts
@@ -1,12 +1,11 @@
 import { coerceRegistryUrl, isRegistryUrl } from "../src/types/registry-url";
-import should from "should";
 
 describe("registry-url", function () {
   describe("validation", function () {
     ["http://registry.npmjs.org", "https://registry.npmjs.org"].forEach(
       (input) =>
         it(`"${input}" should be registry-url`, function () {
-          should(isRegistryUrl(input)).be.ok();
+          expect(isRegistryUrl(input)).toBeTruthy();
         })
     );
     [
@@ -16,16 +15,16 @@ describe("registry-url", function () {
       "http://registry.npmjs.org/",
     ].forEach((input) =>
       it(`"${input}" should not be registry-url`, function () {
-        should(isRegistryUrl(input)).not.be.ok();
+        expect(isRegistryUrl(input)).not.toBeTruthy();
       })
     );
   });
   describe("coerce", function () {
     it("should coerce urls without protocol", () => {
-      should(coerceRegistryUrl("test.com")).be.equal("http://test.com");
+      expect(coerceRegistryUrl("test.com")).toEqual("http://test.com");
     });
     it("should remove trailing slash", () => {
-      should(coerceRegistryUrl("http://test.com/")).be.equal("http://test.com");
+      expect(coerceRegistryUrl("http://test.com/")).toEqual("http://test.com");
     });
   });
 });

--- a/test/scoped-registry.test.ts
+++ b/test/scoped-registry.test.ts
@@ -5,39 +5,38 @@ import {
   scopedRegistry,
 } from "../src/types/scoped-registry";
 import { exampleRegistryUrl } from "./mock-registry";
-import should from "should";
 import { domainName } from "../src/types/domain-name";
 
 describe("scoped-registry", function () {
   describe("construction", function () {
     it("should have empty scopes list if scopes are not specified", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      should(registry.scopes).be.empty();
+      expect(registry.scopes).toHaveLength(0);
     });
   });
   describe("add scope", function () {
     it("should keep scope-list alphabetical", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      should(addScope(registry, domainName("b"))).be.true();
-      should(addScope(registry, domainName("a"))).be.true();
-      should(registry.scopes).be.deepEqual(["a", "b"]);
+      expect(addScope(registry, domainName("b"))).toBeTruthy();
+      expect(addScope(registry, domainName("a"))).toBeTruthy();
+      expect(registry.scopes).toEqual(["a", "b"]);
     });
     it("should filter duplicates", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      should(addScope(registry, domainName("a"))).be.true();
-      should(addScope(registry, domainName("a"))).be.false();
-      should(registry.scopes).be.deepEqual(["a"]);
+      expect(addScope(registry, domainName("a"))).toBeTruthy();
+      expect(addScope(registry, domainName("a"))).toBeFalsy();
+      expect(registry.scopes).toEqual(["a"]);
     });
   });
   describe("has scope", function () {
     it("should have scope that was added", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
       addScope(registry, domainName("a"));
-      should(hasScope(registry, domainName("a"))).be.true();
+      expect(hasScope(registry, domainName("a"))).toBeTruthy();
     });
     it("should not have scope that was not added", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      should(hasScope(registry, domainName("a"))).be.false();
+      expect(hasScope(registry, domainName("a"))).toBeFalsy();
     });
   });
   describe("remove scope", function () {
@@ -45,23 +44,23 @@ describe("scoped-registry", function () {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
       ]);
-      should(removeScope(registry, domainName("a"))).be.true();
-      should(hasScope(registry, domainName("a"))).be.false();
+      expect(removeScope(registry, domainName("a"))).toBeTruthy();
+      expect(hasScope(registry, domainName("a"))).toBeFalsy();
     });
     it("should not do nothing if scope does not exist", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
       ]);
-      should(removeScope(registry, domainName("b"))).be.false();
-      should(hasScope(registry, domainName("a"))).be.true();
+      expect(removeScope(registry, domainName("b"))).toBeFalsy();
+      expect(hasScope(registry, domainName("a"))).toBeTruthy();
     });
     it("should remove duplicate scopes", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
         domainName("a"),
       ]);
-      should(removeScope(registry, domainName("a"))).be.true();
-      should(registry.scopes).be.empty();
+      expect(removeScope(registry, domainName("a"))).toBeTruthy();
+      expect(registry.scopes).toHaveLength(0);
     });
   });
 });

--- a/test/semantic-version.test.ts
+++ b/test/semantic-version.test.ts
@@ -1,16 +1,15 @@
-import should from "should";
 import { isSemanticVersion } from "../src/types/semantic-version";
 
 describe("semantic-version", function () {
   describe("validate", function () {
     ["1.2.3", "1.2.3-alpha"].forEach((input) =>
       it(`"${input}" is a semantic version`, function () {
-        should(isSemanticVersion(input)).be.true();
+        expect(isSemanticVersion(input)).toBeTruthy();
       })
     );
     ["", " ", "wow", "1", "1.2"].forEach((input) =>
       it(`"${input}" is not a semantic version`, function () {
-        should(isSemanticVersion(input)).not.be.true();
+        expect(isSemanticVersion(input)).not.toBeTruthy();
       })
     );
   });

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -1,6 +1,5 @@
 import { runWithEnv } from "./mock-env";
 import { getUpmConfigDir } from "../src/utils/upm-config-io";
-import should from "should";
 
 describe("upm-config-io", function () {
   describe("get directory", function () {
@@ -15,7 +14,7 @@ describe("upm-config-io", function () {
           () => getUpmConfigDir(false, false)
         );
 
-        should(actual).be.equal(expected);
+        expect(actual).toEqual(expected);
       });
       it("should be HOME if defined and USERPROFILE is undefined", async function () {
         const expected = "user/dir";
@@ -27,12 +26,12 @@ describe("upm-config-io", function () {
           () => getUpmConfigDir(false, false)
         );
 
-        should(actual).be.equal(expected);
+        expect(actual).toEqual(expected);
       });
       it("should fail if HOME and USERPROFILE and undefined", async function () {
-        await should(
+        await expect(
           runWithEnv({}, () => getUpmConfigDir(false, false))
-        ).rejected();
+        ).rejects.toEqual(expect.any(Error));
       });
     });
   });

--- a/test/upm-config.test.ts
+++ b/test/upm-config.test.ts
@@ -11,7 +11,6 @@ import {
   UpmAuth,
   UPMConfig,
 } from "../src/types/upm-config";
-import should from "should";
 import { Base64 } from "../src/types/base64";
 import { registryUrl, RegistryUrl } from "../src/types/registry-url";
 import { NpmAuth } from "another-npm-registry-client";
@@ -27,7 +26,7 @@ describe("upm-config", function () {
           _auth: encodeBasicAuth("user", "pass"),
         };
         const config = addAuth(registry, auth, {});
-        should(tryGetAuthForRegistry(config, registry)).be.deepEqual(
+        expect(tryGetAuthForRegistry(config, registry)).toEqual(
           tryToNpmAuth(auth)
         );
       });
@@ -40,7 +39,7 @@ describe("upm-config", function () {
           // Not a real base64 string, but we don't care in this test
           _auth: "h8gz8s9zgseihgisejf" as Base64,
         };
-        should(isBasicAuth(auth)).be.true();
+        expect(isBasicAuth(auth)).toBeTruthy();
       });
       it("should be token auth if it has token property", () => {
         const auth: UpmAuth = {
@@ -49,7 +48,7 @@ describe("upm-config", function () {
           // Not a real token, but we don't care in this test
           token: "h8gz8s9zgseihgisejf",
         };
-        should(isTokenAuth(auth)).be.true();
+        expect(isTokenAuth(auth)).toBeTruthy();
       });
     });
     describe("encode/decode", function () {
@@ -58,13 +57,13 @@ describe("upm-config", function () {
         const expectedPassword = "123pass";
         const encoded = encodeBasicAuth(expectedUsername, expectedPassword);
         const [actualUsername, actualPassword] = tryDecodeBasicAuth(encoded)!;
-        should(actualUsername).be.equal(expectedUsername);
-        should(actualPassword).be.equal(expectedPassword);
+        expect(actualUsername).toEqual(expectedUsername);
+        expect(actualPassword).toEqual(expectedPassword);
       });
       it("should not decode invalid data", () => {
         const encoded = "This is not valid data" as Base64;
         const decoded = tryDecodeBasicAuth(encoded)!;
-        should(decoded).be.null();
+        expect(decoded).toBeNull();
       });
     });
     describe("always-auth", function () {
@@ -75,7 +74,7 @@ describe("upm-config", function () {
           // Not a real base64 string, but we don't care in this test
           _auth: "h8gz8s9zgseihgisejf" as Base64,
         };
-        should(shouldAlwaysAuth(auth)).be.true();
+        expect(shouldAlwaysAuth(auth)).toBeTruthy();
       });
       it("should not always-auth when prop is false", () => {
         const auth: UpmAuth = {
@@ -84,7 +83,7 @@ describe("upm-config", function () {
           // Not a real base64 string, but we don't care in this test
           _auth: "h8gz8s9zgseihgisejf" as Base64,
         };
-        should(shouldAlwaysAuth(auth)).be.false();
+        expect(shouldAlwaysAuth(auth)).toBeFalsy();
       });
       it("should not always-auth when prop is missing", () => {
         const auth: UpmAuth = {
@@ -92,7 +91,7 @@ describe("upm-config", function () {
           // Not a real base64 string, but we don't care in this test
           _auth: "h8gz8s9zgseihgisejf" as Base64,
         };
-        should(shouldAlwaysAuth(auth)).be.false();
+        expect(shouldAlwaysAuth(auth)).toBeFalsy();
       });
     });
     describe("get auth for registry", function () {
@@ -113,7 +112,7 @@ describe("upm-config", function () {
         };
 
         const actual = tryGetAuthForRegistry(config, url);
-        should(actual).be.deepEqual(expected);
+        expect(actual).toEqual(expected);
       });
       it("should find auth for url with trailing slash", function () {
         const url = "http://registry.npmjs.com/" as RegistryUrl;
@@ -132,7 +131,7 @@ describe("upm-config", function () {
         };
 
         const actual = tryGetAuthForRegistry(config, url);
-        should(actual).be.deepEqual(expected);
+        expect(actual).toEqual(expected);
       });
       it("should not find auth for url that does not exist", function () {
         const config: UPMConfig = {
@@ -149,7 +148,7 @@ describe("upm-config", function () {
           config,
           registryUrl("http://registryB.com")
         );
-        should(actual).be.null();
+        expect(actual).toBeNull();
       });
     });
   });


### PR DESCRIPTION
Migrates the test-suite from should to jests builtin assertion library. This also includes adding a few custom matchers.