### PR TITLE
refactor: disambiguate constructors

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -17,7 +17,7 @@ import {
   PackageReference,
   splitPackageReference,
 } from "./types/package-reference";
-import { addScope, scopedRegistry } from "./types/scoped-registry";
+import { addScope, makeScopedRegistry } from "./types/scoped-registry";
 import {
   addDependency,
   addScopedRegistry,
@@ -236,7 +236,7 @@ export const add = async function (
       if (entry === null) {
         const name = url.parse(env.registry.url).hostname;
         if (name === null) throw new Error("Could not resolve registry name");
-        entry = scopedRegistry(name, env.registry.url);
+        entry = makeScopedRegistry(name, env.registry.url);
         manifest = addScopedRegistry(manifest, entry);
         dirty = true;
       }

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -13,7 +13,7 @@ import {
 import { makeNpmClient } from "./npm-client";
 import { DomainName } from "./types/domain-name";
 import {
-  packageReference,
+  makePackageReference,
   PackageReference,
   splitPackageReference,
 } from "./types/package-reference";
@@ -180,7 +180,7 @@ export const add = async function (
               if (depObj.reason.issue === "VersionNotFound")
                 log.notice(
                   "suggest",
-                  `to install ${packageReference(
+                  `to install ${makePackageReference(
                     depObj.name,
                     depObj.reason.requestedVersion
                   )} or a replaceable version manually`
@@ -212,7 +212,10 @@ export const add = async function (
     );
     if (!oldVersion) {
       // Log the added package
-      log.notice("manifest", `added ${packageReference(name, versionToAdd)}`);
+      log.notice(
+        "manifest",
+        `added ${makePackageReference(name, versionToAdd)}`
+      );
       dirty = true;
     } else if (oldVersion !== versionToAdd) {
       // Log the modified package version
@@ -223,7 +226,10 @@ export const add = async function (
       dirty = true;
     } else {
       // Log the existed package
-      log.notice("manifest", `existed ${packageReference(name, versionToAdd)}`);
+      log.notice(
+        "manifest",
+        `existed ${makePackageReference(name, versionToAdd)}`
+      );
     }
     if (!isUpstreamPackage && pkgsInScope.length > 0) {
       let entry = tryGetScopedRegistryByUrl(manifest, env.registry.url);

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -3,7 +3,7 @@ import { parseEnv } from "./utils/env";
 import { makeNpmClient } from "./npm-client";
 import { isPackageUrl } from "./types/package-url";
 import {
-  packageReference,
+  makePackageReference,
   PackageReference,
   splitPackageReference,
 } from "./types/package-reference";
@@ -52,7 +52,7 @@ export const deps = async function (
   depsValid
     .filter((x) => !x.self)
     .forEach((x) =>
-      log.notice("dependency", `${packageReference(x.name, x.version)}`)
+      log.notice("dependency", `${makePackageReference(x.name, x.version)}`)
     );
   depsInvalid
     .filter((x) => !x.self)

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -6,7 +6,7 @@ import {
 import { parseEnv } from "./utils/env";
 import {
   hasVersion,
-  packageReference,
+  makePackageReference,
   PackageReference,
 } from "./types/package-reference";
 import { removeScope } from "./types/scoped-registry";
@@ -53,7 +53,7 @@ export const remove = async function (
     if (versionInManifest) {
       log.notice(
         "manifest",
-        `removed ${packageReference(pkg, versionInManifest)}`
+        `removed ${makePackageReference(pkg, versionInManifest)}`
       );
       manifest = removeDependency(manifest, pkg);
       dirty = true;

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -1,7 +1,7 @@
 import { DomainName, isInternalPackage } from "./types/domain-name";
 import { isSemanticVersion, SemanticVersion } from "./types/semantic-version";
 import log from "./logger";
-import { packageReference } from "./types/package-reference";
+import { makePackageReference } from "./types/package-reference";
 import { addToCache, emptyPackumentCache } from "./packument-cache";
 import {
   pickMostFixable,
@@ -75,7 +75,7 @@ export const fetchPackageDependencies = async function (
 ): Promise<[ValidDependency[], InvalidDependency[]]> {
   log.verbose(
     "dependency",
-    `fetch: ${packageReference(name, version)} deep=${deep}`
+    `fetch: ${makePackageReference(name, version)} deep=${deep}`
   );
   // a list of pending dependency {name, version}
   const pendingList: NameVersionPair[] = [{ name, version }];
@@ -203,7 +203,7 @@ export const fetchPackageDependencies = async function (
       });
       log.verbose(
         "dependency",
-        `${packageReference(entry.name, resolvedVersion)} ${
+        `${makePackageReference(entry.name, resolvedVersion)} ${
           isInternal ? "[internal] " : ""
         }${isUpstream ? "[upstream]" : ""}`
       );

--- a/src/types/domain-name.ts
+++ b/src/types/domain-name.ts
@@ -75,7 +75,7 @@ export const isInternalPackage = (name: DomainName): boolean => {
  * @param s The string.
  * @throws {assert.AssertionError} If string is not in valid format.
  */
-export function domainName(s: string): DomainName {
+export function makeDomainName(s: string): DomainName {
   assert(isDomainName(s), `"${s}" is a domain name`);
   return s;
 }

--- a/src/types/package-id.ts
+++ b/src/types/package-id.ts
@@ -25,7 +25,7 @@ export function isPackageId(s: string): s is PackageId {
  * @param name The package name.
  * @param version The version.
  */
-export function packageId(
+export function makePackageId(
   name: DomainName,
   version: SemanticVersion
 ): PackageId {

--- a/src/types/package-reference.ts
+++ b/src/types/package-reference.ts
@@ -66,7 +66,7 @@ export function splitPackageReference(
  * @param version Optional version-reference. Will be validated to be a
  * {@link VersionReference}.
  */
-export function packageReference(
+export function makePackageReference(
   name: string,
   version?: string
 ): PackageReference {

--- a/src/types/registry-url.ts
+++ b/src/types/registry-url.ts
@@ -21,7 +21,7 @@ export function isRegistryUrl(s: string): s is RegistryUrl {
  * @param s The string.
  * @throws {assert.AssertionError} If string does not have valid format.
  */
-export function registryUrl(s: string): RegistryUrl {
+export function makeRegistryUrl(s: string): RegistryUrl {
   assert(isRegistryUrl(s), `"${s}" is url`);
   return s;
 }
@@ -36,7 +36,7 @@ export function registryUrl(s: string): RegistryUrl {
 export function coerceRegistryUrl(s: string): RegistryUrl {
   if (!s.toLowerCase().startsWith("http")) s = "http://" + s;
   s = removeTrailingSlash(s);
-  return registryUrl(s);
+  return makeRegistryUrl(s);
 }
 
-export const unityRegistryUrl = registryUrl("https://packages.unity.com");
+export const unityRegistryUrl = makeRegistryUrl("https://packages.unity.com");

--- a/src/types/scoped-registry.ts
+++ b/src/types/scoped-registry.ts
@@ -27,7 +27,7 @@ export type ScopedRegistry = {
  * @param url The url.
  * @param scopes The scopes. If not specified defaults to empty array.
  */
-export function scopedRegistry(
+export function makeScopedRegistry(
   name: string,
   url: RegistryUrl,
   scopes?: DomainName[]

--- a/src/types/semantic-version.ts
+++ b/src/types/semantic-version.ts
@@ -20,7 +20,7 @@ export function isSemanticVersion(s: string): s is SemanticVersion {
  * Constructs a semantic version from a string.
  * @param s The string. Will be validated.
  */
-export function semanticVersion(s: string): SemanticVersion {
+export function makeSemanticVersion(s: string): SemanticVersion {
   assert(isSemanticVersion(s), `"${s}" is a semantic version`);
   return s;
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,7 +4,7 @@ import { getUpmConfigDir, loadUpmConfig } from "./upm-config-io";
 import path from "path";
 import fs from "fs";
 import yaml from "yaml";
-import { coerceRegistryUrl, registryUrl } from "../types/registry-url";
+import { coerceRegistryUrl, makeRegistryUrl } from "../types/registry-url";
 import { tryGetAuthForRegistry } from "../types/upm-config";
 import { CmdOptions } from "../types/options";
 import { manifestPathFor } from "../types/project-manifest";
@@ -30,13 +30,13 @@ export const parseEnv = async function (
 ): Promise<Env | null> {
   // set defaults
   let registry: Registry = {
-    url: registryUrl("https://package.openupm.com"),
+    url: makeRegistryUrl("https://package.openupm.com"),
     auth: null,
   };
   let cwd = "";
   let upstream = true;
   let upstreamRegistry: Registry = {
-    url: registryUrl("https://packages.unity.com"),
+    url: makeRegistryUrl("https://packages.unity.com"),
     auth: null,
   };
   let systemUser = false;
@@ -56,11 +56,11 @@ export const parseEnv = async function (
   // region cn
   if (options._global.cn === true) {
     registry = {
-      url: registryUrl("https://package.openupm.cn"),
+      url: makeRegistryUrl("https://package.openupm.cn"),
       auth: null,
     };
     upstreamRegistry = {
-      url: registryUrl("https://packages.unity.cn"),
+      url: makeRegistryUrl("https://packages.unity.cn"),
       auth: null,
     };
     log.notice("region", "cn");

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,5 +1,5 @@
 import promptly from "promptly";
-import { registryUrl, RegistryUrl } from "../types/registry-url";
+import { makeRegistryUrl, RegistryUrl } from "../types/registry-url";
 
 export function promptUsername(): Promise<string> {
   return promptly.prompt("Username: ");
@@ -15,6 +15,6 @@ export function promptEmail(): Promise<string> {
 
 export function promptRegistryUrl(): Promise<RegistryUrl> {
   return promptly.prompt("Registry: ", {
-    validator: [registryUrl],
+    validator: [makeRegistryUrl],
   }) as Promise<RegistryUrl>;
 }

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -13,7 +13,7 @@ import { buildProjectManifest } from "./data-project-manifest";
 import { makeDomainName } from "../src/types/domain-name";
 import { PackageUrl } from "../src/types/package-url";
 import { semanticVersion } from "../src/types/semantic-version";
-import { packageReference } from "../src/types/package-reference";
+import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
 describe("cmd-add.ts", function () {
@@ -165,7 +165,7 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@1.0.0", async function () {
       const retCode = await add(
-        packageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, semanticVersion("1.0.0")),
         options
       );
       expect(retCode).toEqual(0);
@@ -176,7 +176,10 @@ describe("cmd-add.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
     it("add pkg@latest", async function () {
-      const retCode = await add(packageReference(packageA, "latest"), options);
+      const retCode = await add(
+        makePackageReference(packageA, "latest"),
+        options
+      );
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toEqual(expectedManifestA)
@@ -186,12 +189,12 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@0.1.0 then pkg@1.0.0", async function () {
       const retCode1 = await add(
-        packageReference(packageA, semanticVersion("0.1.0")),
+        makePackageReference(packageA, semanticVersion("0.1.0")),
         options
       );
       expect(retCode1).toEqual(0);
       const retCode2 = await add(
-        packageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, semanticVersion("1.0.0")),
         options
       );
       expect(retCode2).toEqual(0);
@@ -203,12 +206,12 @@ describe("cmd-add.ts", function () {
     });
     it("add exited pkg version", async function () {
       const retCode1 = await add(
-        packageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, semanticVersion("1.0.0")),
         options
       );
       expect(retCode1).toEqual(0);
       const retCode2 = await add(
-        packageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, semanticVersion("1.0.0")),
         options
       );
       expect(retCode2).toEqual(0);
@@ -220,7 +223,7 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@not-exist-version", async function () {
       const retCode = await add(
-        packageReference(packageA, semanticVersion("2.0.0")),
+        makePackageReference(packageA, semanticVersion("2.0.0")),
         options
       );
       expect(retCode).toEqual(1);
@@ -236,7 +239,10 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@http", async function () {
       const gitUrl = "https://github.com/yo/com.base.package-a" as PackageUrl;
-      const retCode = await add(packageReference(packageA, gitUrl), options);
+      const retCode = await add(
+        makePackageReference(packageA, gitUrl),
+        options
+      );
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toHaveDependency(packageA, gitUrl)
@@ -249,7 +255,10 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@git", async function () {
       const gitUrl = "git@github.com:yo/com.base.package-a" as PackageUrl;
-      const retCode = await add(packageReference(packageA, gitUrl), options);
+      const retCode = await add(
+        makePackageReference(packageA, gitUrl),
+        options
+      );
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toHaveDependency(packageA, gitUrl)
@@ -262,7 +271,10 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@file", async function () {
       const fileUrl = "file../yo/com.base.package-a" as PackageUrl;
-      const retCode = await add(packageReference(packageA, fileUrl), options);
+      const retCode = await add(
+        makePackageReference(packageA, fileUrl),
+        options
+      );
       expect(retCode).toEqual(0);
       await mockProject.tryAssertManifest((manifest) =>
         expect(manifest).toHaveDependency(packageA, fileUrl)
@@ -319,7 +331,7 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg with nested dependencies", async function () {
       const retCode = await add(
-        packageReference(packageC, "latest"),
+        makePackageReference(packageC, "latest"),
         upstreamOptions
       );
       expect(retCode).toEqual(0);

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -12,7 +12,7 @@ import { buildPackument } from "./data-packument";
 import { buildProjectManifest } from "./data-project-manifest";
 import { makeDomainName } from "../src/types/domain-name";
 import { PackageUrl } from "../src/types/package-url";
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
@@ -165,7 +165,7 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@1.0.0", async function () {
       const retCode = await add(
-        makePackageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
       expect(retCode).toEqual(0);
@@ -189,12 +189,12 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@0.1.0 then pkg@1.0.0", async function () {
       const retCode1 = await add(
-        makePackageReference(packageA, semanticVersion("0.1.0")),
+        makePackageReference(packageA, makeSemanticVersion("0.1.0")),
         options
       );
       expect(retCode1).toEqual(0);
       const retCode2 = await add(
-        makePackageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
       expect(retCode2).toEqual(0);
@@ -206,12 +206,12 @@ describe("cmd-add.ts", function () {
     });
     it("add exited pkg version", async function () {
       const retCode1 = await add(
-        makePackageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
       expect(retCode1).toEqual(0);
       const retCode2 = await add(
-        makePackageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
       expect(retCode2).toEqual(0);
@@ -223,7 +223,7 @@ describe("cmd-add.ts", function () {
     });
     it("add pkg@not-exist-version", async function () {
       const retCode = await add(
-        makePackageReference(packageA, semanticVersion("2.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("2.0.0")),
         options
       );
       expect(retCode).toEqual(1);

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -10,26 +10,26 @@ import {
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildPackument } from "./data-packument";
 import { buildProjectManifest } from "./data-project-manifest";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { PackageUrl } from "../src/types/package-url";
 import { semanticVersion } from "../src/types/semantic-version";
 import { packageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
 describe("cmd-add.ts", function () {
-  const packageMissing = domainName("pkg-not-exist");
-  const packageA = domainName("com.base.package-a");
-  const packageB = domainName("com.base.package-b");
-  const packageC = domainName("com.base.package-c");
-  const packageD = domainName("com.base.package-d");
-  const packageUp = domainName("com.upstream.package-up");
-  const packageLowerEditor = domainName(
+  const packageMissing = makeDomainName("pkg-not-exist");
+  const packageA = makeDomainName("com.base.package-a");
+  const packageB = makeDomainName("com.base.package-b");
+  const packageC = makeDomainName("com.base.package-c");
+  const packageD = makeDomainName("com.base.package-d");
+  const packageUp = makeDomainName("com.upstream.package-up");
+  const packageLowerEditor = makeDomainName(
     "com.base.package-with-lower-editor-version"
   );
-  const packageHigherEditor = domainName(
+  const packageHigherEditor = makeDomainName(
     "com.base.package-with-higher-editor-version"
   );
-  const packageWrongEditor = domainName(
+  const packageWrongEditor = makeDomainName(
     "com.base.package-with-wrong-editor-version"
   );
 

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildPackument } from "./data-packument";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { packageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
@@ -103,7 +103,7 @@ describe("cmd-deps.ts", function () {
       expect(mockConsole).toHaveLineIncluding("out", "is not a valid choice");
     });
     it("deps pkg-not-exist", async function () {
-      const retCode = await deps(domainName("pkg-not-exist"), options);
+      const retCode = await deps(makeDomainName("pkg-not-exist"), options);
       expect(retCode).toEqual(0);
       expect(mockConsole).toHaveLineIncluding("out", "not found");
     });

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -10,7 +10,7 @@ import {
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildPackument } from "./data-packument";
 import { makeDomainName } from "../src/types/domain-name";
-import { packageReference } from "../src/types/package-reference";
+import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
 describe("cmd-deps.ts", function () {
@@ -80,7 +80,7 @@ describe("cmd-deps.ts", function () {
     });
     it("deps pkg@latest", async function () {
       const retCode = await deps(
-        packageReference(remotePackumentA.name, "latest"),
+        makePackageReference(remotePackumentA.name, "latest"),
         options
       );
       expect(retCode).toEqual(0);
@@ -88,7 +88,7 @@ describe("cmd-deps.ts", function () {
     });
     it("deps pkg@1.0.0", async function () {
       const retCode = await deps(
-        packageReference(remotePackumentA.name, "1.0.0"),
+        makePackageReference(remotePackumentA.name, "1.0.0"),
         options
       );
       expect(retCode).toEqual(0);
@@ -96,7 +96,7 @@ describe("cmd-deps.ts", function () {
     });
     it("deps pkg@not-exist-version", async function () {
       const retCode = await deps(
-        packageReference(remotePackumentA.name, "2.0.0"),
+        makePackageReference(remotePackumentA.name, "2.0.0"),
         options
       );
       expect(retCode).toEqual(0);

--- a/test/cmd-login.test.ts
+++ b/test/cmd-login.test.ts
@@ -1,6 +1,6 @@
 import "nock";
 import { generateNpmrcLines, getNpmrcPath } from "../src/cmd-login";
-import { registryUrl } from "../src/types/registry-url";
+import { makeRegistryUrl } from "../src/types/registry-url";
 import { runWithEnv } from "./mock-env";
 import path from "path";
 
@@ -10,7 +10,7 @@ describe("cmd-login.ts", function () {
       expect(
         generateNpmrcLines(
           "",
-          registryUrl("http://registry.npmjs.org"),
+          makeRegistryUrl("http://registry.npmjs.org"),
           "123-456-789"
         )
       ).toEqual(["//registry.npmjs.org/:_authToken=123-456-789"]);
@@ -19,7 +19,7 @@ describe("cmd-login.ts", function () {
       expect(
         generateNpmrcLines(
           "registry=https://registry.npmjs.org/",
-          registryUrl(" registry(http://registry.npmjs.org"),
+          makeRegistryUrl(" registry(http://registry.npmjs.org"),
           "123-456-789"
         )
       ).toEqual([
@@ -31,7 +31,7 @@ describe("cmd-login.ts", function () {
       expect(
         generateNpmrcLines(
           "registry=https://registry.npmjs.org/\n//127.0.0.1:4873/:_authToken=blar-blar-blar\n//registry.npmjs.org/:_authToken=blar-blar-blar",
-          registryUrl("http://registry.npmjs.org"),
+          makeRegistryUrl("http://registry.npmjs.org"),
           "123-456-789"
         )
       ).toEqual([
@@ -44,7 +44,7 @@ describe("cmd-login.ts", function () {
       expect(
         generateNpmrcLines(
           "",
-          registryUrl("http://registry.npmjs.org"),
+          makeRegistryUrl("http://registry.npmjs.org"),
           "123-456-789"
         )
       ).toEqual(["//registry.npmjs.org/:_authToken=123-456-789"]);
@@ -53,14 +53,14 @@ describe("cmd-login.ts", function () {
       expect(
         generateNpmrcLines(
           "",
-          registryUrl("http://registry.npmjs.org"),
+          makeRegistryUrl("http://registry.npmjs.org"),
           "=123-456-789="
         )
       ).toEqual(['//registry.npmjs.org/:_authToken="=123-456-789="']);
       expect(
         generateNpmrcLines(
           "",
-          registryUrl("http://registry.npmjs.org"),
+          makeRegistryUrl("http://registry.npmjs.org"),
           "?123-456-789?"
         )
       ).toEqual(['//registry.npmjs.org/:_authToken="?123-456-789?"']);

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -4,7 +4,7 @@ import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildProjectManifest } from "./data-project-manifest";
 import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
-import { packageReference } from "../src/types/package-reference";
+import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
 const packageA = makeDomainName("com.example.package-a");
@@ -61,7 +61,7 @@ describe("cmd-remove.ts", function () {
         },
       };
       const retCode = await remove(
-        packageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, semanticVersion("1.0.0")),
         options
       );
       expect(retCode).toEqual(1);

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -2,14 +2,14 @@ import { remove } from "../src/cmd-remove";
 import { exampleRegistryUrl } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildProjectManifest } from "./data-project-manifest";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import { packageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
-const packageA = domainName("com.example.package-a");
-const packageB = domainName("com.example.package-b");
-const missingPackage = domainName("pkg-not-exist");
+const packageA = makeDomainName("com.example.package-a");
+const packageB = makeDomainName("com.example.package-b");
+const missingPackage = makeDomainName("pkg-not-exist");
 
 describe("cmd-remove.ts", function () {
   describe("remove", function () {

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -3,7 +3,7 @@ import { exampleRegistryUrl } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildProjectManifest } from "./data-project-manifest";
 import { makeDomainName } from "../src/types/domain-name";
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
@@ -61,7 +61,7 @@ describe("cmd-remove.ts", function () {
         },
       };
       const retCode = await remove(
-        makePackageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
       expect(retCode).toEqual(1);

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -10,7 +10,7 @@ import {
 import { SearchEndpointResult } from "./types";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { makeDomainName } from "../src/types/domain-name";
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
 describe("cmd-search.ts", function () {
@@ -48,7 +48,7 @@ describe("cmd-search.ts", function () {
           package: {
             name: makeDomainName("com.example.package-a"),
             scope: "unscoped",
-            version: semanticVersion("1.0.0"),
+            version: makeSemanticVersion("1.0.0"),
             description: "A demo package",
             date: "2019-10-02T04:02:38.335Z",
             links: {},

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./mock-registry";
 import { SearchEndpointResult } from "./types";
 import { attachMockConsole, MockConsole } from "./mock-console";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
@@ -46,7 +46,7 @@ describe("cmd-search.ts", function () {
       objects: [
         {
           package: {
-            name: domainName("com.example.package-a"),
+            name: makeDomainName("com.example.package-a"),
             scope: "unscoped",
             version: semanticVersion("1.0.0"),
             description: "A demo package",

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -9,14 +9,14 @@ import {
 } from "./mock-registry";
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildPackument } from "./data-packument";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import { packageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
-const packageA = domainName("com.example.package-a");
-const packageUp = domainName("com.example.package-up");
-const packageMissing = domainName("pkg-not-exist");
+const packageA = makeDomainName("com.example.package-a");
+const packageUp = makeDomainName("com.example.package-up");
+const packageMissing = makeDomainName("pkg-not-exist");
 
 describe("cmd-view.ts", function () {
   const options: ViewOptions = {

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -11,7 +11,7 @@ import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildPackument } from "./data-packument";
 import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
-import { packageReference } from "../src/types/package-reference";
+import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
 const packageA = makeDomainName("com.example.package-a");
@@ -133,7 +133,7 @@ describe("cmd-view.ts", function () {
     });
     it("view pkg@1.0.0", async function () {
       const retCode = await view(
-        packageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, semanticVersion("1.0.0")),
         options
       );
       expect(retCode).toEqual(1);

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -10,7 +10,7 @@ import {
 import { attachMockConsole, MockConsole } from "./mock-console";
 import { buildPackument } from "./data-packument";
 import { makeDomainName } from "../src/types/domain-name";
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 import { makePackageReference } from "../src/types/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 
@@ -41,7 +41,7 @@ describe("cmd-view.ts", function () {
         .set("time", {
           modified: "2019-11-28T18:51:58.123Z",
           created: "2019-11-28T18:51:58.123Z",
-          [semanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
+          [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
         })
         .set("_rev", "3-418f950115c32bd0")
         .set("readme", "A demo package")
@@ -73,7 +73,7 @@ describe("cmd-view.ts", function () {
         .set("time", {
           modified: "2019-11-28T18:51:58.123Z",
           created: "2019-11-28T18:51:58.123Z",
-          [semanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
+          [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
         })
         .set("_rev", "3-418f950115c32bd0")
         .set("readme", "A demo package")
@@ -133,7 +133,7 @@ describe("cmd-view.ts", function () {
     });
     it("view pkg@1.0.0", async function () {
       const retCode = await view(
-        makePackageReference(packageA, semanticVersion("1.0.0")),
+        makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
       expect(retCode).toEqual(1);

--- a/test/data-packument.ts
+++ b/test/data-packument.ts
@@ -4,7 +4,7 @@ import {
   isSemanticVersion,
   SemanticVersion,
 } from "../src/types/semantic-version";
-import { packageId } from "../src/types/package-id";
+import { makePackageId } from "../src/types/package-id";
 import { UnityPackument, UnityPackumentVersion } from "../src/types/packument";
 
 /**
@@ -16,7 +16,7 @@ class UnityPackumentVersionBuilder {
   constructor(name: DomainName, version: SemanticVersion) {
     this.version = {
       name,
-      _id: packageId(name, version),
+      _id: makePackageId(name, version),
       version,
       dependencies: {},
       contributors: [],

--- a/test/data-project-manifest.ts
+++ b/test/data-project-manifest.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { isDomainName } from "../src/types/domain-name";
 import { exampleRegistryUrl } from "./mock-registry";
 import { isSemanticVersion } from "../src/types/semantic-version";
-import { addScope, scopedRegistry } from "../src/types/scoped-registry";
+import { addScope, makeScopedRegistry } from "../src/types/scoped-registry";
 import {
   addDependency,
   addScopedRegistry,
@@ -31,7 +31,7 @@ class UnityProjectManifestBuilder {
     if (this.manifest.scopedRegistries === undefined)
       this.manifest = addScopedRegistry(
         this.manifest,
-        scopedRegistry("example.com", exampleRegistryUrl)
+        makeScopedRegistry("example.com", exampleRegistryUrl)
       );
 
     const registry = this.manifest.scopedRegistries![0]!;

--- a/test/domain-name.test.ts
+++ b/test/domain-name.test.ts
@@ -1,5 +1,5 @@
 import {
-  domainName,
+  makeDomainName,
   isDomainName,
   isInternalPackage,
   namespaceFor,
@@ -53,15 +53,15 @@ describe("domain-name", function () {
   describe("internal package", function () {
     it("test com.otherorg.software", function () {
       expect(
-        isInternalPackage(domainName("com.otherorg.software"))
+        isInternalPackage(makeDomainName("com.otherorg.software"))
       ).not.toBeTruthy();
     });
     it("test com.unity.ugui", function () {
-      expect(isInternalPackage(domainName("com.unity.ugui"))).toBeTruthy();
+      expect(isInternalPackage(makeDomainName("com.unity.ugui"))).toBeTruthy();
     });
     it("test com.unity.modules.tilemap", function () {
       expect(
-        isInternalPackage(domainName("com.unity.modules.tilemap"))
+        isInternalPackage(makeDomainName("com.unity.modules.tilemap"))
       ).toBeTruthy();
     });
   });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,6 +1,6 @@
 import { parseEnv } from "../src/utils/env";
 import { attachMockConsole, MockConsole } from "./mock-console";
-import { registryUrl } from "../src/types/registry-url";
+import { makeRegistryUrl } from "../src/types/registry-url";
 import { TokenAuth, UPMConfig } from "../src/types/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
@@ -18,7 +18,7 @@ const testNpmAuth: NpmAuth = {
 };
 
 const testUpmConfig: UPMConfig = {
-  npmAuth: { [registryUrl("http://registry.npmjs.org")]: testUpmAuth },
+  npmAuth: { [makeRegistryUrl("http://registry.npmjs.org")]: testUpmAuth },
 };
 
 describe("env", function () {

--- a/test/mock-registry.ts
+++ b/test/mock-registry.ts
@@ -2,10 +2,10 @@ import nock from "nock";
 import { SearchEndpointResult } from "./types";
 import { isDomainName } from "../src/types/domain-name";
 import assert from "assert";
-import { registryUrl, unityRegistryUrl } from "../src/types/registry-url";
+import { makeRegistryUrl, unityRegistryUrl } from "../src/types/registry-url";
 import { UnityPackument } from "../src/types/packument";
 
-export const exampleRegistryUrl = registryUrl("http://example.com");
+export const exampleRegistryUrl = makeRegistryUrl("http://example.com");
 
 export function startMockRegistry() {
   if (!nock.isActive()) nock.activate();

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -9,10 +9,10 @@ import {
   stopMockRegistry,
 } from "./mock-registry";
 import { buildPackument } from "./data-packument";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { makeNpmClient } from "../src/npm-client";
 
-const packageA = domainName("package-a");
+const packageA = makeDomainName("package-a");
 
 describe("registry-client", function () {
   describe("fetchPackageInfo", function () {

--- a/test/package-reference.test.ts
+++ b/test/package-reference.test.ts
@@ -1,6 +1,6 @@
 import {
   isPackageReference,
-  packageReference,
+  makePackageReference,
   splitPackageReference,
 } from "../src/types/package-reference";
 
@@ -29,7 +29,7 @@ describe("package-reference", function () {
   describe("split", function () {
     function shouldSplitCorrectly(name: string, version?: string) {
       const [actualName, actualVersion] = splitPackageReference(
-        packageReference(name, version)
+        makePackageReference(name, version)
       );
       expect(actualName).toEqual(name);
       expect(actualVersion).toEqual(version);

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,12 +1,12 @@
 import { tryGetLatestVersion } from "../src/types/packument";
 
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 
 describe("packument", function () {
   describe("tryGetLatestVersion", function () {
     it("from dist-tags", async function () {
       const version = tryGetLatestVersion({
-        "dist-tags": { latest: semanticVersion("1.0.0") },
+        "dist-tags": { latest: makeSemanticVersion("1.0.0") },
       });
       expect(version).toEqual("1.0.0");
     });

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -5,7 +5,7 @@ import {
   saveProjectManifest,
 } from "../src/utils/project-manifest-io";
 import { DomainName, makeDomainName } from "../src/types/domain-name";
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 import {
   addDependency,
   manifestPathFor,
@@ -62,7 +62,7 @@ describe("project-manifest io", () => {
     manifest = addDependency(
       manifest,
       makeDomainName("some-pack"),
-      semanticVersion("1.0.0")
+      makeSemanticVersion("1.0.0")
     );
     expect(
       await saveProjectManifest(mockProject.projectPath, manifest)

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -4,7 +4,7 @@ import {
   loadProjectManifest,
   saveProjectManifest,
 } from "../src/utils/project-manifest-io";
-import { DomainName, domainName } from "../src/types/domain-name";
+import { DomainName, makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import {
   addDependency,
@@ -61,7 +61,7 @@ describe("project-manifest io", () => {
     expect(manifest).not.toHaveDependencies();
     manifest = addDependency(
       manifest,
-      domainName("some-pack"),
+      makeDomainName("some-pack"),
       semanticVersion("1.0.0")
     );
     expect(

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -7,7 +7,7 @@ import {
   tryGetScopedRegistryByUrl,
 } from "../src/types/project-manifest";
 import { makeDomainName } from "../src/types/domain-name";
-import { semanticVersion } from "../src/types/semantic-version";
+import { makeSemanticVersion } from "../src/types/semantic-version";
 import { makeScopedRegistry } from "../src/types/scoped-registry";
 import { makeRegistryUrl } from "../src/types/registry-url";
 
@@ -19,7 +19,7 @@ describe("project-manifest", function () {
       manifest = addDependency(
         manifest,
         makeDomainName("test"),
-        semanticVersion("1.2.3")
+        makeSemanticVersion("1.2.3")
       );
 
       expect(manifest.dependencies).toEqual({ test: "1.2.3" });
@@ -30,12 +30,12 @@ describe("project-manifest", function () {
       manifest = addDependency(
         manifest,
         makeDomainName("test"),
-        semanticVersion("1.2.3")
+        makeSemanticVersion("1.2.3")
       );
       manifest = addDependency(
         manifest,
         makeDomainName("test"),
-        semanticVersion("2.3.4")
+        makeSemanticVersion("2.3.4")
       );
 
       expect(manifest.dependencies).toEqual({ test: "2.3.4" });
@@ -46,7 +46,7 @@ describe("project-manifest", function () {
       manifest = addDependency(
         manifest,
         makeDomainName("test"),
-        semanticVersion("1.2.3")
+        makeSemanticVersion("1.2.3")
       );
       manifest = removeDependency(manifest, makeDomainName("test"));
 

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/types/project-manifest";
 import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
-import { scopedRegistry } from "../src/types/scoped-registry";
+import { makeScopedRegistry } from "../src/types/scoped-registry";
 import { makeRegistryUrl } from "../src/types/registry-url";
 
 describe("project-manifest", function () {
@@ -64,7 +64,7 @@ describe("project-manifest", function () {
     it("should should find scoped-registry with url if present", () => {
       let manifest = emptyProjectManifest;
       const url = makeRegistryUrl("https://test.com");
-      const expected = scopedRegistry("test", url);
+      const expected = makeScopedRegistry("test", url);
 
       manifest = addScopedRegistry(manifest, expected);
 
@@ -73,7 +73,7 @@ describe("project-manifest", function () {
     it("should should not find scoped-registry with incorrect url", () => {
       let manifest = emptyProjectManifest;
       const url = makeRegistryUrl("https://test.com");
-      const expected = scopedRegistry(
+      const expected = makeScopedRegistry(
         "test",
         makeRegistryUrl("https://test2.com")
       );

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -6,7 +6,7 @@ import {
   removeDependency,
   tryGetScopedRegistryByUrl,
 } from "../src/types/project-manifest";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import { scopedRegistry } from "../src/types/scoped-registry";
 import { registryUrl } from "../src/types/registry-url";
@@ -18,7 +18,7 @@ describe("project-manifest", function () {
 
       manifest = addDependency(
         manifest,
-        domainName("test"),
+        makeDomainName("test"),
         semanticVersion("1.2.3")
       );
 
@@ -29,12 +29,12 @@ describe("project-manifest", function () {
 
       manifest = addDependency(
         manifest,
-        domainName("test"),
+        makeDomainName("test"),
         semanticVersion("1.2.3")
       );
       manifest = addDependency(
         manifest,
-        domainName("test"),
+        makeDomainName("test"),
         semanticVersion("2.3.4")
       );
 
@@ -45,17 +45,17 @@ describe("project-manifest", function () {
 
       manifest = addDependency(
         manifest,
-        domainName("test"),
+        makeDomainName("test"),
         semanticVersion("1.2.3")
       );
-      manifest = removeDependency(manifest, domainName("test"));
+      manifest = removeDependency(manifest, makeDomainName("test"));
 
       expect(manifest.dependencies).toEqual({});
     });
     it("should do nothing when dependency does not exist", () => {
       let manifest = emptyProjectManifest;
 
-      manifest = removeDependency(manifest, domainName("test"));
+      manifest = removeDependency(manifest, makeDomainName("test"));
 
       expect(manifest.dependencies).toEqual({});
     });
@@ -84,16 +84,16 @@ describe("project-manifest", function () {
     it("should not add testables which already exist", () => {
       let manifest = emptyProjectManifest;
 
-      manifest = addTestable(manifest, domainName("a"));
-      manifest = addTestable(manifest, domainName("a"));
+      manifest = addTestable(manifest, makeDomainName("a"));
+      manifest = addTestable(manifest, makeDomainName("a"));
 
       expect(manifest.testables).toEqual(["a"]);
     });
     it("should add testables in alphabetical order", () => {
       let manifest = emptyProjectManifest;
 
-      manifest = addTestable(manifest, domainName("b"));
-      manifest = addTestable(manifest, domainName("a"));
+      manifest = addTestable(manifest, makeDomainName("b"));
+      manifest = addTestable(manifest, makeDomainName("a"));
 
       expect(manifest.testables).toEqual(["a", "b"]);
     });

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -9,7 +9,7 @@ import {
 import { makeDomainName } from "../src/types/domain-name";
 import { semanticVersion } from "../src/types/semantic-version";
 import { scopedRegistry } from "../src/types/scoped-registry";
-import { registryUrl } from "../src/types/registry-url";
+import { makeRegistryUrl } from "../src/types/registry-url";
 
 describe("project-manifest", function () {
   describe("dependency", function () {
@@ -63,7 +63,7 @@ describe("project-manifest", function () {
   describe("scoped-registry", function () {
     it("should should find scoped-registry with url if present", () => {
       let manifest = emptyProjectManifest;
-      const url = registryUrl("https://test.com");
+      const url = makeRegistryUrl("https://test.com");
       const expected = scopedRegistry("test", url);
 
       manifest = addScopedRegistry(manifest, expected);
@@ -72,8 +72,11 @@ describe("project-manifest", function () {
     });
     it("should should not find scoped-registry with incorrect url", () => {
       let manifest = emptyProjectManifest;
-      const url = registryUrl("https://test.com");
-      const expected = scopedRegistry("test", registryUrl("https://test2.com"));
+      const url = makeRegistryUrl("https://test.com");
+      const expected = scopedRegistry(
+        "test",
+        makeRegistryUrl("https://test2.com")
+      );
 
       manifest = addScopedRegistry(manifest, expected);
 

--- a/test/scoped-registry.test.ts
+++ b/test/scoped-registry.test.ts
@@ -5,7 +5,7 @@ import {
   scopedRegistry,
 } from "../src/types/scoped-registry";
 import { exampleRegistryUrl } from "./mock-registry";
-import { domainName } from "../src/types/domain-name";
+import { makeDomainName } from "../src/types/domain-name";
 
 describe("scoped-registry", function () {
   describe("construction", function () {
@@ -17,49 +17,49 @@ describe("scoped-registry", function () {
   describe("add scope", function () {
     it("should keep scope-list alphabetical", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      expect(addScope(registry, domainName("b"))).toBeTruthy();
-      expect(addScope(registry, domainName("a"))).toBeTruthy();
+      expect(addScope(registry, makeDomainName("b"))).toBeTruthy();
+      expect(addScope(registry, makeDomainName("a"))).toBeTruthy();
       expect(registry.scopes).toEqual(["a", "b"]);
     });
     it("should filter duplicates", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      expect(addScope(registry, domainName("a"))).toBeTruthy();
-      expect(addScope(registry, domainName("a"))).toBeFalsy();
+      expect(addScope(registry, makeDomainName("a"))).toBeTruthy();
+      expect(addScope(registry, makeDomainName("a"))).toBeFalsy();
       expect(registry.scopes).toEqual(["a"]);
     });
   });
   describe("has scope", function () {
     it("should have scope that was added", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      addScope(registry, domainName("a"));
-      expect(hasScope(registry, domainName("a"))).toBeTruthy();
+      addScope(registry, makeDomainName("a"));
+      expect(hasScope(registry, makeDomainName("a"))).toBeTruthy();
     });
     it("should not have scope that was not added", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl);
-      expect(hasScope(registry, domainName("a"))).toBeFalsy();
+      expect(hasScope(registry, makeDomainName("a"))).toBeFalsy();
     });
   });
   describe("remove scope", function () {
     it("should not have scope after removing it", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
-        domainName("a"),
+        makeDomainName("a"),
       ]);
-      expect(removeScope(registry, domainName("a"))).toBeTruthy();
-      expect(hasScope(registry, domainName("a"))).toBeFalsy();
+      expect(removeScope(registry, makeDomainName("a"))).toBeTruthy();
+      expect(hasScope(registry, makeDomainName("a"))).toBeFalsy();
     });
     it("should not do nothing if scope does not exist", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
-        domainName("a"),
+        makeDomainName("a"),
       ]);
-      expect(removeScope(registry, domainName("b"))).toBeFalsy();
-      expect(hasScope(registry, domainName("a"))).toBeTruthy();
+      expect(removeScope(registry, makeDomainName("b"))).toBeFalsy();
+      expect(hasScope(registry, makeDomainName("a"))).toBeTruthy();
     });
     it("should remove duplicate scopes", () => {
       const registry = scopedRegistry("test", exampleRegistryUrl, [
-        domainName("a"),
-        domainName("a"),
+        makeDomainName("a"),
+        makeDomainName("a"),
       ]);
-      expect(removeScope(registry, domainName("a"))).toBeTruthy();
+      expect(removeScope(registry, makeDomainName("a"))).toBeTruthy();
       expect(registry.scopes).toHaveLength(0);
     });
   });

--- a/test/scoped-registry.test.ts
+++ b/test/scoped-registry.test.ts
@@ -2,7 +2,7 @@ import {
   addScope,
   hasScope,
   removeScope,
-  scopedRegistry,
+  makeScopedRegistry,
 } from "../src/types/scoped-registry";
 import { exampleRegistryUrl } from "./mock-registry";
 import { makeDomainName } from "../src/types/domain-name";
@@ -10,19 +10,19 @@ import { makeDomainName } from "../src/types/domain-name";
 describe("scoped-registry", function () {
   describe("construction", function () {
     it("should have empty scopes list if scopes are not specified", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
+      const registry = makeScopedRegistry("test", exampleRegistryUrl);
       expect(registry.scopes).toHaveLength(0);
     });
   });
   describe("add scope", function () {
     it("should keep scope-list alphabetical", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
+      const registry = makeScopedRegistry("test", exampleRegistryUrl);
       expect(addScope(registry, makeDomainName("b"))).toBeTruthy();
       expect(addScope(registry, makeDomainName("a"))).toBeTruthy();
       expect(registry.scopes).toEqual(["a", "b"]);
     });
     it("should filter duplicates", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
+      const registry = makeScopedRegistry("test", exampleRegistryUrl);
       expect(addScope(registry, makeDomainName("a"))).toBeTruthy();
       expect(addScope(registry, makeDomainName("a"))).toBeFalsy();
       expect(registry.scopes).toEqual(["a"]);
@@ -30,32 +30,32 @@ describe("scoped-registry", function () {
   });
   describe("has scope", function () {
     it("should have scope that was added", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
+      const registry = makeScopedRegistry("test", exampleRegistryUrl);
       addScope(registry, makeDomainName("a"));
       expect(hasScope(registry, makeDomainName("a"))).toBeTruthy();
     });
     it("should not have scope that was not added", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl);
+      const registry = makeScopedRegistry("test", exampleRegistryUrl);
       expect(hasScope(registry, makeDomainName("a"))).toBeFalsy();
     });
   });
   describe("remove scope", function () {
     it("should not have scope after removing it", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl, [
+      const registry = makeScopedRegistry("test", exampleRegistryUrl, [
         makeDomainName("a"),
       ]);
       expect(removeScope(registry, makeDomainName("a"))).toBeTruthy();
       expect(hasScope(registry, makeDomainName("a"))).toBeFalsy();
     });
     it("should not do nothing if scope does not exist", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl, [
+      const registry = makeScopedRegistry("test", exampleRegistryUrl, [
         makeDomainName("a"),
       ]);
       expect(removeScope(registry, makeDomainName("b"))).toBeFalsy();
       expect(hasScope(registry, makeDomainName("a"))).toBeTruthy();
     });
     it("should remove duplicate scopes", () => {
-      const registry = scopedRegistry("test", exampleRegistryUrl, [
+      const registry = makeScopedRegistry("test", exampleRegistryUrl, [
         makeDomainName("a"),
         makeDomainName("a"),
       ]);

--- a/test/upm-config.test.ts
+++ b/test/upm-config.test.ts
@@ -12,7 +12,7 @@ import {
   UPMConfig,
 } from "../src/types/upm-config";
 import { Base64 } from "../src/types/base64";
-import { registryUrl, RegistryUrl } from "../src/types/registry-url";
+import { makeRegistryUrl, RegistryUrl } from "../src/types/registry-url";
 import { NpmAuth } from "another-npm-registry-client";
 import { exampleRegistryUrl } from "./mock-registry";
 
@@ -96,7 +96,7 @@ describe("upm-config", function () {
     });
     describe("get auth for registry", function () {
       it("should find auth for url without trailing slash", function () {
-        const url = registryUrl("http://registry.npmjs.com");
+        const url = makeRegistryUrl("http://registry.npmjs.com");
         const expected: NpmAuth = {
           alwaysAuth: false,
           token: "This is not a valid token",
@@ -146,7 +146,7 @@ describe("upm-config", function () {
 
         const actual = tryGetAuthForRegistry(
           config,
-          registryUrl("http://registryB.com")
+          makeRegistryUrl("http://registryB.com")
         );
         expect(actual).toBeNull();
       });


### PR DESCRIPTION
Currently the names of constructor functions often conflict with variable names. For example the constructor function for `ScopedRegistry` is called `scopedRegistry`. Often you would also like to call a variable of type `ScopedRegistry` `scopedRegistry`. Then there is a name-conflict. This is also true for other types/constructors.

In order to fix this issue `make` was prefixed to all constructor functions, i.e. `makeScopedRegistry`.

Another option would have been to capitalize constructor functions, i.e. `ScopedRegistry`, but that would conflict with the type name.