### PR TITLE
refactor: use normalized result-type

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   verbose: true,
   setupFilesAfterEnv: [
       "./test/mock-console-assertions.ts",
-      "./test/project-manifest-assertions.ts"
+      "./test/project-manifest-assertions.ts",
+      "./test/result-assertions.ts"
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.19.11",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@badrap/result": "^0.2.13",
         "@commander-js/extra-typings": "^9.5.0",
         "@iarna/toml": "^2.2.5",
         "another-npm-registry-client": "^8.7.0",
@@ -27,6 +26,7 @@
         "semver": "^7.5.4",
         "ts-brand": "^0.0.2",
         "ts-custom-error": "^3.3.1",
+        "ts-results-es": "^4.1.0",
         "update-notifier": "^5.1.0",
         "yaml": "^2.2.2"
       },
@@ -780,11 +780,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@badrap/result": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@badrap/result/-/result-0.2.13.tgz",
-      "integrity": "sha512-Qvyzz0dmGY0h8pwvBFo1BznAKf5Y5NXIDiqhPALWtfU7oHbAToCtPu4FlYQ3uysskSWLx8GUiyhe0nv0nDd/7Q=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -11792,6 +11787,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-results-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts-results-es/-/ts-results-es-4.1.0.tgz",
+      "integrity": "sha512-7V37C/Zzx2K2U48fpC7jiQc5aDFZJoGD6sQ6EZgeoHqdTTIHy8yVB8+oXZx268hz9qJa0oUCrc1OAyPJH5Q8MQ=="
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
@@ -12756,11 +12756,6 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
-    },
-    "@badrap/result": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@badrap/result/-/result-0.2.13.tgz",
-      "integrity": "sha512-Qvyzz0dmGY0h8pwvBFo1BznAKf5Y5NXIDiqhPALWtfU7oHbAToCtPu4FlYQ3uysskSWLx8GUiyhe0nv0nDd/7Q=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -20205,6 +20200,11 @@
           "dev": true
         }
       }
+    },
+    "ts-results-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts-results-es/-/ts-results-es-4.1.0.tgz",
+      "integrity": "sha512-7V37C/Zzx2K2U48fpC7jiQc5aDFZJoGD6sQ6EZgeoHqdTTIHy8yVB8+oXZx268hz9qJa0oUCrc1OAyPJH5Q8MQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.19.11",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@badrap/result": "^0.2.13",
         "@commander-js/extra-typings": "^9.5.0",
         "@iarna/toml": "^2.2.5",
         "another-npm-registry-client": "^8.7.0",
@@ -25,6 +26,7 @@
         "promptly": "^3.2.0",
         "semver": "^7.5.4",
         "ts-brand": "^0.0.2",
+        "ts-custom-error": "^3.3.1",
         "update-notifier": "^5.1.0",
         "yaml": "^2.2.2"
       },
@@ -778,6 +780,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@badrap/result": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@badrap/result/-/result-0.2.13.tgz",
+      "integrity": "sha512-Qvyzz0dmGY0h8pwvBFo1BznAKf5Y5NXIDiqhPALWtfU7oHbAToCtPu4FlYQ3uysskSWLx8GUiyhe0nv0nDd/7Q=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -11725,6 +11732,14 @@
       "resolved": "https://registry.npmjs.org/ts-brand/-/ts-brand-0.0.2.tgz",
       "integrity": "sha512-UhSzWY4On9ZHIj6DKkRYVN/8OaprbLAZ3b/Y2AJwdl6oozSABsQ0PvwDh4vOVdkvOtWQOkIrjctZ1kj8YfF3jA=="
     },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.1.2",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
@@ -12741,6 +12756,11 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@badrap/result": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@badrap/result/-/result-0.2.13.tgz",
+      "integrity": "sha512-Qvyzz0dmGY0h8pwvBFo1BznAKf5Y5NXIDiqhPALWtfU7oHbAToCtPu4FlYQ3uysskSWLx8GUiyhe0nv0nDd/7Q=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -20156,6 +20176,11 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/ts-brand/-/ts-brand-0.0.2.tgz",
       "integrity": "sha512-UhSzWY4On9ZHIj6DKkRYVN/8OaprbLAZ3b/Y2AJwdl6oozSABsQ0PvwDh4vOVdkvOtWQOkIrjctZ1kj8YfF3jA=="
