### PR TITLE
refactor: make scoped-registry type readonly

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -226,16 +226,19 @@ export const add = async function (
       log.notice("manifest", `existed ${packageReference(name, versionToAdd)}`);
     }
     if (!isUpstreamPackage && pkgsInScope.length > 0) {
-      let entry = tryGetScopedRegistryByUrl(manifest, env.registry.url);
-      if (entry === null) {
+      let targetScopedRegistry = tryGetScopedRegistryByUrl(
+        manifest,
+        env.registry.url
+      );
+      if (targetScopedRegistry === null) {
         const name = url.parse(env.registry.url).hostname;
         if (name === null) throw new Error("Could not resolve registry name");
-        entry = scopedRegistry(name, env.registry.url);
-        manifest = addScopedRegistry(manifest, entry);
+        targetScopedRegistry = scopedRegistry(name, env.registry.url);
+        manifest = addScopedRegistry(manifest, targetScopedRegistry);
         dirty = true;
       }
       pkgsInScope.forEach((name) => {
-        const wasAdded = addScope(entry!, name);
+        const wasAdded = addScope(targetScopedRegistry!, name);
         if (wasAdded) dirty = true;
       });
     }

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -141,25 +141,6 @@ export function addScopedRegistry(
 }
 
 /**
- * Removes a scoped-registry to the manifest.
- * @param manifest The manifest.
- * @param name The name of the scoped-registry to remove.
- */
-export function removeScopedRegistry(
-  manifest: UnityProjectManifest,
-  name: string
-): UnityProjectManifest {
-  if (manifest.scopedRegistries === undefined) return manifest;
-
-  return {
-    ...manifest,
-    scopedRegistries: manifest.scopedRegistries.filter(
-      (it) => it.name !== name
-    ),
-  };
-}
-
-/**
  * Adds a testable to the manifest, if it is not already added.
  * @param manifest The manifest.
  * @param name The testable name.

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -97,6 +97,37 @@ export function tryGetScopedRegistryByUrl(
 }
 
 /**
+ * Updates a scoped-registry in a manifest by applying a mapping-function to it.
+ * @param manifest The manifest.
+ * @param registryUrl The url of the scoped-registry that should be mapped.
+ * @param mapF The mapping function. Gets the scoped-registry with the given
+ * registry-url as input, or null if the manifest has no scoped-registry with
+ * that url. The scoped-registry returned by the function will be written back
+ * to the manifest. If the function returns null the scoped-registry will be
+ * removed from the manifest.
+ * @returns The updated manifest.
+ */
+export function mapScopedRegistry(
+  manifest: UnityProjectManifest,
+  registryUrl: RegistryUrl,
+  mapF: (scopedRegistry: ScopedRegistry | null) => ScopedRegistry | null
+): UnityProjectManifest {
+  const updated = mapF(tryGetScopedRegistryByUrl(manifest, registryUrl));
+
+  let newScopedRegistries = manifest.scopedRegistries?.filter(
+    (it) => it.url !== (updated?.url ?? registryUrl)
+  );
+
+  if (updated !== null)
+    newScopedRegistries = [...(newScopedRegistries ?? []), updated];
+
+  return {
+    ...manifest,
+    scopedRegistries: newScopedRegistries,
+  };
+}
+
+/**
  * Adds a scoped-registry to the manifest.
  * NOTE: Does not check if a scoped-registry with the same name already exists.
  * @param manifest The manifest.
@@ -106,10 +137,7 @@ export function addScopedRegistry(
   manifest: UnityProjectManifest,
   scopedRegistry: ScopedRegistry
 ): UnityProjectManifest {
-  return {
-    ...manifest,
-    scopedRegistries: [...(manifest.scopedRegistries ?? []), scopedRegistry],
-  };
+  return mapScopedRegistry(manifest, scopedRegistry.url, () => scopedRegistry);
 }
 
 /**
@@ -170,36 +198,5 @@ export function pruneManifest(
     scopedRegistries: manifest.scopedRegistries?.filter(
       (it) => it.scopes.length > 0
     ),
-  };
-}
-
-/**
- * Updates a scoped-registry in a manifest by applying a mapping-function to it.
- * @param manifest The manifest.
- * @param registryUrl The url of the scoped-registry that should be mapped.
- * @param mapF The mapping function. Gets the scoped-registry with the given
- * registry-url as input, or null if the manifest has no scoped-registry with
- * that url. The scoped-registry returned by the function will be written back
- * to the manifest. If the function returns null the scoped-registry will be
- * removed from the manifest.
- * @returns The updated manifest.
- */
-export function mapScopedRegistry(
-  manifest: UnityProjectManifest,
-  registryUrl: RegistryUrl,
-  mapF: (scopedRegistry: ScopedRegistry | null) => ScopedRegistry | null
-): UnityProjectManifest {
-  const updated = mapF(tryGetScopedRegistryByUrl(manifest, registryUrl));
-
-  let newScopedRegistries = manifest.scopedRegistries?.filter(
-    (it) => it.url !== (updated?.url ?? registryUrl)
-  );
-
-  if (updated !== null)
-    newScopedRegistries = [...(newScopedRegistries ?? []), updated];
-
-  return {
-    ...manifest,
-    scopedRegistries: newScopedRegistries,
   };
 }

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -172,3 +172,34 @@ export function pruneManifest(
     ),
   };
 }
+
+/**
+ * Updates a scoped-registry in a manifest by applying a mapping-function to it.
+ * @param manifest The manifest.
+ * @param registryUrl The url of the scoped-registry that should be mapped.
+ * @param mapF The mapping function. Gets the scoped-registry with the given
+ * registry-url as input, or null if the manifest has no scoped-registry with
+ * that url. The scoped-registry returned by the function will be written back
+ * to the manifest. If the function returns null the scoped-registry will be
+ * removed from the manifest.
+ * @returns The updated manifest.
+ */
+export function mapScopedRegistry(
+  manifest: UnityProjectManifest,
+  registryUrl: RegistryUrl,
+  mapF: (scopedRegistry: ScopedRegistry | null) => ScopedRegistry | null
+): UnityProjectManifest {
+  const updated = mapF(tryGetScopedRegistryByUrl(manifest, registryUrl));
+
+  let newScopedRegistries = manifest.scopedRegistries?.filter(
+    (it) => it.url !== (updated?.url ?? registryUrl)
+  );
+
+  if (updated !== null)
+    newScopedRegistries = [...(newScopedRegistries ?? []), updated];
+
+  return {
+    ...manifest,
+    scopedRegistries: newScopedRegistries,
+  };
+}

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -1,5 +1,5 @@
-import { RegistryUrl } from "./registry-url";
-import { DomainName } from "./domain-name";
+import {RegistryUrl} from "./registry-url";
+import {DomainName} from "./domain-name";
 
 /**
  * Contains information about a scoped registry.
@@ -49,13 +49,14 @@ export function hasScope(registry: ScopedRegistry, scope: DomainName): boolean {
  * also be sorted alphabetically.
  * @param registry The registry.
  * @param scope The scope.
- * @returns Boolean whether the scope was added successfully.
  */