+    },
+    "ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="
     },
     "ts-jest": {
       "version": "29.1.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@badrap/result": "^0.2.13",
     "@commander-js/extra-typings": "^9.5.0",
     "@iarna/toml": "^2.2.5",
     "another-npm-registry-client": "^8.7.0",
@@ -82,6 +83,7 @@
     "promptly": "^3.2.0",
     "semver": "^7.5.4",
     "ts-brand": "^0.0.2",
+    "ts-custom-error": "^3.3.1",
     "update-notifier": "^5.1.0",
     "yaml": "^2.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@badrap/result": "^0.2.13",
     "@commander-js/extra-typings": "^9.5.0",
     "@iarna/toml": "^2.2.5",
     "another-npm-registry-client": "^8.7.0",
@@ -84,6 +83,7 @@
     "semver": "^7.5.4",
     "ts-brand": "^0.0.2",
     "ts-custom-error": "^3.3.1",
+    "ts-results-es": "^4.1.0",
     "update-notifier": "^5.1.0",
     "yaml": "^2.2.2"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,8 +109,8 @@ program
   .aliases(["s", "se", "find"])
   .description("Search package by keyword")
   .action(async function (keyword, options) {
-    const retCode = await search(keyword, makeCmdOptions(options));
-    if (retCode !== 0) process.exit(retCode);
+    const searchResult = await search(keyword, makeCmdOptions(options));
+    if (searchResult.isErr()) process.exit(1);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,8 +151,8 @@ program
   )
   .description("authenticate with a scoped registry")
   .action(async function (options) {
-    const retCode = await login(makeCmdOptions(options));
-    if (retCode !== 0) process.exit(retCode);
+    const loginResult = await login(makeCmdOptions(options));
+    if (loginResult.isErr()) process.exit(1);
   });
 
 // prompt for invalid command

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,8 +83,8 @@ openupm add <pkg>@<version> [otherPkgs...]`
   )
   .action(async function (pkg, otherPkgs, options) {
     const pkgs = [pkg].concat(otherPkgs);
-    const retCode = await add(pkgs, makeCmdOptions(options));
-    if (retCode !== 0) process.exit(retCode);
+    const addResult = await add(pkgs, makeCmdOptions(options));
+    if (addResult.isErr()) process.exit(1);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,8 +134,8 @@ openupm deps <pkg>
 openupm deps <pkg>@<version>`
   )
   .action(async function (pkg, options) {
-    const retCode = await deps(pkg, makeCmdOptions(options));
-    if (retCode !== 0) process.exit(retCode);
+    const depsResult = await deps(pkg, makeCmdOptions(options));
+    if (depsResult.isErr()) process.exit(1);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,8 +99,8 @@ program
   .description("remove package from manifest json")
   .action(async function (pkg, otherPkgs, options) {
     const pkgs = [pkg].concat(otherPkgs);
-    const retCode = await remove(pkgs, makeCmdOptions(options));
-    if (retCode !== 0) process.exit(retCode);
+    const removeResult = await remove(pkgs, makeCmdOptions(options));
+    if (removeResult.isErr()) process.exit(1);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,7 +120,7 @@ program
   .description("view package information")
   .action(async function (pkg, options) {
     const result = await view(pkg, makeCmdOptions(options));
-    if (!result.isOk()) process.exit(1);
+    if (result.isErr()) process.exit(1);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,8 +119,8 @@ program
   .aliases(["v", "info", "show"])
   .description("view package information")
   .action(async function (pkg, options) {
-    const retCode = await view(pkg, makeCmdOptions(options));
-    if (retCode !== 0) process.exit(retCode);
+    const result = await view(pkg, makeCmdOptions(options));
+    if (!result.isOk()) process.exit(1);
   });
 
 program

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -67,8 +67,10 @@ export const add = async function (
     const [name, requestedVersion] = splitPackageReference(pkg);
 
     // load manifest
-    let manifest = await loadProjectManifest(env.cwd);
-    if (manifest === null) return { code: 1, dirty: false };
+    const manifestResult = await loadProjectManifest(env.cwd);
+    if (!manifestResult.isOk) return { code: 1, dirty: false };
+    let manifest = manifestResult.value;
+
     // packages that added to scope registry
     const pkgsInScope = Array.of<DomainName>();
     let versionToAdd = requestedVersion;
@@ -178,7 +180,7 @@ export const add = async function (
             depObj.reason instanceof VersionNotFoundError
           ) {
             // Not sure why it thinks the manifest can be null here.
-            const resolvedVersion = manifest!.dependencies[depObj.name];
+            const resolvedVersion = manifest.dependencies[depObj.name];
             const wasResolved = Boolean(resolvedVersion);
             if (!wasResolved) {
               isAnyDependencyUnresolved = true;

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -84,7 +84,7 @@ export const add = async function (
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return Err([envResult.error]);
+  if (envResult.isErr()) return Err([envResult.error]);
   const env = envResult.value;
 
   const client = makeNpmClient();
@@ -99,7 +99,7 @@ export const add = async function (
 
     // load manifest
     const loadResult = await tryLoadProjectManifest(env.cwd);
-    if (!loadResult.isOk()) return loadResult;
+    if (loadResult.isErr()) return loadResult;
     let manifest = loadResult.value;
 
     // packages that added to scope registry
@@ -112,7 +112,7 @@ export const add = async function (
         requestedVersion,
         env.registry
       );
-      if (!resolveResult.isOk() && env.upstream) {
+      if (resolveResult.isErr() && env.upstream) {
         resolveResult = await tryResolve(
           client,
           name,
@@ -122,7 +122,7 @@ export const add = async function (
         if (resolveResult.isOk()) isUpstreamPackage = true;
       }
 
-      if (!resolveResult.isOk()) {
+      if (resolveResult.isErr()) {
         if (resolveResult.error instanceof PackumentNotFoundError)
           log.error("404", `package not found: ${name}`);
         else if (resolveResult.error instanceof VersionNotFoundError) {

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -249,7 +249,7 @@ export const add = async function (
     if (options.test) manifest = addTestable(manifest, name);
     // save manifest
     if (dirty) {
-      if (!(await saveProjectManifest(env.cwd, manifest)))
+      if (!(await saveProjectManifest(env.cwd, manifest)).isOk)
         return { code: 1, dirty };
     }
     return { code: 0, dirty };

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -55,7 +55,7 @@ export const add = async function (
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk) return 1;
+  if (!envResult.isOk()) return 1;
   const env = envResult.value;
 
   const client = makeNpmClient();
@@ -68,7 +68,7 @@ export const add = async function (
 
     // load manifest
     const manifestResult = await tryLoadProjectManifest(env.cwd);
-    if (!manifestResult.isOk) return { code: 1, dirty: false };
+    if (!manifestResult.isOk()) return { code: 1, dirty: false };
     let manifest = manifestResult.value;
 
     // packages that added to scope registry
@@ -81,17 +81,17 @@ export const add = async function (
         requestedVersion,
         env.registry
       );
-      if (!resolveResult.isOk && env.upstream) {
+      if (!resolveResult.isOk() && env.upstream) {
         resolveResult = await tryResolve(
           client,
           name,
           requestedVersion,
           env.upstreamRegistry
         );
-        if (resolveResult.isOk) isUpstreamPackage = true;
+        if (resolveResult.isOk()) isUpstreamPackage = true;
       }
 
-      if (!resolveResult.isOk) {
+      if (!resolveResult.isOk()) {
         if (resolveResult.error instanceof PackumentNotFoundError)
           log.error("404", `package not found: ${name}`);
         else if (resolveResult.error instanceof VersionNotFoundError) {
@@ -249,7 +249,7 @@ export const add = async function (
     if (options.test) manifest = addTestable(manifest, name);
     // save manifest
     if (dirty) {
-      if (!(await trySaveProjectManifest(env.cwd, manifest)).isOk)
+      if (!(await trySaveProjectManifest(env.cwd, manifest)).isOk())
         return { code: 1, dirty };
     }
     return { code: 0, dirty };

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -54,8 +54,9 @@ export const add = async function (
 ): Promise<AddResultCode> {
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
-  const env = await parseEnv(options, true);
-  if (env === null) return 1;
+  const envResult = await parseEnv(options, true);
+  if (!envResult.isOk) return 1;
+  const env = envResult.value;
 
   const client = makeNpmClient();
 

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -2,8 +2,8 @@ import log from "./logger";
 import url from "url";
 import { isPackageUrl, PackageUrl } from "./types/package-url";
 import {
-  loadProjectManifest,
-  saveProjectManifest,
+  tryLoadProjectManifest,
+  trySaveProjectManifest,
 } from "./utils/project-manifest-io";
 import { parseEnv } from "./utils/env";
 import {
@@ -67,7 +67,7 @@ export const add = async function (
     const [name, requestedVersion] = splitPackageReference(pkg);
 
     // load manifest
-    const manifestResult = await loadProjectManifest(env.cwd);
+    const manifestResult = await tryLoadProjectManifest(env.cwd);
     if (!manifestResult.isOk) return { code: 1, dirty: false };
     let manifest = manifestResult.value;
 
@@ -249,7 +249,7 @@ export const add = async function (
     if (options.test) manifest = addTestable(manifest, name);
     // save manifest
     if (dirty) {
-      if (!(await saveProjectManifest(env.cwd, manifest)).isOk)
+      if (!(await trySaveProjectManifest(env.cwd, manifest)).isOk)
         return { code: 1, dirty };
     }
     return { code: 0, dirty };

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -26,12 +26,12 @@ import {
 } from "./types/project-manifest";
 import { CmdOptions } from "./types/options";
 import {
-  PackumentNotFoundError,
   tryResolve,
   VersionNotFoundError,
 } from "./packument-resolving";
 import { SemanticVersion } from "./types/semantic-version";
 import { fetchPackageDependencies } from "./dependency-resolving";
+import {PackumentNotFoundError} from "./common-errors";
 
 export type AddOptions = CmdOptions<{
   test?: boolean;

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -9,11 +9,11 @@ import {
 } from "./types/package-reference";
 import { CmdOptions } from "./types/options";
 import {
-  PackumentNotFoundError,
   PackumentResolveError,
   VersionNotFoundError,
 } from "./packument-resolving";
 import { fetchPackageDependencies } from "./dependency-resolving";
+import {PackumentNotFoundError} from "./common-errors";
 
 type DepsResultCode = 0 | 1;
 

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -38,7 +38,7 @@ export const deps = async function (
 ): Promise<Result<void, DepsError>> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return envResult;
+  if (envResult.isErr()) return envResult;
   const env = envResult.value;
 
   const client = makeNpmClient();

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -37,7 +37,7 @@ export const deps = async function (
 ): Promise<DepsResultCode> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk) return 1;
+  if (!envResult.isOk()) return 1;
   const env = envResult.value;
 
   const client = makeNpmClient();

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -1,5 +1,5 @@
 import log from "./logger";
-import { parseEnv } from "./utils/env";
+import { EnvParseError, parseEnv } from "./utils/env";
 import { makeNpmClient } from "./npm-client";
 import { isPackageUrl } from "./types/package-url";
 import {
@@ -13,9 +13,10 @@ import {
   VersionNotFoundError,
 } from "./packument-resolving";
 import { fetchPackageDependencies } from "./dependency-resolving";
-import {PackumentNotFoundError} from "./common-errors";
+import { PackumentNotFoundError } from "./common-errors";
+import { Ok, Result } from "ts-results-es";
 
-type DepsResultCode = 0 | 1;
+export type DepsError = EnvParseError;
 
 export type DepsOptions = CmdOptions<{
   deep?: boolean;
@@ -34,10 +35,10 @@ function errorPrefixForError(error: PackumentResolveError): string {
 export const deps = async function (
   pkg: PackageReference,
   options: DepsOptions
-): Promise<DepsResultCode> {
+): Promise<Result<void, DepsError>> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return 1;
+  if (!envResult.isOk()) return envResult;
   const env = envResult.value;
 
   const client = makeNpmClient();
@@ -67,5 +68,5 @@ export const deps = async function (
       log.warn(prefix, x.name);
     });
 
-  return 0;
+  return Ok(undefined);
 };

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -8,7 +8,11 @@ import {
   splitPackageReference,
 } from "./types/package-reference";
 import { CmdOptions } from "./types/options";
-import { ResolveFailure } from "./packument-resolving";
+import {
+  PackumentNotFoundError,
+  PackumentResolveError,
+  VersionNotFoundError,
+} from "./packument-resolving";
 import { fetchPackageDependencies } from "./dependency-resolving";
 
 type DepsResultCode = 0 | 1;
@@ -17,9 +21,10 @@ export type DepsOptions = CmdOptions<{
   deep?: boolean;
 }>;
 
-function errorPrefixForIssue(issue: ResolveFailure["issue"]): string {
-  if (issue === "PackumentNotFound") return "missing dependency";
-  else if (issue === "VersionNotFound") return "missing dependency version";
+function errorPrefixForError(error: PackumentResolveError): string {
+  if (error instanceof PackumentNotFoundError) return "missing dependency";
+  else if (error instanceof VersionNotFoundError)
+    return "missing dependency version";
   return "unknown";
 }
 
@@ -57,7 +62,7 @@ export const deps = async function (
   depsInvalid
     .filter((x) => !x.self)
     .forEach((x) => {
-      const prefix = errorPrefixForIssue(x.reason.issue);
+      const prefix = errorPrefixForError(x.reason);
       log.warn(prefix, x.name);
     });
 

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -36,8 +36,9 @@ export const deps = async function (
   options: DepsOptions
 ): Promise<DepsResultCode> {
   // parse env
-  const env = await parseEnv(options, false);
-  if (env === null) return 1;
+  const envResult = await parseEnv(options, true);
+  if (!envResult.isOk) return 1;
+  const env = envResult.value;
 
   const client = makeNpmClient();
 

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -31,8 +31,9 @@ export const login = async function (
   options: LoginOptions
 ): Promise<LoginResultCode> {
   // parse env
-  const env = await parseEnv(options, false);
-  if (env === null) return 1;
+  const envResult = await parseEnv(options, true);
+  if (!envResult.isOk) return 1;
+  const env = envResult.value;
   // query parameters
   const username = options.username ?? (await promptUsername());
   const password = options.password ?? (await promptPassword());

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -42,7 +42,7 @@ export const login = async function (
 ): Promise<Result<void, LoginError>> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return envResult;
+  if (envResult.isErr()) return envResult;
   const env = envResult.value;
 
   // query parameters
@@ -58,7 +58,7 @@ export const login = async function (
   const alwaysAuth = options.alwaysAuth || false;
 
   const configDirResult = await tryGetUpmConfigDir(env.wsl, env.systemUser);
-  if (!configDirResult.isOk()) return configDirResult;
+  if (configDirResult.isErr()) return configDirResult;
   const configDir = configDirResult.value;
 
   if (options.basicAuth) {

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -46,7 +46,9 @@ export const login = async function (
 
   const alwaysAuth = options.alwaysAuth || false;
 
-  const configDir = await getUpmConfigDir(env.wsl, env.systemUser);
+  const configDirResult = await getUpmConfigDir(env.wsl, env.systemUser);
+  if (!configDirResult.isOk) return 1;
+  const configDir = configDirResult.value;
 
   if (options.basicAuth) {
     // basic auth

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { makeNpmClient } from "./npm-client";
 import log from "./logger";
-import { tryStoreUpmAuth, tryGetUpmConfigDir } from "./utils/upm-config-io";
+import { tryGetUpmConfigDir, tryStoreUpmAuth } from "./utils/upm-config-io";
 import { parseEnv } from "./utils/env";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "./types/upm-config";
 import { coerceRegistryUrl, RegistryUrl } from "./types/registry-url";
@@ -32,7 +32,7 @@ export const login = async function (
 ): Promise<LoginResultCode> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk) return 1;
+  if (!envResult.isOk()) return 1;
   const env = envResult.value;
   // query parameters
   const username = options.username ?? (await promptUsername());
@@ -47,7 +47,7 @@ export const login = async function (
   const alwaysAuth = options.alwaysAuth || false;
 
   const configDirResult = await tryGetUpmConfigDir(env.wsl, env.systemUser);
-  if (!configDirResult.isOk) return 1;
+  if (!configDirResult.isOk()) return 1;
   const configDir = configDirResult.value;
 
   if (options.basicAuth) {
@@ -58,7 +58,7 @@ export const login = async function (
       alwaysAuth,
       _auth,
     } satisfies BasicAuth);
-    if (result.isErr) return 1;
+    if (result.isErr()) return 1;
   } else {
     // npm login
     const result = await npmLogin(username, password, email, loginRegistry);
@@ -75,7 +75,7 @@ export const login = async function (
       alwaysAuth,
       token,
     } satisfies TokenAuth);
-    if (storeResult.isErr) return 1;
+    if (storeResult.isErr()) return 1;
   }
 
   return 0;
@@ -98,7 +98,7 @@ const npmLogin = async function (
   const client = makeNpmClient();
   const result = await client.addUser(registry, username, password, email);
 
-  if (result.isOk) {
+  if (result.isOk()) {
     log.notice("auth", `you are authenticated as '${username}'`);
     return { code: 0, token: result.value };
   }

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { makeNpmClient } from "./npm-client";
 import log from "./logger";
-import { storeUpmAuth, tryGetUpmConfigDir } from "./utils/upm-config-io";
+import { tryStoreUpmAuth, tryGetUpmConfigDir } from "./utils/upm-config-io";
 import { parseEnv } from "./utils/env";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "./types/upm-config";
 import { coerceRegistryUrl, RegistryUrl } from "./types/registry-url";
@@ -53,7 +53,7 @@ export const login = async function (
   if (options.basicAuth) {
     // basic auth
     const _auth = encodeBasicAuth(username, password);
-    const result = await storeUpmAuth(configDir, loginRegistry, {
+    const result = await tryStoreUpmAuth(configDir, loginRegistry, {
       email,
       alwaysAuth,
       _auth,
@@ -70,7 +70,7 @@ export const login = async function (
     const token = result.token;
     // write npm token
     await writeNpmToken(loginRegistry, result.token);
-    const storeResult = await storeUpmAuth(configDir, loginRegistry, {
+    const storeResult = await tryStoreUpmAuth(configDir, loginRegistry, {
       email,
       alwaysAuth,
       token,

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { makeNpmClient } from "./npm-client";
 import log from "./logger";
-import { getUpmConfigDir, storeUpmAuth } from "./utils/upm-config-io";
+import { tryGetUpmConfigDir, storeUpmAuth } from "./utils/upm-config-io";
 import { parseEnv } from "./utils/env";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "./types/upm-config";
 import { coerceRegistryUrl, RegistryUrl } from "./types/registry-url";
@@ -46,7 +46,7 @@ export const login = async function (
 
   const alwaysAuth = options.alwaysAuth || false;
 
-  const configDirResult = await getUpmConfigDir(env.wsl, env.systemUser);
+  const configDirResult = await tryGetUpmConfigDir(env.wsl, env.systemUser);
   if (!configDirResult.isOk) return 1;
   const configDir = configDirResult.value;
 

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -93,16 +93,16 @@ const npmLogin = async function (
   const client = makeNpmClient();
   const result = await client.addUser(registry, username, password, email);
 
-  if (result.isSuccess) {
+  if (result.isOk) {
     log.notice("auth", `you are authenticated as '${username}'`);
-    return { code: 0, token: result.token };
+    return { code: 0, token: result.value };
   }
 
-  if (result.status === 401) {
+  if (result.error.status === 401) {
     log.warn("401", "Incorrect username or password");
     return { code: 1 };
   } else {
-    log.error(result.status.toString(), result.message);
+    log.error(result.error.status.toString(), result.error.message);
     return { code: 1 };
   }
 };

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -1,7 +1,7 @@
 import log from "./logger";
 import {
-  loadProjectManifest,
-  saveProjectManifest,
+  tryLoadProjectManifest,
+  trySaveProjectManifest,
 } from "./utils/project-manifest-io";
 import { parseEnv } from "./utils/env";
 import {
@@ -46,7 +46,7 @@ export const remove = async function (
       return { code: 1, dirty };
     }
     // load manifest
-    const manifestResult = await loadProjectManifest(env.cwd);
+    const manifestResult = await tryLoadProjectManifest(env.cwd);
     if (!manifestResult.isOk) return { code: 1, dirty };
     let manifest = manifestResult.value;
 
@@ -69,7 +69,7 @@ export const remove = async function (
     }
     // save manifest
     if (dirty) {
-      if (!(await saveProjectManifest(env.cwd, manifest)).isOk)
+      if (!(await trySaveProjectManifest(env.cwd, manifest)).isOk)
         return { code: 1, dirty };
     }
     if (pkgsNotFound.length) {

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -40,7 +40,7 @@ export const remove = async function (
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return Err([envResult.error]);
+  if (envResult.isErr()) return Err([envResult.error]);
   const env = envResult.value;
 
   const removeSingle = async function (
@@ -53,7 +53,7 @@ export const remove = async function (
     }
     // load manifest
     const manifestResult = await tryLoadProjectManifest(env.cwd);
-    if (!manifestResult.isOk()) return manifestResult;
+    if (manifestResult.isErr()) return manifestResult;
     let manifest = manifestResult.value;
 
     // not found array

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -32,7 +32,7 @@ export const remove = async function (
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk) return 1;
+  if (!envResult.isOk()) return 1;
   const env = envResult.value;
 
   const removeSingle = async function (
@@ -47,7 +47,7 @@ export const remove = async function (
     }
     // load manifest
     const manifestResult = await tryLoadProjectManifest(env.cwd);
-    if (!manifestResult.isOk) return { code: 1, dirty };
+    if (!manifestResult.isOk()) return { code: 1, dirty };
     let manifest = manifestResult.value;
 
     // not found array
@@ -69,7 +69,7 @@ export const remove = async function (
     }
     // save manifest
     if (dirty) {
-      if (!(await trySaveProjectManifest(env.cwd, manifest)).isOk)
+      if (!(await trySaveProjectManifest(env.cwd, manifest)).isOk())
         return { code: 1, dirty };
     }
     if (pkgsNotFound.length) {

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -31,8 +31,9 @@ export const remove = async function (
 ): Promise<RemoveResultCode> {
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
-  const env = await parseEnv(options, true);
-  if (env === null) return 1;
+  const envResult = await parseEnv(options, true);
+  if (!envResult.isOk) return 1;
+  const env = envResult.value;
 
   const removeSingle = async function (
     pkg: PackageReference

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -46,8 +46,10 @@ export const remove = async function (
       return { code: 1, dirty };
     }
     // load manifest
-    let manifest = await loadProjectManifest(env.cwd);
-    if (manifest === null) return { code: 1, dirty };
+    const manifestResult = await loadProjectManifest(env.cwd);
+    if (!manifestResult.isOk) return { code: 1, dirty };
+    let manifest = manifestResult.value;
+
     // not found array
     const pkgsNotFound = Array.of<PackageReference>();
     const versionInManifest = manifest.dependencies[pkg];

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -69,7 +69,7 @@ export const remove = async function (
     }
     // save manifest
     if (dirty) {
-      if (!(await saveProjectManifest(env.cwd, manifest)))
+      if (!(await saveProjectManifest(env.cwd, manifest)).isOk)
         return { code: 1, dirty };
     }
     if (pkgsNotFound.length) {

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -55,7 +55,7 @@ export async function search(
 ): Promise<Result<void, SearchError>> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return envResult;
+  if (envResult.isErr()) return envResult;
   const env = envResult.value;
 
   const npmClient = makeNpmClient();

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -31,7 +31,7 @@ const searchOld = async function (
   registry: Registry,
   keyword: string
 ): Promise<SearchedPackument[] | null> {
-  const results = await npmClient.tryGetAll(registry);
+  const results = (await npmClient.tryGetAll(registry)).unwrapOr(null);
   let packuments = Array.of<SearchedPackument>();
 
   if (results === null) return null;

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -56,7 +56,7 @@ export async function search(
 ): Promise<SearchResultCode> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk) return 1;
+  if (!envResult.isOk()) return 1;
   const env = envResult.value;
 
   const npmClient = makeNpmClient();

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -21,9 +21,9 @@ const searchEndpoint = async function (
 ): Promise<SearchedPackument[] | null> {
   const results = await npmClient.trySearch(registry, keyword);
 
-  if (results !== null) log.verbose("npmsearch", results.join(os.EOL));
+  if (results.isOk()) log.verbose("npmsearch", results.value.join(os.EOL));
 
-  return results;
+  return results.unwrapOr(null);
 };
 
 const searchOld = async function (

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -55,8 +55,9 @@ export async function search(
   options: SearchOptions
 ): Promise<SearchResultCode> {
   // parse env
-  const env = await parseEnv(options, false);
-  if (env === null) return 1;
+  const envResult = await parseEnv(options, true);
+  if (!envResult.isOk) return 1;
+  const env = envResult.value;
 
   const npmClient = makeNpmClient();
 

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -24,7 +24,7 @@ export const view = async function (
 ): Promise<Result<void, ViewError>> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return envResult;
+  if (envResult.isErr()) return envResult;
   const env = envResult.value;
 
   const client = makeNpmClient();

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -17,8 +17,10 @@ export const view = async function (
   options: ViewOptions
 ): Promise<ViewResultCode> {
   // parse env
-  const env = await parseEnv(options, false);
-  if (env === null) return 1;
+  const envResult = await parseEnv(options, true);
+  if (!envResult.isOk) return 1;
+  const env = envResult.value;
+
   const client = makeNpmClient();
 
   // parse name

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -2,24 +2,35 @@ import chalk from "chalk";
 import log from "./logger";
 import assert from "assert";
 import { tryGetLatestVersion, UnityPackument } from "./types/packument";
-import { parseEnv } from "./utils/env";
+import { EnvParseError, parseEnv } from "./utils/env";
 import { makeNpmClient } from "./npm-client";
 import { hasVersion, PackageReference } from "./types/package-reference";
 import { CmdOptions } from "./types/options";
 import { recordKeys } from "./utils/record-utils";
-import { AsyncResult, Ok } from "ts-results-es";
+import { AsyncResult, Err, Ok, Result } from "ts-results-es";
+import { CustomError } from "ts-custom-error";
+
+import { PackumentNotFoundError } from "./common-errors";
+
+export class PackageWithVersionError extends CustomError {
+  constructor() {
+    super(
+      "A package-reference including a version was specified when only a name was expected."
+    );
+  }
+}
 
 export type ViewOptions = CmdOptions;
 
-type ViewResultCode = 0 | 1;
+export type ViewError = EnvParseError | PackageWithVersionError;
 
 export const view = async function (
   pkg: PackageReference,
   options: ViewOptions
-): Promise<ViewResultCode> {
+): Promise<Result<void, ViewError>> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk()) return 1;
+  if (!envResult.isOk()) return envResult;
   const env = envResult.value;
 
   const client = makeNpmClient();
@@ -27,27 +38,26 @@ export const view = async function (
   // parse name
   if (hasVersion(pkg)) {
     log.warn("", `please do not specify a version (Write only '${pkg}').`);
-    return 1;
+    return Err(new PackageWithVersionError());
   }
   // verify name
-  return (
-    await new AsyncResult(client.tryFetchPackument(env.registry, pkg))
-      .andThen(async (packument) => {
-        if (packument === null && env.upstream)
-          return await client.tryFetchPackument(env.upstreamRegistry, pkg);
-        return Ok(packument);
-      })
-      .map((packument) => {
-        if (packument === null) {
-          log.error("404", `package not found: ${pkg}`);
-          return 1;
-        }
-        // print info
-        printInfo(packument);
-        return 0;
-      })
-      .orElse(() => Ok(1)).promise
-  ).unwrap();
+  return await new AsyncResult(client.tryFetchPackument(env.registry, pkg))
+    .andThen(async (packument) => {
+      if (packument === null && env.upstream)
+        return await client.tryFetchPackument(env.upstreamRegistry, pkg);
+      return Ok(packument);
+    })
+    .andThen((packument) => {
+      if (packument === null) {
+        log.error("404", `package not found: ${pkg}`);
+        return Err(new PackumentNotFoundError());
+      }
+      return Ok(packument);
+    })
+    .map((packument) => {
+      // print info
+      printInfo(packument);
+    }).promise;
 };
 
 const printInfo = function (packument: UnityPackument) {

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -8,17 +8,11 @@ import { hasVersion, PackageReference } from "./types/package-reference";
 import { CmdOptions } from "./types/options";
 import { recordKeys } from "./utils/record-utils";
 import { AsyncResult, Err, Ok, Result } from "ts-results-es";
-import { CustomError } from "ts-custom-error";
 
-import { PackumentNotFoundError } from "./common-errors";
-
-export class PackageWithVersionError extends CustomError {
-  constructor() {
-    super(
-      "A package-reference including a version was specified when only a name was expected."
-    );
-  }
-}
+import {
+  PackageWithVersionError,
+  PackumentNotFoundError,
+} from "./common-errors";
 
 export type ViewOptions = CmdOptions;
 

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -18,7 +18,7 @@ export const view = async function (
 ): Promise<ViewResultCode> {
   // parse env
   const envResult = await parseEnv(options, true);
-  if (!envResult.isOk) return 1;
+  if (!envResult.isOk()) return 1;
   const env = envResult.value;
 
   const client = makeNpmClient();

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -1,0 +1,7 @@
+import { CustomError } from "ts-custom-error";
+
+export class RequiredFileNotFoundError extends CustomError {
+  constructor(readonly path: string) {
+    super(`The required file at "${path}" could not be found.`);
+  }
+}

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -23,3 +23,11 @@ export class PackumentNotFoundError extends CustomError {
     super("A packument was not found.");
   }
 }
+
+export class PackageWithVersionError extends CustomError {
+  constructor() {
+    super(
+      "A package-reference including a version was specified when only a name was expected."
+    );
+  }
+}

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -14,3 +14,12 @@ export class IOError extends CustomError {
     super("An interaction with the file-system caused an error.", { cause });
   }
 }
+
+/**
+ * Error for when the packument was not found.
+ */
+export class PackumentNotFoundError extends CustomError {
+  constructor() {
+    super("A packument was not found.");
+  }
+}

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -5,3 +5,12 @@ export class RequiredFileNotFoundError extends CustomError {
     super(`The required file at "${path}" could not be found.`);
   }
 }
+
+/**
+ * Generic IO error for when interacting with the file-system failed.
+ */
+export class IOError extends CustomError {
+  constructor(cause?: Error) {
+    super("An interaction with the file-system caused an error.", { cause });
+  }
+}

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -96,22 +96,16 @@ export const fetchPackageDependencies = async function (
     version: ResolvableVersion
   ) {
     // First try cache
-    let resolveResult = tryResolveFromCache(
+    const cacheResult = tryResolveFromCache(
       packumentCache,
       registry.url,
       packumentName,
       version
     );
+    if (cacheResult.isOk()) return cacheResult;
+
     // Then registry
-    if (!resolveResult.isOk()) {
-      resolveResult = await tryResolve(
-        client,
-        packumentName,
-        version,
-        registry
-      );
-    }
-    return resolveResult;
+    return await tryResolve(client, packumentName, version, registry);
   }
 
   while (pendingList.length > 0) {

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -103,7 +103,7 @@ export const fetchPackageDependencies = async function (
       version
     );
     // Then registry
-    if (!resolveResult.isOk) {
+    if (!resolveResult.isOk()) {
       resolveResult = await tryResolve(
         client,
         packumentName,
@@ -136,18 +136,18 @@ export const fetchPackageDependencies = async function (
           entry.version
         );
         // Then upstream registry
-        if (!resolveResult.isOk) {
+        if (!resolveResult.isOk()) {
           const upstreamResult = await tryResolveFromRegistry(
             upstreamRegistry,
             entry.name,
             entry.version
           );
-          if (upstreamResult.isOk) resolveResult = upstreamResult;
+          if (upstreamResult.isOk()) resolveResult = upstreamResult;
           else resolveResult = pickMostFixable(resolveResult, upstreamResult);
         }
 
         // If none resolved successfully, log the most fixable failure
-        if (!resolveResult.isOk) {
+        if (!resolveResult.isOk()) {
           if (resolveResult.error instanceof PackumentNotFoundError) {
             log.warn("404", `package not found: ${entry.name}`);
           } else if (resolveResult.error instanceof VersionNotFoundError) {

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -4,7 +4,6 @@ import log from "./logger";
 import { packageReference } from "./types/package-reference";
 import { addToCache, emptyPackumentCache } from "./packument-cache";
 import {
-  PackumentNotFoundError,
   PackumentResolveError,
   pickMostFixable,
   ResolvableVersion,
@@ -16,6 +15,7 @@ import { unityRegistryUrl } from "./types/registry-url";
 import { recordEntries } from "./utils/record-utils";
 import assert from "assert";
 import { NpmClient, Registry } from "./npm-client";
+import {PackumentNotFoundError} from "./common-errors";
 
 export type DependencyBase = {
   /**

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -15,7 +15,7 @@ import { unityRegistryUrl } from "./types/registry-url";
 import { recordEntries } from "./utils/record-utils";
 import assert from "assert";
 import { NpmClient, Registry } from "./npm-client";
-import {PackumentNotFoundError} from "./common-errors";
+import { PackumentNotFoundError } from "./common-errors";
 
 export type DependencyBase = {
   /**
@@ -130,7 +130,7 @@ export const fetchPackageDependencies = async function (
           entry.version
         );
         // Then upstream registry
-        if (!resolveResult.isOk()) {
+        if (resolveResult.isErr()) {
           const upstreamResult = await tryResolveFromRegistry(
             upstreamRegistry,
             entry.name,
@@ -141,7 +141,7 @@ export const fetchPackageDependencies = async function (
         }
 
         // If none resolved successfully, log the most fixable failure
-        if (!resolveResult.isOk()) {
+        if (resolveResult.isErr()) {
           if (resolveResult.error instanceof PackumentNotFoundError) {
             log.warn("404", `package not found: ${entry.name}`);
           } else if (resolveResult.error instanceof VersionNotFoundError) {

--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -35,11 +35,6 @@ export class AuthenticationError extends CustomError {
 type AuthenticationToken = string;
 
 /**
- * The result of adding a user.
- */
-type AddUserResult = Result<AuthenticationToken, AuthenticationError>;
-
-/**
  * A type representing a searched packument. Instead of having all versions
  * this type only includes the latest version.
  */
@@ -84,7 +79,7 @@ export interface NpmClient {
     username: string,
     email: string,
     password: string
-  ): Promise<AddUserResult>;
+  ): Promise<Result<AuthenticationToken, AuthenticationError>>;
 
   /**
    * Attempts to search a npm registry.

--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -8,9 +8,7 @@ import npmSearch from "libnpmsearch";
 import { is404Error, isHttpError } from "./utils/error-type-guards";
 import npmFetch from "npm-registry-fetch";
 import { CustomError } from "ts-custom-error";
-import { Result } from "@badrap/result";
-import err = Result.err;
-import ok = Result.ok;
+import { Err, Ok, Result } from "ts-results-es";
 
 /**
  * Error for when authentication failed.
@@ -149,14 +147,14 @@ export const makeNpmClient = (): NpmClient => {
           (error, responseData, _, response) => {
             if (error !== null || !responseData.ok)
               resolve(
-                err(
+                Err(
                   new AuthenticationError(
                     response.statusCode,
                     response.statusMessage
                   )
                 )
               );
-            else resolve(ok(responseData.token));
+            else resolve(Ok(responseData.token));
           }
         );
       });

--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -89,7 +89,7 @@ export interface NpmClient {
   trySearch(
     registry: Registry,
     keyword: string
-  ): Promise<SearchedPackument[] | null>;
+  ): Promise<Result<SearchedPackument[], HttpErrorBase>>;
 
   /**
    * Attempts to query the /-/all endpoint.
@@ -162,19 +162,17 @@ export const makeNpmClient = (): NpmClient => {
       });
     },
 
-    async trySearch(
-      registry: Registry,
-      keyword: string
-    ): Promise<SearchedPackument[] | null> {
+    async trySearch(registry, keyword) {
       try {
         // NOTE: The results of the search will be Packument objects so we can change the type
-        return (await npmSearch(
+        const packuments = (await npmSearch(
           keyword,
           getNpmFetchOptions(registry)
         )) as SearchedPackument[];
-      } catch (err) {
-        if (isHttpError(err) && !is404Error(err)) log.error("", err.message);
-        return null;
+        return Ok(packuments);
+      } catch (error) {
+        assertIsHttpError(error);
+        return Err(error);
       }
     },
 

--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -5,7 +5,7 @@ import { DomainName } from "./types/domain-name";
 import { SemanticVersion } from "./types/semantic-version";
 import { RegistryUrl } from "./types/registry-url";
 import npmSearch from "libnpmsearch";
-import { assertIsHttpError, is404Error } from "./utils/error-type-guards";
+import { assertIsHttpError } from "./utils/error-type-guards";
 import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
 import { CustomError } from "ts-custom-error";
 import { Err, Ok, Result } from "ts-results-es";
@@ -93,7 +93,7 @@ export interface NpmClient {
    */
   tryGetAll(
     registry: Registry
-  ): Promise<Result<AllPackumentsResult | null, HttpErrorBase>>;
+  ): Promise<Result<AllPackumentsResult, HttpErrorBase>>;
 }
 
 export type Registry = Readonly<{
@@ -183,7 +183,6 @@ export const makeNpmClient = (): NpmClient => {
         return Ok(result);
       } catch (error) {
         assertIsHttpError(error);
-        if (is404Error(error)) return Ok(null);
         return Err(error);
       }
     },

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -1,19 +1,20 @@
-import { VersionReference } from "./types/package-reference";
-import { NpmClient, Registry } from "./npm-client";
-import { DomainName } from "./types/domain-name";
-import { SemanticVersion } from "./types/semantic-version";
+import {VersionReference} from "./types/package-reference";
+import {NpmClient, Registry} from "./npm-client";
+import {DomainName} from "./types/domain-name";
+import {SemanticVersion} from "./types/semantic-version";
 import {
   tryGetLatestVersion,
   UnityPackument,
   UnityPackumentVersion,
 } from "./types/packument";
-import { recordKeys } from "./utils/record-utils";
-import { PackageUrl } from "./types/package-url";
-import { PackumentCache, tryGetFromCache } from "./packument-cache";
-import { RegistryUrl } from "./types/registry-url";
-import { CustomError } from "ts-custom-error";
-import { Err, Ok, Result } from "ts-results-es";
-import { HttpErrorBase } from "npm-registry-fetch";
+import {recordKeys} from "./utils/record-utils";
+import {PackageUrl} from "./types/package-url";
+import {PackumentCache, tryGetFromCache} from "./packument-cache";
+import {RegistryUrl} from "./types/registry-url";
+import {CustomError} from "ts-custom-error";
+import {Err, Ok, Result} from "ts-results-es";
+import {HttpErrorBase} from "npm-registry-fetch";
+import {PackumentNotFoundError} from "./common-errors";
 
 /**
  * A version-reference that is resolvable.
@@ -39,15 +40,6 @@ interface ResolvedPackument {
    * The source from which the packument was resolved.
    */
   readonly source: RegistryUrl;
-}
-
-/**
- * Error for when the packument was not found on the searched registry.
- */
-export class PackumentNotFoundError extends CustomError {
-  constructor() {
-    super("A packument was not found on a registry.");
-  }
 }
 
 /**

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -1,20 +1,20 @@
-import {VersionReference} from "./types/package-reference";
-import {NpmClient, Registry} from "./npm-client";
-import {DomainName} from "./types/domain-name";
-import {SemanticVersion} from "./types/semantic-version";
+import { VersionReference } from "./types/package-reference";
+import { NpmClient, Registry } from "./npm-client";
+import { DomainName } from "./types/domain-name";
+import { SemanticVersion } from "./types/semantic-version";
 import {
   tryGetLatestVersion,
   UnityPackument,
   UnityPackumentVersion,
 } from "./types/packument";
-import {recordKeys} from "./utils/record-utils";
-import {PackageUrl} from "./types/package-url";
-import {PackumentCache, tryGetFromCache} from "./packument-cache";
-import {RegistryUrl} from "./types/registry-url";
-import {CustomError} from "ts-custom-error";
-import {Err, Ok, Result} from "ts-results-es";
-import {HttpErrorBase} from "npm-registry-fetch";
-import {PackumentNotFoundError} from "./common-errors";
+import { recordKeys } from "./utils/record-utils";
+import { PackageUrl } from "./types/package-url";
+import { PackumentCache, tryGetFromCache } from "./packument-cache";
+import { RegistryUrl } from "./types/registry-url";
+import { CustomError } from "ts-custom-error";
+import { Err, Ok, Result } from "ts-results-es";
+import { HttpErrorBase } from "npm-registry-fetch";
+import { PackumentNotFoundError } from "./common-errors";
 
 /**
  * A version-reference that is resolvable.

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,8 +1,8 @@
 import log from "../logger";
 import chalk from "chalk";
 import {
-  tryGetUpmConfigDir,
   GetUpmConfigDirError,
+  tryGetUpmConfigDir,
   tryLoadUpmConfig,
 } from "./upm-config-io";
 import path from "path";
@@ -13,11 +13,9 @@ import { tryGetAuthForRegistry } from "../types/upm-config";
 import { CmdOptions } from "../types/options";
 import { manifestPathFor } from "../types/project-manifest";
 import { Registry } from "../npm-client";
-import { Result } from "@badrap/result";
 import { CustomError } from "ts-custom-error";
-import ok = Result.ok;
-import err = Result.err;
 import { RequiredFileNotFoundError } from "../common-errors";
+import { Err, Ok, Result } from "ts-results-es";
 
 export type Env = Readonly<{
   cwd: string;
@@ -92,7 +90,7 @@ export const parseEnv = async function (
   if (options._global.wsl) wsl = true;
 
   const configDirResult = await tryGetUpmConfigDir(wsl, systemUser);
-  if (!configDirResult.isOk) return err(configDirResult.error);
+  if (!configDirResult.isOk()) return Err(configDirResult.error);
   const configDir = configDirResult.value;
 
   const upmConfig = await tryLoadUpmConfig(configDir);
@@ -109,7 +107,7 @@ export const parseEnv = async function (
   }
   // return if no need to check path
   if (!checkPath)
-    return ok({
+    return Ok({
       cwd,
       editorVersion,
       registry,
@@ -123,7 +121,7 @@ export const parseEnv = async function (
     cwd = path.resolve(options._global.chdir);
     if (!fs.existsSync(cwd)) {
       log.error("env", `can not resolve path ${cwd}`);
-      return err(new CwdNotFoundError());
+      return Err(new CwdNotFoundError());
     }
   } else cwd = process.cwd();
   // manifest path
@@ -133,7 +131,7 @@ export const parseEnv = async function (
       "manifest",
       `can not locate manifest.json at path ${manifestPath}`
     );
-    return err(new RequiredFileNotFoundError(manifestPath));
+    return Err(new RequiredFileNotFoundError(manifestPath));
   }
 
   // editor version
@@ -165,7 +163,7 @@ export const parseEnv = async function (
     editorVersion = projectVersionContent.m_EditorVersion;
   }
   // return
-  return ok({
+  return Ok({
     cwd,
     editorVersion,
     registry,

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -17,7 +17,7 @@ import { Result } from "@badrap/result";
 import { CustomError } from "ts-custom-error";
 import ok = Result.ok;
 import err = Result.err;
-import {RequiredFileNotFoundError} from "../common-errors";
+import { RequiredFileNotFoundError } from "../common-errors";
 
 export type Env = Readonly<{
   cwd: string;
@@ -97,7 +97,7 @@ export const parseEnv = async function (
 
   const upmConfig = await loadUpmConfig(configDir);
 
-  if (upmConfig !== undefined && upmConfig.npmAuth !== undefined) {
+  if (upmConfig !== null && upmConfig.npmAuth !== undefined) {
     registry = {
       url: registry.url,
       auth: tryGetAuthForRegistry(upmConfig, registry.url),

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -11,6 +11,7 @@ import { manifestPathFor } from "../types/project-manifest";
 import { Registry } from "../npm-client";
 import { Result } from "@badrap/result";
 import { CustomError } from "ts-custom-error";
+import { ManifestNotFoundError } from "./project-manifest-io";
 import ok = Result.ok;
 import err = Result.err;
 
@@ -25,8 +26,6 @@ export type Env = Readonly<{
 }>;
 
 export class CwdNotFoundError extends CustomError {}
-
-export class ManifestNotFoundError extends CustomError {}
 
 export type EnvParseError = CwdNotFoundError;
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -90,7 +90,7 @@ export const parseEnv = async function (
   if (options._global.wsl) wsl = true;
 
   const configDirResult = await tryGetUpmConfigDir(wsl, systemUser);
-  if (!configDirResult.isOk()) return Err(configDirResult.error);
+  if (configDirResult.isErr()) return Err(configDirResult.error);
   const configDir = configDirResult.value;
 
   const upmConfig = await tryLoadUpmConfig(configDir);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -31,15 +31,13 @@ export class CwdNotFoundError extends CustomError {}
 
 export type EnvParseError = CwdNotFoundError | GetUpmConfigDirError;
 
-export type EnvParseResult = Result<Env, EnvParseError>;
-
 /**
  * Attempts to parse env.
  */
 export const parseEnv = async function (
   options: CmdOptions,
   checkPath: boolean
-): Promise<EnvParseResult> {
+): Promise<Result<Env, EnvParseError>> {
   // set defaults
   let registry: Registry = {
     url: registryUrl("https://package.openupm.com"),

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,7 @@
 import log from "../logger";
 import chalk from "chalk";
 import {
-  getUpmConfigDir,
+  tryGetUpmConfigDir,
   GetUpmConfigDirError,
   loadUpmConfig,
 } from "./upm-config-io";
@@ -91,7 +91,7 @@ export const parseEnv = async function (
   if (options._global.systemUser) systemUser = true;
   if (options._global.wsl) wsl = true;
 
-  const configDirResult = await getUpmConfigDir(wsl, systemUser);
+  const configDirResult = await tryGetUpmConfigDir(wsl, systemUser);
   if (!configDirResult.isOk) return err(configDirResult.error);
   const configDir = configDirResult.value;
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import {
   tryGetUpmConfigDir,
   GetUpmConfigDirError,
-  loadUpmConfig,
+  tryLoadUpmConfig,
 } from "./upm-config-io";
 import path from "path";
 import fs from "fs";
@@ -95,7 +95,7 @@ export const parseEnv = async function (
   if (!configDirResult.isOk) return err(configDirResult.error);
   const configDir = configDirResult.value;
 
-  const upmConfig = await loadUpmConfig(configDir);
+  const upmConfig = await tryLoadUpmConfig(configDir);
 
   if (upmConfig !== null && upmConfig.npmAuth !== undefined) {
     registry = {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -15,9 +15,9 @@ import { manifestPathFor } from "../types/project-manifest";
 import { Registry } from "../npm-client";
 import { Result } from "@badrap/result";
 import { CustomError } from "ts-custom-error";
-import { ManifestNotFoundError } from "./project-manifest-io";
 import ok = Result.ok;
 import err = Result.err;
+import {RequiredFileNotFoundError} from "../common-errors";
 
 export type Env = Readonly<{
   cwd: string;
@@ -133,7 +133,7 @@ export const parseEnv = async function (
       "manifest",
       `can not locate manifest.json at path ${manifestPath}`
     );
-    return err(new ManifestNotFoundError());
+    return err(new RequiredFileNotFoundError(manifestPath));
   }
 
   // editor version

--- a/src/utils/error-type-guards.ts
+++ b/src/utils/error-type-guards.ts
@@ -18,6 +18,12 @@ export function assertIsError(x: unknown): asserts x is ErrnoException {
     });
 }
 
+export function assertIsHttpError(x: unknown): asserts x is HttpErrorBase {
+  assertIsError(x);
+  if (!("statusCode" in x))
+    throw new AssertionError({ message: "Argument was not an HTTP-error." });
+}
+
 export const isHttpError = (x: unknown): x is HttpErrorBase => {
   return x instanceof Error && "statusCode" in x;
 };

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -18,20 +18,13 @@ export type ManifestLoadError = RequiredFileNotFoundError | ManifestParseError;
 
 export type ManifestSaveError = Error;
 
-export type ManifestLoadResult = Result<
-  UnityProjectManifest,
-  ManifestLoadError
->;
-
-export type ManifestSaveResult = Result<void, ManifestSaveError>;
-
 /**
  * Attempts to load the manifest for a Unity project.
  * @param projectPath The path to the root of the project.
  */
 export const tryLoadProjectManifest = async function (
   projectPath: string
-): Promise<ManifestLoadResult> {
+): Promise<Result<UnityProjectManifest, ManifestLoadError>> {
   const manifestPath = manifestPathFor(projectPath);
   try {
     const text = await fs.readFile(manifestPath, { encoding: "utf8" });
@@ -58,7 +51,7 @@ export const tryLoadProjectManifest = async function (
 export const trySaveProjectManifest = async function (
   projectPath: string,
   manifest: UnityProjectManifest
-): Promise<ManifestSaveResult> {
+): Promise<Result<void, ManifestSaveError>> {
   const manifestPath = manifestPathFor(projectPath);
   manifest = pruneManifest(manifest);
   const json = JSON.stringify(manifest, null, 2);

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -8,11 +8,9 @@ import {
 } from "../types/project-manifest";
 import fse from "fs-extra";
 import path from "path";
-import { Result } from "@badrap/result";
 import { CustomError } from "ts-custom-error";
 import { RequiredFileNotFoundError } from "../common-errors";
-import err = Result.err;
-import ok = Result.ok;
+import { Err, Ok, Result } from "ts-results-es";
 
 export class ManifestParseError extends CustomError {}
 
@@ -38,16 +36,16 @@ export const tryLoadProjectManifest = async function (
   try {
     const text = await fs.readFile(manifestPath, { encoding: "utf8" });
     // TODO: Actually validate the content of the file
-    return ok(JSON.parse(text) as UnityProjectManifest);
+    return Ok(JSON.parse(text) as UnityProjectManifest);
   } catch (error) {
     assertIsError(error);
     if (error.code === "ENOENT") {
       log.error("manifest", `manifest at ${manifestPath} does not exist`);
-      return err(new RequiredFileNotFoundError(manifestPath));
+      return Err(new RequiredFileNotFoundError(manifestPath));
     } else {
       log.error("manifest", `failed to parse manifest at ${manifestPath}`);
       log.error("manifest", error.message);
-      return err(new ManifestParseError());
+      return Err(new ManifestParseError());
     }
   }
 };
@@ -67,11 +65,11 @@ export const trySaveProjectManifest = async function (
   try {
     await fse.ensureDir(path.dirname(manifestPath));
     await fs.writeFile(manifestPath, json);
-    return ok(undefined);
+    return Ok(undefined);
   } catch (error) {
     assertIsError(error);
     log.error("manifest", "can not write manifest json file");
     log.error("manifest", error.message);
-    return err(error);
+    return Err(error);
   }
 };

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -19,10 +19,14 @@ export class ManifestParseError extends CustomError {}
 
 export type ManifestLoadError = ManifestNotFoundError | ManifestParseError;
 
+export type ManifestSaveError = Error;
+
 export type ManifestLoadResult = Result<
   UnityProjectManifest,
   ManifestLoadError
 >;
+
+export type ManifestSaveResult = Result<void, ManifestSaveError>;
 
 /**
  * Attempts to load the manifest for a Unity project.
@@ -57,18 +61,18 @@ export const loadProjectManifest = async function (
 export const saveProjectManifest = async function (
   projectPath: string,
   manifest: UnityProjectManifest
-) {
+): Promise<ManifestSaveResult> {
   const manifestPath = manifestPathFor(projectPath);
   manifest = pruneManifest(manifest);
   const json = JSON.stringify(manifest, null, 2);
   try {
     await fse.ensureDir(path.dirname(manifestPath));
     await fs.writeFile(manifestPath, json);
-    return true;
-  } catch (err) {
-    assertIsError(err);
+    return ok(undefined);
+  } catch (error) {
+    assertIsError(error);
     log.error("manifest", "can not write manifest json file");
-    log.error("manifest", err.message);
-    return false;
+    log.error("manifest", error.message);
+    return err(error);
   }
 };

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -32,7 +32,7 @@ export type ManifestSaveResult = Result<void, ManifestSaveError>;
  * Attempts to load the manifest for a Unity project.
  * @param projectPath The path to the root of the project.
  */
-export const loadProjectManifest = async function (
+export const tryLoadProjectManifest = async function (
   projectPath: string
 ): Promise<ManifestLoadResult> {
   const manifestPath = manifestPathFor(projectPath);
@@ -58,7 +58,7 @@ export const loadProjectManifest = async function (
  * @param projectPath The path to the projects root directory.
  * @param manifest The manifest to save.
  */
-export const saveProjectManifest = async function (
+export const trySaveProjectManifest = async function (
   projectPath: string,
   manifest: UnityProjectManifest
 ): Promise<ManifestSaveResult> {

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -10,14 +10,13 @@ import fse from "fs-extra";
 import path from "path";
 import { Result } from "@badrap/result";
 import { CustomError } from "ts-custom-error";
+import { RequiredFileNotFoundError } from "../common-errors";
 import err = Result.err;
 import ok = Result.ok;
 
-export class ManifestNotFoundError extends CustomError {}
-
 export class ManifestParseError extends CustomError {}
 
-export type ManifestLoadError = ManifestNotFoundError | ManifestParseError;
+export type ManifestLoadError = RequiredFileNotFoundError | ManifestParseError;
 
 export type ManifestSaveError = Error;
 
@@ -44,7 +43,7 @@ export const tryLoadProjectManifest = async function (
     assertIsError(error);
     if (error.code === "ENOENT") {
       log.error("manifest", `manifest at ${manifestPath} does not exist`);
-      return err(new ManifestNotFoundError());
+      return err(new RequiredFileNotFoundError(manifestPath));
     } else {
       log.error("manifest", `failed to parse manifest at ${manifestPath}`);
       log.error("manifest", error.message);

--- a/src/utils/project-version-io.ts
+++ b/src/utils/project-version-io.ts
@@ -1,5 +1,9 @@
 import path from "path";
 import fse from "fs-extra";
+import { Result } from "@badrap/result";
+import { assertIsError } from "./error-type-guards";
+import ok = Result.ok;
+import err = Result.err;
 
 /**
  * Creates a ProjectVersion.txt file for a Unity project.
@@ -10,12 +14,18 @@ import fse from "fs-extra";
 export async function createProjectVersionTxt(
   projectDirPath: string,
   version: string
-) {
-  const projectSettingsDir = path.join(projectDirPath, "ProjectSettings");
-  await fse.mkdirp(projectSettingsDir);
-  const data = `m_EditorVersion: ${version}`;
-  await fse.writeFile(
-    path.join(projectSettingsDir, "ProjectVersion.txt"),
-    data
-  );
+): Promise<Result<void, Error>> {
+  try {
+    const projectSettingsDir = path.join(projectDirPath, "ProjectSettings");
+    await fse.mkdirp(projectSettingsDir);
+    const data = `m_EditorVersion: ${version}`;
+    await fse.writeFile(
+      path.join(projectSettingsDir, "ProjectVersion.txt"),
+      data
+    );
+    return ok(undefined);
+  } catch (error) {
+    assertIsError(error);
+    return err(error);
+  }
 }

--- a/src/utils/project-version-io.ts
+++ b/src/utils/project-version-io.ts
@@ -1,9 +1,7 @@
 import path from "path";
 import fse from "fs-extra";
-import { Result } from "@badrap/result";
 import { assertIsError } from "./error-type-guards";
-import ok = Result.ok;
-import err = Result.err;
+import { Err, Ok, Result } from "ts-results-es";
 
 /**
  * Creates a ProjectVersion.txt file for a Unity project.
@@ -23,9 +21,9 @@ export async function tryCreateProjectVersionTxt(
       path.join(projectSettingsDir, "ProjectVersion.txt"),
       data
     );
-    return ok(undefined);
+    return Ok(undefined);
   } catch (error) {
     assertIsError(error);
-    return err(error);
+    return Err(error);
   }
 }

--- a/src/utils/project-version-io.ts
+++ b/src/utils/project-version-io.ts
@@ -11,7 +11,7 @@ import err = Result.err;
  * @param projectDirPath The projects root folder.
  * @param version The editor-version to use.
  */
-export async function createProjectVersionTxt(
+export async function tryCreateProjectVersionTxt(
   projectDirPath: string,
   version: string
 ): Promise<Result<void, Error>> {

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -96,7 +96,7 @@ export const tryLoadUpmConfig = async (
  * @param config The config to save.
  * @param configDir The directory in which to save the config.
  */
-export const saveUpmConfig = async (
+export const trySaveUpmConfig = async (
   config: UPMConfig,
   configDir: string
 ): Promise<Result<void, IOError>> => {
@@ -127,5 +127,5 @@ export const storeUpmAuth = async function (
   config = addAuth(registry, auth, config);
 
   // Write config file
-  (await saveUpmConfig(config, configDir)).unwrap();
+  (await trySaveUpmConfig(config, configDir)).unwrap();
 };

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -74,7 +74,7 @@ export const tryGetUpmConfigDir = async (
  * @param configDir The directory from which to load the config.
  * @returns The config or null if not found.
  */
-export const loadUpmConfig = async (
+export const tryLoadUpmConfig = async (
   configDir: string
 ): Promise<UPMConfig | null> => {
   const configPath = path.join(configDir, configFileName);
@@ -115,7 +115,7 @@ export const storeUpmAuth = async function (
   auth: UpmAuth
 ) {
   // Read config file
-  let config: UPMConfig = (await loadUpmConfig(configDir)) || {};
+  let config: UPMConfig = (await tryLoadUpmConfig(configDir)) || {};
 
   config = addAuth(registry, auth, config);
 

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -8,11 +8,9 @@ import execute from "./process";
 import { addAuth, UpmAuth, UPMConfig } from "../types/upm-config";
 import { RegistryUrl } from "../types/registry-url";
 import { CustomError } from "ts-custom-error";
-import { Result } from "@badrap/result";
 import { IOError } from "../common-errors";
 import { assertIsError } from "./error-type-guards";
-import err = Result.err;
-import ok = Result.ok;
+import { Err, Ok, Result } from "ts-results-es";
 
 const configFileName = ".upmconfig.toml";
 
@@ -45,15 +43,15 @@ export const tryGetUpmConfigDir = async (
 ): Promise<Result<string, GetUpmConfigDirError>> => {
   const systemUserSubPath = "Unity/config/ServiceAccounts";
   if (wsl) {
-    if (!isWsl) return err(new NoWslError());
+    if (!isWsl) return Err(new NoWslError());
     if (systemUser) {
       const allUserProfilePath = await execute(
         'wslpath "$(wslvar ALLUSERSPROFILE)"',
         { trim: true }
       );
-      return ok(path.join(allUserProfilePath, systemUserSubPath));
+      return Ok(path.join(allUserProfilePath, systemUserSubPath));
     } else {
-      return ok(
+      return Ok(
         await execute('wslpath "$(wslvar USERPROFILE)"', {
           trim: true,
         })
@@ -61,13 +59,13 @@ export const tryGetUpmConfigDir = async (
     }
   } else if (systemUser) {
     if (!process.env.ALLUSERSPROFILE)
-      return err(new RequiredEnvMissingError("ALLUSERSPROFILE"));
-    return ok(path.join(process.env.ALLUSERSPROFILE, systemUserSubPath));
+      return Err(new RequiredEnvMissingError("ALLUSERSPROFILE"));
+    return Ok(path.join(process.env.ALLUSERSPROFILE, systemUserSubPath));
   } else {
     const dirName = process.env.USERPROFILE ?? process.env.HOME;
     if (dirName === undefined)
-      return err(new RequiredEnvMissingError("USERPROFILE", "HOME"));
-    return ok(dirName);
+      return Err(new RequiredEnvMissingError("USERPROFILE", "HOME"));
+    return Ok(dirName);
   }
 };
 
@@ -106,10 +104,10 @@ export const trySaveUpmConfig = async (
     const content = TOML.stringify(config);
     await fs.writeFile(configPath, content, "utf8");
     log.notice("config", "saved unity config at " + configPath);
-    return ok(undefined);
+    return Ok(undefined);
   } catch (error) {
     assertIsError(error);
-    return err(error);
+    return Err(error);
   }
 };
 

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -72,10 +72,11 @@ export const tryGetUpmConfigDir = async (
 /**
  * Attempts to load the upm config.
  * @param configDir The directory from which to load the config.
+ * @returns The config or null if not found.
  */
 export const loadUpmConfig = async (
   configDir: string
-): Promise<UPMConfig | undefined> => {
+): Promise<UPMConfig | null> => {
   const configPath = path.join(configDir, configFileName);
   try {
     const content = await fs.readFile(configPath, "utf8");
@@ -84,7 +85,7 @@ export const loadUpmConfig = async (
     // NOTE: We assume correct format
     return config as UPMConfig;
   } catch {
-    return undefined;
+    return null;
   }
 };
 

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -120,12 +120,12 @@ export const storeUpmAuth = async function (
   configDir: string,
   registry: RegistryUrl,
   auth: UpmAuth
-) {
+): Promise<Result<void, IOError>> {
   // Read config file
-  let config: UPMConfig = (await tryLoadUpmConfig(configDir)) || {};
+  let config = (await tryLoadUpmConfig(configDir)) || {};
 
   config = addAuth(registry, auth, config);
 
   // Write config file
-  (await trySaveUpmConfig(config, configDir)).unwrap();
+  return await trySaveUpmConfig(config, configDir);
 };

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -116,7 +116,7 @@ export const trySaveUpmConfig = async (
 /**
  * Stores authentication information in the projects upm config.
  */
-export const storeUpmAuth = async function (
+export const tryStoreUpmAuth = async function (
   configDir: string,
   registry: RegistryUrl,
   auth: UpmAuth

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -37,7 +37,7 @@ export type GetUpmConfigDirError = NoWslError | RequiredEnvMissingError;
  * @param wsl Whether WSL should be treated as Windows.
  * @param systemUser Whether to authenticate as a Windows system-user.
  */
-export const getUpmConfigDir = async (
+export const tryGetUpmConfigDir = async (
   wsl: boolean,
   systemUser: boolean
 ): Promise<Result<string, GetUpmConfigDirError>> => {

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -155,8 +155,8 @@ describe("cmd-add.ts", function () {
     });
 
     it("add pkg", async function () {
-      const retCode = await add(packageA, options);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageA, options);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestA)
       );
@@ -164,11 +164,11 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@1.0.0", async function () {
-      const retCode = await add(
+      const addResult = await add(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      expect(retCode).toEqual(0);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestA)
       );
@@ -176,8 +176,11 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@latest", async function () {
-      const retCode = await add(packageReference(packageA, "latest"), options);
-      expect(retCode).toEqual(0);
+      const addResult = await add(
+        packageReference(packageA, "latest"),
+        options
+      );
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestA)
       );
@@ -185,16 +188,16 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@0.1.0 then pkg@1.0.0", async function () {
-      const retCode1 = await add(
+      const addResult1 = await add(
         packageReference(packageA, semanticVersion("0.1.0")),
         options
       );
-      expect(retCode1).toEqual(0);
-      const retCode2 = await add(
+      expect(addResult1).toBeOk();
+      const addResult2 = await add(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      expect(retCode2).toEqual(0);
+      expect(addResult2).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestA)
       );
@@ -202,16 +205,16 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add exited pkg version", async function () {
-      const retCode1 = await add(
+      const addResult1 = await add(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      expect(retCode1).toEqual(0);
-      const retCode2 = await add(
+      expect(addResult1).toBeOk();
+      const addResult2 = await add(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      expect(retCode2).toEqual(0);
+      expect(addResult2).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestA)
       );
@@ -219,11 +222,11 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@not-exist-version", async function () {
-      const retCode = await add(
+      const addResult = await add(
         packageReference(packageA, semanticVersion("2.0.0")),
         options
       );
-      expect(retCode).toEqual(1);
+      expect(addResult).toBeError();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(defaultManifest)
       );
@@ -236,8 +239,8 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@http", async function () {
       const gitUrl = "https://github.com/yo/com.base.package-a" as PackageUrl;
-      const retCode = await add(packageReference(packageA, gitUrl), options);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageReference(packageA, gitUrl), options);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toHaveDependency(packageA, gitUrl)
       );
@@ -249,8 +252,8 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@git", async function () {
       const gitUrl = "git@github.com:yo/com.base.package-a" as PackageUrl;
-      const retCode = await add(packageReference(packageA, gitUrl), options);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageReference(packageA, gitUrl), options);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toHaveDependency(packageA, gitUrl)
       );
@@ -262,8 +265,8 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@file", async function () {
       const fileUrl = "file../yo/com.base.package-a" as PackageUrl;
-      const retCode = await add(packageReference(packageA, fileUrl), options);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageReference(packageA, fileUrl), options);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toHaveDependency(packageA, fileUrl)
       );
@@ -274,16 +277,16 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg-not-exist", async function () {
-      const retCode = await add(packageMissing, options);
-      expect(retCode).toEqual(1);
+      const addResult = await add(packageMissing, options);
+      expect(addResult).toBeError();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(defaultManifest)
       );
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("add more than one pkgs", async function () {
-      const retCode = await add([packageA, packageB], options);
-      expect(retCode).toEqual(0);
+      const addResult = await add([packageA, packageB], options);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestAB)
       );
@@ -298,8 +301,8 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg from upstream", async function () {
-      const retCode = await add(packageUp, upstreamOptions);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageUp, upstreamOptions);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestUpstream)
       );
@@ -310,19 +313,19 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg-not-exist from upstream", async function () {
-      const retCode = await add(packageMissing, upstreamOptions);
-      expect(retCode).toEqual(1);
+      const addResult = await add(packageMissing, upstreamOptions);
+      expect(addResult).toBeError();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(defaultManifest)
       );
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("add pkg with nested dependencies", async function () {
-      const retCode = await add(
+      const addResult = await add(
         packageReference(packageC, "latest"),
         upstreamOptions
       );
-      expect(retCode).toEqual(0);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestC)
       );
@@ -330,8 +333,8 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with tests", async function () {
-      const retCode = await add(packageA, testableOptions);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageA, testableOptions);
+      expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestTestable)
       );
@@ -339,35 +342,35 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with lower editor version", async function () {
-      const retCode = await add(packageLowerEditor, testableOptions);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageLowerEditor, testableOptions);
+      expect(addResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg with higher editor version", async function () {
-      const retCode = await add(packageHigherEditor, testableOptions);
-      expect(retCode).toEqual(1);
+      const addResult = await add(packageHigherEditor, testableOptions);
+      expect(addResult).toBeError();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "requires 2020.2 but found 2019.2.13f1"
       );
     });
     it("force add pkg with higher editor version", async function () {
-      const retCode = await add(packageHigherEditor, forceOptions);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageHigherEditor, forceOptions);
+      expect(addResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "requires 2020.2 but found 2019.2.13f1"
       );
     });
     it("add pkg with wrong editor version", async function () {
-      const retCode = await add(packageWrongEditor, testableOptions);
-      expect(retCode).toEqual(1);
+      const addResult = await add(packageWrongEditor, testableOptions);
+      expect(addResult).toBeError();
       expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
     it("force add pkg with wrong editor version", async function () {
-      const retCode = await add(packageWrongEditor, forceOptions);
-      expect(retCode).toEqual(0);
+      const addResult = await add(packageWrongEditor, forceOptions);
+      expect(addResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
   });

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -65,51 +65,51 @@ describe("cmd-deps.ts", function () {
     });
 
     it("deps pkg", async function () {
-      const retCode = await deps(remotePackumentA.name, options);
-      expect(retCode).toEqual(0);
+      const depsResult = await deps(remotePackumentA.name, options);
+      expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg --deep", async function () {
-      const retCode = await deps(remotePackumentA.name, {
+      const depsResult = await deps(remotePackumentA.name, {
         ...options,
         deep: true,
       });
-      expect(retCode).toEqual(0);
+      expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentUp.name);
     });
     it("deps pkg@latest", async function () {
-      const retCode = await deps(
+      const depsResult = await deps(
         packageReference(remotePackumentA.name, "latest"),
         options
       );
-      expect(retCode).toEqual(0);
+      expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg@1.0.0", async function () {
-      const retCode = await deps(
+      const depsResult = await deps(
         packageReference(remotePackumentA.name, "1.0.0"),
         options
       );
-      expect(retCode).toEqual(0);
+      expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
     it("deps pkg@not-exist-version", async function () {
-      const retCode = await deps(
+      const depsResult = await deps(
         packageReference(remotePackumentA.name, "2.0.0"),
         options
       );
-      expect(retCode).toEqual(0);
+      expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "is not a valid choice");
     });
     it("deps pkg-not-exist", async function () {
-      const retCode = await deps(domainName("pkg-not-exist"), options);
-      expect(retCode).toEqual(0);
+      const depsResult = await deps(domainName("pkg-not-exist"), options);
+      expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "not found");
     });
     it("deps pkg upstream", async function () {
-      const retCode = await deps(remotePackumentUp.name, options);
-      expect(retCode).toEqual(0);
+      const depsResult = await deps(remotePackumentUp.name, options);
+      expect(depsResult).toBeOk();
     });
   });
 });

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -45,8 +45,8 @@ describe("cmd-remove.ts", function () {
           registry: exampleRegistryUrl,
         },
       };
-      const retCode = await remove(packageA, options);
-      expect(retCode).toEqual(0);
+      const removeResult = await remove(packageA, options);
+      expect(removeResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) => {
         expect(manifest).not.toHaveDependency(packageA);
         expect(manifest).toHaveScope(packageB);
@@ -60,11 +60,11 @@ describe("cmd-remove.ts", function () {
           registry: exampleRegistryUrl,
         },
       };
-      const retCode = await remove(
+      const removeResult = await remove(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      expect(retCode).toEqual(1);
+      expect(removeResult).toBeError();
       await mockProject.tryAssertManifest((manifest) => {
         expect(manifest).toEqual(defaultManifest);
       });
@@ -79,8 +79,8 @@ describe("cmd-remove.ts", function () {
           registry: exampleRegistryUrl,
         },
       };
-      const retCode = await remove(missingPackage, options);
-      expect(retCode).toEqual(1);
+      const removeResult = await remove(missingPackage, options);
+      expect(removeResult).toBeError();
       await mockProject.tryAssertManifest((manifest) => {
         expect(manifest).toEqual(defaultManifest);
       });
@@ -92,8 +92,8 @@ describe("cmd-remove.ts", function () {
           registry: exampleRegistryUrl,
         },
       };
-      const retCode = await remove([packageA, packageB], options);
-      expect(retCode).toEqual(0);
+      const removeResult = await remove([packageA, packageB], options);
+      expect(removeResult).toBeOk();
 
       await mockProject.tryAssertManifest((manifest) => {
         expect(manifest).not.toHaveDependency(packageA);
@@ -115,8 +115,8 @@ describe("cmd-remove.ts", function () {
           registry: exampleRegistryUrl,
         },
       };
-      const retCode = await remove([packageA, packageB], options);
-      expect(retCode).toEqual(0);
+      const removeResult = await remove([packageA, packageB], options);
+      expect(removeResult).toBeOk();
 
       await mockProject.tryAssertManifest((manifest) => {
         expect(manifest.scopedRegistries).toHaveLength(0);

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -79,7 +79,7 @@ describe("cmd-search.ts", function () {
     beforeEach(function () {
       startMockRegistry();
       registerSearchResult("package-a", searchEndpointResult);
-      registerSearchResult("pkg-not-exit", searchEndpointEmptyResult);
+      registerSearchResult("pkg-not-exist", searchEndpointEmptyResult);
     });
     afterEach(function () {
       stopMockRegistry();

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -85,15 +85,15 @@ describe("cmd-search.ts", function () {
       stopMockRegistry();
     });
     it("simple", async function () {
-      const retCode = await search("package-a", options);
-      expect(retCode).toEqual(0);
+      const searchResult = await search("package-a", options);
+      expect(searchResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "package-a");
       expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
       expect(mockConsole).toHaveLineIncluding("out", "2019-10-02");
     });
     it("pkg not exist", async function () {
-      const retCode = await search("pkg-not-exist", options);
-      expect(retCode).toEqual(0);
+      const searchResult = await search("pkg-not-exist", options);
+      expect(searchResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "No matches found");
     });
   });
@@ -135,8 +135,8 @@ describe("cmd-search.ts", function () {
       nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
         "Content-Type": "application/json",
       });
-      const retCode = await search("package-a", options);
-      expect(retCode).toEqual(0);
+      const searchResult = await search("package-a", options);
+      expect(searchResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "fast search endpoint is not available"
@@ -149,8 +149,8 @@ describe("cmd-search.ts", function () {
       nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
         "Content-Type": "application/json",
       });
-      const retCode = await search("pkg-not-exist", options);
-      expect(retCode).toEqual(0);
+      const searchResult = await search("pkg-not-exist", options);
+      expect(searchResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "No matches found");
     });
   });

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -124,40 +124,40 @@ describe("cmd-view.ts", function () {
     });
 
     it("view pkg", async function () {
-      const retCode = await view(packageA, options);
-      expect(retCode).toEqual(0);
+      const viewResult = await view(packageA, options);
+      expect(viewResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "com.example.package-a@1.0.0"
       );
     });
     it("view pkg@1.0.0", async function () {
-      const retCode = await view(
+      const viewResult = await view(
         packageReference(packageA, semanticVersion("1.0.0")),
         options
       );
-      expect(retCode).toEqual(1);
+      expect(viewResult).toBeError();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "do not specify a version"
       );
     });
     it("view pkg-not-exist", async function () {
-      const retCode = await view(packageMissing, options);
-      expect(retCode).toEqual(1);
+      const viewResult = await view(packageMissing, options);
+      expect(viewResult).toBeError();
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
     it("view pkg from upstream", async function () {
-      const retCode = await view(packageUp, upstreamOptions);
-      expect(retCode).toEqual(0);
+      const viewResult = await view(packageUp, upstreamOptions);
+      expect(viewResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "com.example.package-up@1.0.0"
       );
     });
     it("view pkg-not-exist from upstream", async function () {
-      const retCode = await view(packageMissing, upstreamOptions);
-      expect(retCode).toEqual(1);
+      const viewResult = await view(packageMissing, upstreamOptions);
+      expect(viewResult).toBeError();
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
   });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -47,26 +47,24 @@ describe("env", function () {
     });
 
     it("defaults", async function () {
-      const env = await parseEnv({ _global: {} }, false);
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://package.openupm.com");
-      expect(env!.upstream).toBeTruthy();
-      expect(env!.upstreamRegistry.url).toEqual("https://packages.unity.com");
-      expect(env!.cwd).toEqual("");
-      expect(env!.editorVersion === null).toBeTruthy();
+      const env = (await parseEnv({ _global: {} }, false)).unwrap();
+      expect(env.registry.url).toEqual("https://package.openupm.com");
+      expect(env.upstream).toBeTruthy();
+      expect(env.upstreamRegistry.url).toEqual("https://packages.unity.com");
+      expect(env.cwd).toEqual("");
+      expect(env.editorVersion === null).toBeTruthy();
     });
 
     it("check path", async function () {
-      const env = await parseEnv({ _global: {} }, true);
-      expect(env).not.toBeNull();
-      expect(env!.cwd).toEqual(mockProject.projectPath);
+      const env = (await parseEnv({ _global: {} }, true)).unwrap();
+      expect(env.cwd).toEqual(mockProject.projectPath);
     });
     it("can not resolve path", async function () {
-      const env = await parseEnv(
+      const envResult = await parseEnv(
         { _global: { chdir: "/path-not-exist" } },
         true
       );
-      expect(env).toBeNull();
+      expect(envResult.isOk).toBeFalsy();
       expect(mockConsole).toHaveLineIncluding("out", "can not resolve path");
     });
 
@@ -75,132 +73,151 @@ describe("env", function () {
       const manifestPath = manifestPathFor(mockProject.projectPath);
       fse.rmSync(manifestPath);
 
-      const env = await parseEnv({ _global: {} }, true);
-      expect(env).toBeNull();
+      const envResult = await parseEnv({ _global: {} }, true);
+      expect(envResult.isOk).toBeFalsy();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "can not locate manifest.json"
       );
     });
     it("custom registry", async function () {
-      const env = await parseEnv(
-        { _global: { registry: "https://registry.npmjs.org" } },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://registry.npmjs.org");
+      const env = (
+        await parseEnv(
+          { _global: { registry: "https://registry.npmjs.org" } },
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("https://registry.npmjs.org");
     });
     it("custom registry with splash", async function () {
-      const env = await parseEnv(
-        { _global: { registry: "https://registry.npmjs.org/" } },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://registry.npmjs.org");
+      const env = (
+        await parseEnv(
+          { _global: { registry: "https://registry.npmjs.org/" } },
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("https://registry.npmjs.org");
     });
     it("custom registry with extra path", async function () {
-      const env = await parseEnv(
-        {
-          _global: {
-            registry: "https://registry.npmjs.org/some",
+      const env = (
+        await parseEnv(
+          {
+            _global: {
+              registry: "https://registry.npmjs.org/some",
+            },
           },
-        },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://registry.npmjs.org/some");
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("https://registry.npmjs.org/some");
     });
     it("custom registry with extra path and splash", async function () {
-      const env = await parseEnv(
-        {
-          _global: {
-            registry: "https://registry.npmjs.org/some/",
+      const env = (
+        await parseEnv(
+          {
+            _global: {
+              registry: "https://registry.npmjs.org/some/",
+            },
           },
-        },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://registry.npmjs.org/some");
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("https://registry.npmjs.org/some");
     });
     it("custom registry without http", async function () {
-      const env = await parseEnv(
-        { _global: { registry: "registry.npmjs.org" } },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("http://registry.npmjs.org");
+      const env = (
+        await parseEnv({ _global: { registry: "registry.npmjs.org" } }, false)
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("http://registry.npmjs.org");
     });
     it("custom registry with ipv4+port", async function () {
-      const env = await parseEnv(
-        { _global: { registry: "http://127.0.0.1:4873" } },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("http://127.0.0.1:4873");
+      const env = (
+        await parseEnv(
+          { _global: { registry: "http://127.0.0.1:4873" } },
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("http://127.0.0.1:4873");
     });
     it("custom registry with ipv6+port", async function () {
-      const env = await parseEnv(
-        {
-          _global: { registry: "http://[1:2:3:4:5:6:7:8]:4873" },
-        },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("http://[1:2:3:4:5:6:7:8]:4873");
+      const env = (
+        await parseEnv(
+          {
+            _global: { registry: "http://[1:2:3:4:5:6:7:8]:4873" },
+          },
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("http://[1:2:3:4:5:6:7:8]:4873");
     });
     it("should have registry auth if specified", async function () {
-      const env = await parseEnv(
-        {
-          _global: {
-            registry: "registry.npmjs.org",
+      const env = (
+        await parseEnv(
+          {
+            _global: {
+              registry: "registry.npmjs.org",
+            },
           },
-        },
-        true
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.auth).toEqual(testNpmAuth);
+          true
+        )
+      ).unwrap();
+
+      expect(env.registry.auth).toEqual(testNpmAuth);
     });
     it("should not have unspecified registry auth", async function () {
-      const env = await parseEnv(
-        {
-          _global: {
-            registry: "registry.other.org",
+      const env = (
+        await parseEnv(
+          {
+            _global: {
+              registry: "registry.other.org",
+            },
           },
-        },
-        true
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.auth).toBeNull();
+          true
+        )
+      ).unwrap();
+
+      expect(env.registry.auth).toBeNull();
     });
     it("upstream", async function () {
-      const env = await parseEnv({ _global: { upstream: false } }, false);
-      expect(env).not.toBeNull();
-      expect(env!.upstream).not.toBeTruthy();
+      const env = (
+        await parseEnv({ _global: { upstream: false } }, false)
+      ).unwrap();
+
+      expect(env.upstream).not.toBeTruthy();
     });
     it("editorVersion", async function () {
-      const env = await parseEnv({ _global: {} }, true);
-      expect(env).not.toBeNull();
-      expect(env!.editorVersion).toEqual("2019.2.13f1");
+      const env = (await parseEnv({ _global: {} }, true)).unwrap();
+
+      expect(env.editorVersion).toEqual("2019.2.13f1");
     });
     it("region cn", async function () {
-      const env = await parseEnv({ _global: { cn: true } }, false);
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://package.openupm.cn");
-      expect(env!.upstreamRegistry.url).toEqual("https://packages.unity.cn");
+      const env = (await parseEnv({ _global: { cn: true } }, false)).unwrap();
+
+      expect(env.registry.url).toEqual("https://package.openupm.cn");
+      expect(env.upstreamRegistry.url).toEqual("https://packages.unity.cn");
     });
     it("region cn with a custom registry", async function () {
-      const env = await parseEnv(
-        {
-          _global: {
-            cn: true,
-            registry: "https://reg.custom-package.com",
+      const env = (
+        await parseEnv(
+          {
+            _global: {
+              cn: true,
+              registry: "https://reg.custom-package.com",
+            },
           },
-        },
-        false
-      );
-      expect(env).not.toBeNull();
-      expect(env!.registry.url).toEqual("https://reg.custom-package.com");
-      expect(env!.upstreamRegistry.url).toEqual("https://packages.unity.cn");
+          false
+        )
+      ).unwrap();
+
+      expect(env.registry.url).toEqual("https://reg.custom-package.com");
+      expect(env.upstreamRegistry.url).toEqual("https://packages.unity.cn");
     });
   });
 });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -64,7 +64,7 @@ describe("env", function () {
         { _global: { chdir: "/path-not-exist" } },
         true
       );
-      expect(envResult.isOk).toBeFalsy();
+      expect(envResult.isOk()).toBeFalsy();
       expect(mockConsole).toHaveLineIncluding("out", "can not resolve path");
     });
 
@@ -74,7 +74,7 @@ describe("env", function () {
       fse.rmSync(manifestPath);
 
       const envResult = await parseEnv({ _global: {} }, true);
-      expect(envResult.isOk).toBeFalsy();
+      expect(envResult.isOk()).toBeFalsy();
       expect(mockConsole).toHaveLineIncluding(
         "out",
         "can not locate manifest.json"

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -18,6 +18,10 @@ declare global {
       toHaveScope(scope: DomainName): R;
 
       toHaveScopedRegistries(): R;
+
+      toBeOk(valueAsserter?: (value: unknown) => void): R;
+
+      toBeError(errorAsserter?: (error: Error) => void): R;
     }
   }
 }

--- a/test/mock-env.ts
+++ b/test/mock-env.ts
@@ -5,7 +5,7 @@ export type MockEnvSession = {
   /**
    * Stops this mock-env session and revert to the original {@link process.env}.
    */
-  unhook(): void;
+  unhoOk(): void;
 };
 
 /**
@@ -23,7 +23,7 @@ export function mockEnv(env: object): MockEnvSession {
     );
   process.env = { ...env, IS_MOCK: "TRUE" };
   return {
-    unhook() {
+    unhoOk() {
       process.env = originalEnv;
     },
   };
@@ -43,6 +43,6 @@ export function runWithEnv<T>(env: object, func: () => T): T {
   try {
     return func();
   } finally {
-    envSession.unhook();
+    envSession.unhoOk();
   }
 }

--- a/test/mock-env.ts
+++ b/test/mock-env.ts
@@ -5,7 +5,7 @@ export type MockEnvSession = {
   /**
    * Stops this mock-env session and revert to the original {@link process.env}.
    */
-  unhoOk(): void;
+  unhook(): void;
 };
 
 /**
@@ -23,7 +23,7 @@ export function mockEnv(env: object): MockEnvSession {
     );
   process.env = { ...env, IS_MOCK: "TRUE" };
   return {
-    unhoOk() {
+    unhook() {
       process.env = originalEnv;
     },
   };
@@ -43,6 +43,6 @@ export function runWithEnv<T>(env: object, func: () => T): T {
   try {
     return func();
   } finally {
-    envSession.unhoOk();
+    envSession.unhook();
   }
 }

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -25,24 +25,24 @@ describe("registry-client", function () {
       stopMockRegistry();
     });
     it("simple", async function () {
-      const env = await parseEnv(
+      const env = (await parseEnv(
         { _global: { registry: exampleRegistryUrl } },
         false
-      );
-      expect(env).not.toBeNull();
+      )).unwrap();
+      
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
-      const info = await client.tryFetchPackument(env!.registry, packageA);
+      const info = await client.tryFetchPackument(env.registry, packageA);
       expect(info).toEqual(packumentRemote);
     });
     it("404", async function () {
-      const env = await parseEnv(
+      const env = (await parseEnv(
         { _global: { registry: exampleRegistryUrl } },
         false
-      );
-      expect(env).not.toBeNull();
+      )).unwrap();
+      
       registerMissingPackument(packageA);
-      const info = await client.tryFetchPackument(env!.registry, packageA);
+      const info = await client.tryFetchPackument(env.registry, packageA);
       expect(info).toBeNull();
     });
   });

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -25,22 +25,20 @@ describe("registry-client", function () {
       stopMockRegistry();
     });
     it("simple", async function () {
-      const env = (await parseEnv(
-        { _global: { registry: exampleRegistryUrl } },
-        false
-      )).unwrap();
-      
+      const env = (
+        await parseEnv({ _global: { registry: exampleRegistryUrl } }, false)
+      ).unwrap();
+
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
       const info = await client.tryFetchPackument(env.registry, packageA);
       expect(info).toEqual(packumentRemote);
     });
     it("404", async function () {
-      const env = (await parseEnv(
-        { _global: { registry: exampleRegistryUrl } },
-        false
-      )).unwrap();
-      
+      const env = (
+        await parseEnv({ _global: { registry: exampleRegistryUrl } }, false)
+      ).unwrap();
+
       registerMissingPackument(packageA);
       const info = await client.tryFetchPackument(env.registry, packageA);
       expect(info).toBeNull();

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -31,8 +31,10 @@ describe("registry-client", function () {
 
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
-      const info = await client.tryFetchPackument(env.registry, packageA);
-      expect(info).toEqual(packumentRemote);
+      const result = await client.tryFetchPackument(env.registry, packageA);
+      expect(result).toBeOk((packument) =>
+        expect(packument).toEqual(packumentRemote)
+      );
     });
     it("404", async function () {
       const env = (
@@ -40,8 +42,8 @@ describe("registry-client", function () {
       ).unwrap();
 
       registerMissingPackument(packageA);
-      const info = await client.tryFetchPackument(env.registry, packageA);
-      expect(info).toBeNull();
+      const result = await client.tryFetchPackument(env.registry, packageA);
+      expect(result).toBeOk((packument) => expect(packument).toBeNull());
     });
   });
 });

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -1,10 +1,10 @@
 import { attachMockConsole, MockConsole } from "./mock-console";
 
 import {
-  loadProjectManifest,
+  tryLoadProjectManifest,
   ManifestNotFoundError,
   ManifestParseError,
-  saveProjectManifest,
+  trySaveProjectManifest,
 } from "../src/utils/project-manifest-io";
 import { DomainName, domainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
@@ -42,14 +42,16 @@ describe("project-manifest io", () => {
   });
 
   it("loadManifest", async () => {
-    const manifestResult = await loadProjectManifest(mockProject.projectPath);
+    const manifestResult = await tryLoadProjectManifest(
+      mockProject.projectPath
+    );
 
     expect(manifestResult).toBeOk((manifest) =>
       expect(manifest).toEqual({ dependencies: {} })
     );
   });
   it("no manifest file", async () => {
-    const manifestResult = await loadProjectManifest("/invalid-path");
+    const manifestResult = await tryLoadProjectManifest("/invalid-path");
 
     expect(manifestResult).toBeError((error) =>
       expect(error).toBeInstanceOf(ManifestNotFoundError)
@@ -60,7 +62,9 @@ describe("project-manifest io", () => {
     const manifestPath = manifestPathFor(mockProject.projectPath);
     fse.writeFileSync(manifestPath, "invalid data");
 
-    const manifestResult = await loadProjectManifest(mockProject.projectPath);
+    const manifestResult = await tryLoadProjectManifest(
+      mockProject.projectPath
+    );
     expect(manifestResult).toBeError((error) =>
       expect(error).toBeInstanceOf(ManifestParseError)
     );
@@ -68,7 +72,7 @@ describe("project-manifest io", () => {
   });
   it("saveManifest", async () => {
     let manifest = (
-      await loadProjectManifest(mockProject.projectPath)
+      await tryLoadProjectManifest(mockProject.projectPath)
     ).unwrap();
     expect(manifest).not.toHaveDependencies();
     manifest = addDependency(
@@ -77,10 +81,10 @@ describe("project-manifest io", () => {
       semanticVersion("1.0.0")
     );
     expect(
-      await saveProjectManifest(mockProject.projectPath, manifest)
+      await trySaveProjectManifest(mockProject.projectPath, manifest)
     ).toBeOk();
     const manifest2 = (
-      await loadProjectManifest(mockProject.projectPath)
+      await tryLoadProjectManifest(mockProject.projectPath)
     ).unwrap();
     expect(manifest2).toEqual(manifest);
   });
@@ -103,10 +107,10 @@ describe("project-manifest io", () => {
 
     // Save and load manifest
     expect(
-      await saveProjectManifest(mockProject.projectPath, initialManifest)
+      await trySaveProjectManifest(mockProject.projectPath, initialManifest)
     ).toBeOk();
     const savedManifest = (
-      await loadProjectManifest(mockProject.projectPath)
+      await tryLoadProjectManifest(mockProject.projectPath)
     ).unwrap();
 
     expect(savedManifest.scopedRegistries).toHaveLength(0);

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -2,7 +2,6 @@ import { attachMockConsole, MockConsole } from "./mock-console";
 
 import {
   tryLoadProjectManifest,
-  ManifestNotFoundError,
   ManifestParseError,
   trySaveProjectManifest,
 } from "../src/utils/project-manifest-io";
@@ -19,6 +18,7 @@ import path from "path";
 import { buildProjectManifest } from "./data-project-manifest";
 import { removeScope } from "../src/types/scoped-registry";
 import { exampleRegistryUrl } from "./mock-registry";
+import {RequiredFileNotFoundError} from "../src/common-errors";
 
 describe("project-manifest io", () => {
   let mockConsole: MockConsole = null!;
@@ -54,7 +54,7 @@ describe("project-manifest io", () => {
     const manifestResult = await tryLoadProjectManifest("/invalid-path");
 
     expect(manifestResult).toBeError((error) =>
-      expect(error).toBeInstanceOf(ManifestNotFoundError)
+      expect(error).toBeInstanceOf(RequiredFileNotFoundError)
     );
     expect(mockConsole).toHaveLineIncluding("out", "does not exist");
   });

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -78,7 +78,7 @@ describe("project-manifest io", () => {
     );
     expect(
       await saveProjectManifest(mockProject.projectPath, manifest)
-    ).toBeTruthy();
+    ).toBeOk();
     const manifest2 = (
       await loadProjectManifest(mockProject.projectPath)
     ).unwrap();
@@ -104,7 +104,7 @@ describe("project-manifest io", () => {
     // Save and load manifest
     expect(
       await saveProjectManifest(mockProject.projectPath, initialManifest)
-    ).toBeTruthy();
+    ).toBeOk();
     const savedManifest = (
       await loadProjectManifest(mockProject.projectPath)
     ).unwrap();

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -1,8 +1,8 @@
 import { attachMockConsole, MockConsole } from "./mock-console";
 
 import {
-  tryLoadProjectManifest,
   ManifestParseError,
+  tryLoadProjectManifest,
   trySaveProjectManifest,
 } from "../src/utils/project-manifest-io";
 import { DomainName, domainName } from "../src/types/domain-name";
@@ -18,7 +18,7 @@ import path from "path";
 import { buildProjectManifest } from "./data-project-manifest";
 import { removeScope } from "../src/types/scoped-registry";
 import { exampleRegistryUrl } from "./mock-registry";
-import {RequiredFileNotFoundError} from "../src/common-errors";
+import { RequiredFileNotFoundError } from "../src/common-errors";
 
 describe("project-manifest io", () => {
   let mockConsole: MockConsole = null!;

--- a/test/result-assertions.ts
+++ b/test/result-assertions.ts
@@ -2,7 +2,7 @@ import { Result } from "ts-results-es";
 
 expect.extend({
   toBeOk<T>(result: Result<T, Error>, valueAsserter?: (value: T) => void) {
-    if (!result.isOk())
+    if (result.isErr())
       return {
         pass: false,
         message: () =>

--- a/test/result-assertions.ts
+++ b/test/result-assertions.ts
@@ -1,8 +1,8 @@
-import { Result } from "@badrap/result";
+import { Result } from "ts-results-es";
 
 expect.extend({
   toBeOk<T>(result: Result<T, Error>, valueAsserter?: (value: T) => void) {
-    if (!result.isOk)
+    if (!result.isOk())
       return {
         pass: false,
         message: () =>
@@ -18,7 +18,7 @@ expect.extend({
     result: Result<unknown, T>,
     errorAsserter?: (error: T) => void
   ) {
-    if (result.isOk)
+    if (result.isOk())
       return {
         pass: false,
         message: () =>

--- a/test/result-assertions.ts
+++ b/test/result-assertions.ts
@@ -1,0 +1,32 @@
+import { Result } from "@badrap/result";
+
+expect.extend({
+  toBeOk<T>(result: Result<T, Error>, valueAsserter?: (value: T) => void) {
+    if (!result.isOk)
+      return {
+        pass: false,
+        message: () =>
+          `Expected result to be ok, but had error: ${result.error},`,
+      };
+
+    if (valueAsserter !== undefined) valueAsserter(result.value);
+
+    return { pass: true, message: () => "How did this happen?" };
+  },
+
+  toBeError<T extends Error>(
+    result: Result<unknown, T>,
+    errorAsserter?: (error: T) => void
+  ) {
+    if (result.isOk)
+      return {
+        pass: false,
+        message: () =>
+          `Expected result to be error, but had value: ${result.value},`,
+      };
+
+    if (errorAsserter !== undefined) errorAsserter(result.error);
+
+    return { pass: true, message: () => "How did this happen?" };
+  },
+});

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -6,15 +6,15 @@ import path from "path";
 import os from "os";
 import fse from "fs-extra";
 import {
-  loadProjectManifest,
+  tryLoadProjectManifest,
   ManifestLoadResult,
-  saveProjectManifest,
+  trySaveProjectManifest,
 } from "../../src/utils/project-manifest-io";
 import assert from "assert";
 import { mockEnv, MockEnvSession } from "../mock-env";
 import { UPMConfig } from "../../src/types/upm-config";
 import { saveUpmConfig } from "../../src/utils/upm-config-io";
-import { createProjectVersionTxt } from "../../src/utils/project-version-io";
+import { tryCreateProjectVersionTxt } from "../../src/utils/project-version-io";
 
 /**
  * A mock Unity project for testing.
@@ -110,7 +110,7 @@ export async function setupUnityProject(
 
     // Editor-version
     const version = config.version ?? defaultVersion;
-    const projectVersionResult = await createProjectVersionTxt(
+    const projectVersionResult = await tryCreateProjectVersionTxt(
       projectPath,
       version
     );
@@ -119,7 +119,10 @@ export async function setupUnityProject(
     // Project manifest
     if (config.manifest !== false) {
       const manifest = config.manifest ?? defaultManifest;
-      const manifestResult = await saveProjectManifest(projectPath, manifest);
+      const manifestResult = await trySaveProjectManifest(
+        projectPath,
+        manifest
+      );
       if (!manifestResult.isOk) throw manifestResult.error;
     }
   }
@@ -133,7 +136,7 @@ export async function setupUnityProject(
   }
 
   function tryGetManifest() {
-    return loadProjectManifest(projectPath);
+    return tryLoadProjectManifest(projectPath);
   }
 
   async function tryAssertManifest(

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -110,7 +110,11 @@ export async function setupUnityProject(
 
     // Editor-version
     const version = config.version ?? defaultVersion;
-    await createProjectVersionTxt(projectPath, version);
+    const projectVersionResult = await createProjectVersionTxt(
+      projectPath,
+      version
+    );
+    if (!projectVersionResult.isOk) throw projectVersionResult.error;
 
     // Project manifest
     if (config.manifest !== false) {

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -134,7 +134,7 @@ export async function setupUnityProject(
 
     await fse.rm(rootPath, { recursive: true, force: true });
 
-    envSession?.unhoOk();
+    envSession?.unhook();
   }
 
   function tryGetManifest() {

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -7,6 +7,7 @@ import os from "os";
 import fse from "fs-extra";
 import {
   loadProjectManifest,
+  ManifestLoadResult,
   saveProjectManifest,
 } from "../../src/utils/project-manifest-io";
 import assert from "assert";
@@ -26,9 +27,8 @@ export type MockUnityProject = {
 
   /**
    * Attempts to load the project manifest for the project.
-   * Null if not found.
    */
-  tryGetManifest(): Promise<UnityProjectManifest | null>;
+  tryGetManifest(): Promise<ManifestLoadResult>;
 
   /**
    * Runs an assertion function on the project manifest.
@@ -127,16 +127,16 @@ export async function setupUnityProject(
     envSession?.unhook();
   }
 
-  function tryGetManifest(): Promise<UnityProjectManifest | null> {
+  function tryGetManifest() {
     return loadProjectManifest(projectPath);
   }
 
   async function tryAssertManifest(
     assertFn: (manifest: UnityProjectManifest) => void
   ) {
-    const manifest = await tryGetManifest();
-    assert(manifest !== null);
-    assertFn(manifest);
+    const manifestResult = await tryGetManifest();
+    assert(manifestResult.isOk);
+    assertFn(manifestResult.value);
   }
 
   async function reset() {

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -115,7 +115,8 @@ export async function setupUnityProject(
     // Project manifest
     if (config.manifest !== false) {
       const manifest = config.manifest ?? defaultManifest;
-      await saveProjectManifest(projectPath, manifest);
+      const manifestResult = await saveProjectManifest(projectPath, manifest);
+      if (!manifestResult.isOk) throw manifestResult.error;
     }
   }
 

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -107,7 +107,7 @@ export async function setupUnityProject(
     // Upmconfig
     const upmConfig = config.upmConfig ?? defaultUpmConfig;
     const saveResult = await trySaveUpmConfig(upmConfig, rootPath);
-    if (!saveResult.isOk()) throw saveResult.error;
+    if (saveResult.isErr()) throw saveResult.error;
 
     // Editor-version
     const version = config.version ?? defaultVersion;
@@ -115,7 +115,7 @@ export async function setupUnityProject(
       projectPath,
       version
     );
-    if (!projectVersionResult.isOk()) throw projectVersionResult.error;
+    if (projectVersionResult.isErr()) throw projectVersionResult.error;
 
     // Project manifest
     if (config.manifest !== false) {
@@ -124,7 +124,7 @@ export async function setupUnityProject(
         projectPath,
         manifest
       );
-      if (!manifestResult.isOk()) throw manifestResult.error;
+      if (manifestResult.isErr()) throw manifestResult.error;
     }
   }
 

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -13,7 +13,7 @@ import {
 import assert from "assert";
 import { mockEnv, MockEnvSession } from "../mock-env";
 import { UPMConfig } from "../../src/types/upm-config";
-import { saveUpmConfig } from "../../src/utils/upm-config-io";
+import { trySaveUpmConfig } from "../../src/utils/upm-config-io";
 import { tryCreateProjectVersionTxt } from "../../src/utils/project-version-io";
 
 /**
@@ -106,7 +106,7 @@ export async function setupUnityProject(
 
     // Upmconfig
     const upmConfig = config.upmConfig ?? defaultUpmConfig;
-    const saveResult = await saveUpmConfig(upmConfig, rootPath);
+    const saveResult = await trySaveUpmConfig(upmConfig, rootPath);
     if (!saveResult.isOk) throw saveResult.error;
 
     // Editor-version

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -6,7 +6,7 @@ import path from "path";
 import os from "os";
 import fse from "fs-extra";
 import {
-  ManifestLoadResult,
+  ManifestLoadError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
 } from "../../src/utils/project-manifest-io";
@@ -15,6 +15,7 @@ import { mockEnv, MockEnvSession } from "../mock-env";
 import { UPMConfig } from "../../src/types/upm-config";
 import { trySaveUpmConfig } from "../../src/utils/upm-config-io";
 import { tryCreateProjectVersionTxt } from "../../src/utils/project-version-io";
+import { Result } from "ts-results-es";
 
 /**
  * A mock Unity project for testing.
@@ -28,7 +29,7 @@ export type MockUnityProject = {
   /**
    * Attempts to load the project manifest for the project.
    */
-  tryGetManifest(): Promise<ManifestLoadResult>;
+  tryGetManifest(): Promise<Result<UnityProjectManifest, ManifestLoadError>>;
 
   /**
    * Runs an assertion function on the project manifest.

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -6,8 +6,8 @@ import path from "path";
 import os from "os";
 import fse from "fs-extra";
 import {
-  tryLoadProjectManifest,
   ManifestLoadResult,
+  tryLoadProjectManifest,
   trySaveProjectManifest,
 } from "../../src/utils/project-manifest-io";
 import assert from "assert";
@@ -107,7 +107,7 @@ export async function setupUnityProject(
     // Upmconfig
     const upmConfig = config.upmConfig ?? defaultUpmConfig;
     const saveResult = await trySaveUpmConfig(upmConfig, rootPath);
-    if (!saveResult.isOk) throw saveResult.error;
+    if (!saveResult.isOk()) throw saveResult.error;
 
     // Editor-version
     const version = config.version ?? defaultVersion;
@@ -115,7 +115,7 @@ export async function setupUnityProject(
       projectPath,
       version
     );
-    if (!projectVersionResult.isOk) throw projectVersionResult.error;
+    if (!projectVersionResult.isOk()) throw projectVersionResult.error;
 
     // Project manifest
     if (config.manifest !== false) {
@@ -124,7 +124,7 @@ export async function setupUnityProject(
         projectPath,
         manifest
       );
-      if (!manifestResult.isOk) throw manifestResult.error;
+      if (!manifestResult.isOk()) throw manifestResult.error;
     }
   }
 
@@ -133,7 +133,7 @@ export async function setupUnityProject(
 
     await fse.rm(rootPath, { recursive: true, force: true });
 
-    envSession?.unhook();
+    envSession?.unhoOk();
   }
 
   function tryGetManifest() {
@@ -144,7 +144,7 @@ export async function setupUnityProject(
     assertFn: (manifest: UnityProjectManifest) => void
   ) {
     const manifestResult = await tryGetManifest();
-    assert(manifestResult.isOk);
+    assert(manifestResult.isOk());
     assertFn(manifestResult.value);
   }
 

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -106,7 +106,8 @@ export async function setupUnityProject(
 
     // Upmconfig
     const upmConfig = config.upmConfig ?? defaultUpmConfig;
-    await saveUpmConfig(upmConfig, rootPath);
+    const saveResult = await saveUpmConfig(upmConfig, rootPath);
+    if (!saveResult.isOk) throw saveResult.error;
 
     // Editor-version
     const version = config.version ?? defaultVersion;

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -1,9 +1,8 @@
 import { runWithEnv } from "./mock-env";
 import {
-  tryGetUpmConfigDir,
   RequiredEnvMissingError,
+  tryGetUpmConfigDir,
 } from "../src/utils/upm-config-io";
-import { Result } from "@badrap/result";
 
 describe("upm-config-io", function () {
   describe("get directory", function () {

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -1,5 +1,9 @@
 import { runWithEnv } from "./mock-env";
-import { getUpmConfigDir } from "../src/utils/upm-config-io";
+import {
+  getUpmConfigDir,
+  RequiredEnvMissingError,
+} from "../src/utils/upm-config-io";
+import { Result } from "@badrap/result";
 
 describe("upm-config-io", function () {
   describe("get directory", function () {
@@ -7,31 +11,35 @@ describe("upm-config-io", function () {
       it("should be USERPROFILE if defined", async function () {
         const expected = "user/dir";
 
-        const actual = await runWithEnv(
+        const result = await runWithEnv(
           {
             USERPROFILE: expected,
           },
           () => getUpmConfigDir(false, false)
         );
 
-        expect(actual).toEqual(expected);
+        expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
       });
       it("should be HOME if defined and USERPROFILE is undefined", async function () {
         const expected = "user/dir";
 
-        const actual = await runWithEnv(
+        const result = await runWithEnv(
           {
             HOME: expected,
           },
           () => getUpmConfigDir(false, false)
         );
 
-        expect(actual).toEqual(expected);
+        expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
       });
       it("should fail if HOME and USERPROFILE and undefined", async function () {
-        await expect(
-          runWithEnv({}, () => getUpmConfigDir(false, false))
-        ).rejects.toEqual(expect.any(Error));
+        const result = await runWithEnv({}, () =>
+          getUpmConfigDir(false, false)
+        );
+
+        expect(result).toBeError((error) =>
+          expect(error).toBeInstanceOf(RequiredEnvMissingError)
+        );
       });
     });
   });

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -1,6 +1,6 @@
 import { runWithEnv } from "./mock-env";
 import {
-  getUpmConfigDir,
+  tryGetUpmConfigDir,
   RequiredEnvMissingError,
 } from "../src/utils/upm-config-io";
 import { Result } from "@badrap/result";
@@ -15,7 +15,7 @@ describe("upm-config-io", function () {
           {
             USERPROFILE: expected,
           },
-          () => getUpmConfigDir(false, false)
+          () => tryGetUpmConfigDir(false, false)
         );
 
         expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
@@ -27,14 +27,14 @@ describe("upm-config-io", function () {
           {
             HOME: expected,
           },
-          () => getUpmConfigDir(false, false)
+          () => tryGetUpmConfigDir(false, false)
         );
 
         expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
       });
       it("should fail if HOME and USERPROFILE and undefined", async function () {
         const result = await runWithEnv({}, () =>
-          getUpmConfigDir(false, false)
+          tryGetUpmConfigDir(false, false)
         );
 
         expect(result).toBeError((error) =>


### PR DESCRIPTION
This PR introduces a normalized Result type for functions which may fail for more than 1 reason.

Currently the way functions may express their failure is quite mixed. In the project we have:

- Result-types such as in `packument-resolving`
- Error-codes such as in the cmd files
- thrown Errors
- swallowed Errors (return undefined)

This PR introduces `ts-results-es`' Result type to standardize these APIs inside the project. Errors are not also documented in functions return-type which is neat. This also has the nice side-effect of showing just how many errors are currently not gracefully handled (e.g. the app logs errors but otherwise just quits with a 1 or crashes).

This PR does not yet include additional tests to test for new Errors that are now part of the API. This will come later.