-export function addScope(registry: ScopedRegistry, scope: DomainName): boolean {
-  if (hasScope(registry, scope)) return false;
+export function addScope(
+  registry: ScopedRegistry,
+  scope: DomainName
+): ScopedRegistry {
+  if (hasScope(registry, scope)) return registry;
 
-  registry.scopes = [...registry.scopes, scope].sort();
-  return true;
+  return { ...registry, scopes: [...registry.scopes, scope].sort() };
 }
 
 /**

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -1,5 +1,5 @@
-import {RegistryUrl} from "./registry-url";
-import {DomainName} from "./domain-name";
+import { RegistryUrl } from "./registry-url";
+import { DomainName } from "./domain-name";
 
 /**
  * Contains information about a scoped registry.
@@ -63,13 +63,10 @@ export function addScope(
  * Removes a scope from a registry.
  * @param registry The registry.
  * @param scope The scope.
- * @returns Boolean indicating whether a scope was actually removed.
  */
 export function removeScope(
   registry: ScopedRegistry,
   scope: DomainName
-): boolean {
-  const prevCount = registry.scopes.length;
-  registry.scopes = registry.scopes.filter((it) => it !== scope);
-  return registry.scopes.length !== prevCount;
+): ScopedRegistry {
+  return { ...registry, scopes: registry.scopes.filter((it) => it !== scope) };
 }

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -36,6 +36,15 @@ export function scopedRegistry(
 }
 
 /**
+ * Checks if a registry has a specific scope.
+ * @param registry The registry.
+ * @param scope The scope.
+ */
+export function hasScope(registry: ScopedRegistry, scope: DomainName): boolean {
+  return registry.scopes.includes(scope);
+}
+
+/**
  * Adds a scope to a registry if it is not already in the list. The scopes will
  * also be sorted alphabetically.
  * @param registry The registry.
@@ -43,19 +52,10 @@ export function scopedRegistry(
  * @returns Boolean whether the scope was added successfully.
  */
 export function addScope(registry: ScopedRegistry, scope: DomainName): boolean {
-  if (registry.scopes.includes(scope)) return false;
+  if (hasScope(registry, scope)) return false;
 
   registry.scopes = [...registry.scopes, scope].sort();
   return true;
-}
-
-/**
- * Checks if a registry has a specific scope.
- * @param registry The registry.
- * @param scope The scope.
- */
-export function hasScope(registry: ScopedRegistry, scope: DomainName): boolean {
-  return registry.scopes.includes(scope);
 }
 
 /**

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -5,7 +5,7 @@ import { DomainName } from "./domain-name";
  * Contains information about a scoped registry.
  * @see https://docs.unity3d.com/Manual/upm-scoped.html
  */
-export type ScopedRegistry = {
+export type ScopedRegistry = Readonly<{
   /**
    * The scope name as it appears in the user interface.
    */
@@ -19,7 +19,7 @@ export type ScopedRegistry = {
    * on the package name, or as a namespace.
    */
   scopes: ReadonlyArray<DomainName>;
-};
+}>;
 
 /**
  * Constructs a scoped registry.

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -18,7 +18,7 @@ export type ScopedRegistry = {
    * Array of scopes that you can map to a package name, either as an exact match
    * on the package name, or as a namespace.
    */
-  scopes: DomainName[];
+  scopes: ReadonlyArray<DomainName>;
 };
 
 /**
@@ -45,8 +45,7 @@ export function scopedRegistry(
 export function addScope(registry: ScopedRegistry, scope: DomainName): boolean {
   if (registry.scopes.includes(scope)) return false;
 
-  registry.scopes.push(scope);
-  registry.scopes.sort();
+  registry.scopes = [...registry.scopes, scope].sort();
   return true;
 }
 

--- a/src/utils/array-utils.ts
+++ b/src/utils/array-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Compares two arrays to see if they are equal (i.e. Have the same length
+ * and equal elements). Elements are compared using `===`.
+ * @param a The first array.
+ * @param b The second array.
+ */
+export function areArraysEqual<T>(
+  a: ReadonlyArray<T>,
+  b: ReadonlyArray<T>
+): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}

--- a/test/data-project-manifest.ts
+++ b/test/data-project-manifest.ts
@@ -5,9 +5,9 @@ import { isSemanticVersion } from "../src/types/semantic-version";
 import { addScope, scopedRegistry } from "../src/types/scoped-registry";
 import {
   addDependency,
-  addScopedRegistry,
   addTestable,
   emptyProjectManifest,
+  mapScopedRegistry,
   UnityProjectManifest,
 } from "../src/types/project-manifest";
 
@@ -28,14 +28,15 @@ class UnityProjectManifestBuilder {
   addScope(name: string): UnityProjectManifestBuilder {
     assert(isDomainName(name), `${name} is domain name`);
 
-    if (this.manifest.scopedRegistries === undefined)
-      this.manifest = addScopedRegistry(
-        this.manifest,
-        scopedRegistry("example.com", exampleRegistryUrl)
-      );
-
-    const registry = this.manifest.scopedRegistries![0]!;
-    addScope(registry, name);
+    this.manifest = mapScopedRegistry(
+      this.manifest,
+      exampleRegistryUrl,
+      (registry) => {
+        if (registry === null)
+          registry = scopedRegistry("example.com", exampleRegistryUrl);
+        return addScope(registry, name);
+      }
+    );
 
     return this;
   }

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -9,7 +9,7 @@ import { semanticVersion } from "../src/types/semantic-version";
 import {
   addDependency,
   manifestPathFor,
-  tryGetScopedRegistryByUrl,
+  mapScopedRegistry,
 } from "../src/types/project-manifest";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import fse from "fs-extra";
@@ -78,14 +78,16 @@ describe("project-manifest io", () => {
   it("should not save scoped-registry with empty scopes", async () => {
     // Add and then remove a scope to force an empty scoped-registry
     const testDomain = "test" as DomainName;
-    const initialManifest = buildProjectManifest((manifest) =>
+    let initialManifest = buildProjectManifest((manifest) =>
       manifest.addScope(testDomain)
     );
-    const scopedRegistry = tryGetScopedRegistryByUrl(
+    initialManifest = mapScopedRegistry(
       initialManifest,
-      exampleRegistryUrl
-    )!;
-    removeScope(scopedRegistry, testDomain);
+      exampleRegistryUrl,
+      (registry) => {
+        return removeScope(registry!, testDomain);
+      }
+    );
 
     // Save and load manifest
     expect(

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -119,8 +119,7 @@ describe("project-manifest", function () {
     it("should not updated scoped-registry after returning it", () => {
       let manifest = emptyProjectManifest;
       const initial = scopedRegistry("test", exampleRegistryUrl);
-      const expected = { ...initial };
-      addScope(expected, domainName("wow"));
+      const expected = addScope(initial, domainName("wow"));
       manifest = addScopedRegistry(manifest, initial);
 
       manifest = mapScopedRegistry(

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -3,13 +3,15 @@ import {
   addScopedRegistry,
   addTestable,
   emptyProjectManifest,
+  mapScopedRegistry,
   removeDependency,
   tryGetScopedRegistryByUrl,
 } from "../src/types/project-manifest";
 import { domainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
-import { scopedRegistry } from "../src/types/scoped-registry";
+import { addScope, scopedRegistry } from "../src/types/scoped-registry";
 import { registryUrl } from "../src/types/registry-url";
+import { exampleRegistryUrl } from "./mock-registry";
 
 describe("project-manifest", function () {
   describe("dependency", function () {
@@ -60,7 +62,7 @@ describe("project-manifest", function () {
       expect(manifest.dependencies).toEqual({});
     });
   });
-  describe("scoped-registry", function () {
+  describe("get scoped-registry", function () {
     it("should should find scoped-registry with url if present", () => {
       let manifest = emptyProjectManifest;
       const url = registryUrl("https://test.com");
@@ -78,6 +80,57 @@ describe("project-manifest", function () {
       manifest = addScopedRegistry(manifest, expected);
 
       expect(tryGetScopedRegistryByUrl(manifest, url)).toBeNull();
+    });
+  });
+  describe("map scoped-registry", function () {
+    it("should have null as mapping input if manifest does not have scoped-registry", () => {
+      const manifest = emptyProjectManifest;
+
+      expect.assertions(1);
+      mapScopedRegistry(manifest, exampleRegistryUrl, (registry) => {
+        expect(registry).toBeNull();
+        return registry;
+      });
+    });
+
+    it("should have scoped-registry as input if found", () => {
+      let manifest = emptyProjectManifest;
+      const expected = scopedRegistry("test", exampleRegistryUrl);
+      manifest = addScopedRegistry(manifest, expected);
+
+      expect.assertions(1);
+      mapScopedRegistry(manifest, exampleRegistryUrl, (registry) => {
+        expect(registry).toEqual(expected);
+        return registry;
+      });
+    });
+
+    it("should not have scoped-registry after returning null", () => {
+      let manifest = emptyProjectManifest;
+      const initial = scopedRegistry("test", exampleRegistryUrl);
+      manifest = addScopedRegistry(manifest, initial);
+
+      manifest = mapScopedRegistry(manifest, exampleRegistryUrl, () => null);
+
+      const actual = tryGetScopedRegistryByUrl(manifest, exampleRegistryUrl);
+      expect(actual).toBeNull();
+    });
+
+    it("should not updated scoped-registry after returning it", () => {
+      let manifest = emptyProjectManifest;
+      const initial = scopedRegistry("test", exampleRegistryUrl);
+      const expected = { ...initial };
+      addScope(expected, domainName("wow"));
+      manifest = addScopedRegistry(manifest, initial);
+
+      manifest = mapScopedRegistry(
+        manifest,
+        exampleRegistryUrl,
+        () => expected
+      );
+
+      const actual = tryGetScopedRegistryByUrl(manifest, exampleRegistryUrl);
+      expect(actual).toEqual(expected);
     });
   });
   describe("testables", function () {

--- a/test/scoped-registry.test.ts
+++ b/test/scoped-registry.test.ts
@@ -48,25 +48,31 @@ describe("scoped-registry", function () {
   });
   describe("remove scope", function () {
     it("should not have scope after removing it", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl, [
+      let registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
       ]);
-      expect(removeScope(registry, domainName("a"))).toBeTruthy();
+
+      registry = removeScope(registry, domainName("a"));
+
       expect(hasScope(registry, domainName("a"))).toBeFalsy();
     });
     it("should not do nothing if scope does not exist", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl, [
+      let registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
       ]);
-      expect(removeScope(registry, domainName("b"))).toBeFalsy();
+
+      registry = removeScope(registry, domainName("b"));
+
       expect(hasScope(registry, domainName("a"))).toBeTruthy();
     });
     it("should remove duplicate scopes", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl, [
+      let registry = scopedRegistry("test", exampleRegistryUrl, [
         domainName("a"),
         domainName("a"),
       ]);
-      expect(removeScope(registry, domainName("a"))).toBeTruthy();
+
+      registry = removeScope(registry, domainName("a"));
+
       expect(registry.scopes).toHaveLength(0);
     });
   });

--- a/test/scoped-registry.test.ts
+++ b/test/scoped-registry.test.ts
@@ -16,26 +16,33 @@ describe("scoped-registry", function () {
   });
   describe("add scope", function () {
     it("should keep scope-list alphabetical", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
-      expect(addScope(registry, domainName("b"))).toBeTruthy();
-      expect(addScope(registry, domainName("a"))).toBeTruthy();
+      let registry = scopedRegistry("test", exampleRegistryUrl);
+
+      registry = addScope(registry, domainName("b"));
+      registry = addScope(registry, domainName("a"));
+
       expect(registry.scopes).toEqual(["a", "b"]);
     });
     it("should filter duplicates", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
-      expect(addScope(registry, domainName("a"))).toBeTruthy();
-      expect(addScope(registry, domainName("a"))).toBeFalsy();
+      let registry = scopedRegistry("test", exampleRegistryUrl);
+
+      registry = addScope(registry, domainName("a"));
+      registry = addScope(registry, domainName("a"));
+
       expect(registry.scopes).toEqual(["a"]);
     });
   });
   describe("has scope", function () {
     it("should have scope that was added", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
-      addScope(registry, domainName("a"));
+      let registry = scopedRegistry("test", exampleRegistryUrl);
+
+      registry = addScope(registry, domainName("a"));
+
       expect(hasScope(registry, domainName("a"))).toBeTruthy();
     });
     it("should not have scope that was not added", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
+
       expect(hasScope(registry, domainName("a"))).toBeFalsy();
     });
   });


### PR DESCRIPTION
Refactors the `ScopedRegistry` type to be immutable/readonly. This way it is aligned with other types which are now also mostly immutable.

Also adds a utility function `mapScopedRegistry` to modify a scoped-registry inside a manifest.