### PR TITLE
refactor: no logs in manifest-io

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -34,7 +34,10 @@ import {
 } from "./packument-resolving";
 import { SemanticVersion } from "./types/semantic-version";
 import { fetchPackageDependencies } from "./dependency-resolving";
-import { PackumentNotFoundError } from "./common-errors";
+import {
+  PackumentNotFoundError,
+  RequiredFileNotFoundError,
+} from "./common-errors";
 import { Err, Ok, Result } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch";
 import { CustomError } from "ts-custom-error";
@@ -99,7 +102,14 @@ export const add = async function (
 
     // load manifest
     const loadResult = await tryLoadProjectManifest(env.cwd);
-    if (loadResult.isErr()) return loadResult;
+    if (loadResult.isErr()) {
+      if (loadResult.error instanceof RequiredFileNotFoundError)
+        log.error(
+          "manifest",
+          `manifest at ${loadResult.error.path} does not exist`
+        );
+      return loadResult;
+    }
     let manifest = loadResult.value;
 
     // packages that added to scope registry

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -301,7 +301,11 @@ export const add = async function (
     // save manifest
     if (dirty) {
       const saveResult = await trySaveProjectManifest(env.cwd, manifest);
-      if (saveResult.isErr()) return saveResult;
+      if (saveResult.isErr()) {
+        log.error("manifest", "can not write manifest json file");
+        log.error("manifest", saveResult.error.message);
+        return saveResult;
+      }
     }
     return Ok(dirty);
   };

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -3,6 +3,7 @@ import url from "url";
 import { isPackageUrl, PackageUrl } from "./types/package-url";
 import {
   ManifestLoadError,
+  ManifestParseError,
   ManifestSaveError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
@@ -108,6 +109,13 @@ export const add = async function (
           "manifest",
           `manifest at ${loadResult.error.path} does not exist`
         );
+      else if (loadResult.error instanceof ManifestParseError) {
+        log.error(
+          "manifest",
+          `failed to parse manifest at ${loadResult.error.path}`
+        );
+        log.error("manifest", loadResult.error.message);
+      }
       return loadResult;
     }
     let manifest = loadResult.value;

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -42,6 +42,7 @@ import {
 import { Err, Ok, Result } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch";
 import { CustomError } from "ts-custom-error";
+import { logManifestLoadError } from "./error-logging";
 
 export class InvalidPackumentDataError extends CustomError {
   constructor(readonly issue: string) {
@@ -104,18 +105,8 @@ export const add = async function (
     // load manifest
     const loadResult = await tryLoadProjectManifest(env.cwd);
     if (loadResult.isErr()) {
-      if (loadResult.error instanceof RequiredFileNotFoundError)
-        log.error(
-          "manifest",
-          `manifest at ${loadResult.error.path} does not exist`
-        );
-      else if (loadResult.error instanceof ManifestParseError) {
-        log.error(
-          "manifest",
-          `failed to parse manifest at ${loadResult.error.path}`
-        );
-        log.error("manifest", loadResult.error.message);
-      }
+      logManifestLoadError(loadResult.error);
+
       return loadResult;
     }
     let manifest = loadResult.value;

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -3,7 +3,6 @@ import url from "url";
 import { isPackageUrl, PackageUrl } from "./types/package-url";
 import {
   ManifestLoadError,
-  ManifestParseError,
   ManifestSaveError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
@@ -35,14 +34,11 @@ import {
 } from "./packument-resolving";
 import { SemanticVersion } from "./types/semantic-version";
 import { fetchPackageDependencies } from "./dependency-resolving";
-import {
-  PackumentNotFoundError,
-  RequiredFileNotFoundError,
-} from "./common-errors";
+import { PackumentNotFoundError } from "./common-errors";
 import { Err, Ok, Result } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch";
 import { CustomError } from "ts-custom-error";
-import { logManifestLoadError } from "./error-logging";
+import { logManifestLoadError, logManifestSaveError } from "./error-logging";
 
 export class InvalidPackumentDataError extends CustomError {
   constructor(readonly issue: string) {
@@ -293,8 +289,7 @@ export const add = async function (
     if (dirty) {
       const saveResult = await trySaveProjectManifest(env.cwd, manifest);
       if (saveResult.isErr()) {
-        log.error("manifest", "can not write manifest json file");
-        log.error("manifest", saveResult.error.message);
+        logManifestSaveError(saveResult.error);
         return saveResult;
       }
     }

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -1,7 +1,6 @@
 import log from "./logger";
 import {
   ManifestLoadError,
-  ManifestParseError,
   ManifestSaveError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
@@ -23,8 +22,8 @@ import { Err, Ok, Result } from "ts-results-es";
 import {
   PackageWithVersionError,
   PackumentNotFoundError,
-  RequiredFileNotFoundError,
 } from "./common-errors";
+import { logManifestLoadError } from "./error-logging";
 
 export type RemoveError =
   | EnvParseError
@@ -56,18 +55,7 @@ export const remove = async function (
     // load manifest
     const manifestResult = await tryLoadProjectManifest(env.cwd);
     if (manifestResult.isErr()) {
-      if (manifestResult.error instanceof RequiredFileNotFoundError)
-        log.error(
-          "manifest",
-          `manifest at ${manifestResult.error.path} does not exist`
-        );
-      else if (manifestResult.error instanceof ManifestParseError) {
-        log.error(
-          "manifest",
-          `failed to parse manifest at ${manifestResult.error.path}`
-        );
-        log.error("manifest", manifestResult.error.message);
-      }
+      logManifestLoadError(manifestResult.error);
       return manifestResult;
     }
     let manifest = manifestResult.value;

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -22,6 +22,7 @@ import { Err, Ok, Result } from "ts-results-es";
 import {
   PackageWithVersionError,
   PackumentNotFoundError,
+  RequiredFileNotFoundError,
 } from "./common-errors";
 
 export type RemoveError =
@@ -53,7 +54,14 @@ export const remove = async function (
     }
     // load manifest
     const manifestResult = await tryLoadProjectManifest(env.cwd);
-    if (manifestResult.isErr()) return manifestResult;
+    if (manifestResult.isErr()) {
+      if (manifestResult.error instanceof RequiredFileNotFoundError)
+        log.error(
+          "manifest",
+          `manifest at ${manifestResult.error.path} does not exist`
+        );
+      return manifestResult;
+    }
     let manifest = manifestResult.value;
 
     // not found array

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -23,7 +23,7 @@ import {
   PackageWithVersionError,
   PackumentNotFoundError,
 } from "./common-errors";
-import { logManifestLoadError } from "./error-logging";
+import { logManifestLoadError, logManifestSaveError } from "./error-logging";
 
 export type RemoveError =
   | EnvParseError
@@ -75,8 +75,7 @@ export const remove = async function (
     // save manifest
     const saveResult = await trySaveProjectManifest(env.cwd, manifest);
     if (saveResult.isErr()) {
-      log.error("manifest", "can not write manifest json file");
-      log.error("manifest", saveResult.error.message);
+      logManifestSaveError(saveResult.error);
       return saveResult;
     }
 

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -1,6 +1,7 @@
 import log from "./logger";
 import {
   ManifestLoadError,
+  ManifestParseError,
   ManifestSaveError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
@@ -60,6 +61,13 @@ export const remove = async function (
           "manifest",
           `manifest at ${manifestResult.error.path} does not exist`
         );
+      else if (manifestResult.error instanceof ManifestParseError) {
+        log.error(
+          "manifest",
+          `failed to parse manifest at ${manifestResult.error.path}`
+        );
+        log.error("manifest", manifestResult.error.message);
+      }
       return manifestResult;
     }
     let manifest = manifestResult.value;

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -86,7 +86,11 @@ export const remove = async function (
 
     // save manifest
     const saveResult = await trySaveProjectManifest(env.cwd, manifest);
-    if (saveResult.isErr()) return saveResult;
+    if (saveResult.isErr()) {
+      log.error("manifest", "can not write manifest json file");
+      log.error("manifest", saveResult.error.message);
+      return saveResult;
+    }
 
     log.notice(
       "manifest",

--- a/src/error-logging.ts
+++ b/src/error-logging.ts
@@ -1,0 +1,17 @@
+import log from "./logger";
+import { ManifestLoadError } from "./utils/project-manifest-io";
+import { RequiredFileNotFoundError } from "./common-errors";
+
+/**
+ * Logs a {@link ManifestLoadError} to the console.
+ * @param error The error to log.
+ */
+export function logManifestLoadError(error: ManifestLoadError) {
+  const prefix = "manifest";
+  if (error instanceof RequiredFileNotFoundError)
+    log.error(prefix, `manifest at ${error.path} does not exist`);
+  else {
+    log.error(prefix, `failed to parse manifest at ${error.path}`);
+    log.error(prefix, error.cause.message);
+  }
+}

--- a/src/error-logging.ts
+++ b/src/error-logging.ts
@@ -1,5 +1,8 @@
 import log from "./logger";
-import { ManifestLoadError } from "./utils/project-manifest-io";
+import {
+  ManifestLoadError,
+  ManifestSaveError,
+} from "./utils/project-manifest-io";
 import { RequiredFileNotFoundError } from "./common-errors";
 
 /**
@@ -14,4 +17,14 @@ export function logManifestLoadError(error: ManifestLoadError) {
     log.error(prefix, `failed to parse manifest at ${error.path}`);
     log.error(prefix, error.cause.message);
   }
+}
+
+/**
+ * Logs a {@link ManifestSaveError} to the console.
+ * @param error The error to log.
+ */
+export function logManifestSaveError(error: ManifestSaveError) {
+  const prefix = "manifest";
+  log.error(prefix, "can not write manifest json file");
+  log.error(prefix, error.message);
 }

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -60,8 +60,6 @@ export const trySaveProjectManifest = async function (
     return Ok(undefined);
   } catch (error) {
     assertIsError(error);
-    log.error("manifest", "can not write manifest json file");
-    log.error("manifest", error.message);
     return Err(error);
   }
 };

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -12,7 +12,11 @@ import { CustomError } from "ts-custom-error";
 import { RequiredFileNotFoundError } from "../common-errors";
 import { Err, Ok, Result } from "ts-results-es";
 
-export class ManifestParseError extends CustomError {}
+export class ManifestParseError extends CustomError {
+  constructor(readonly path: string, cause: Error) {
+    super("A project-manifest could not be parsed", { cause });
+  }
+}
 
 export type ManifestLoadError = RequiredFileNotFoundError | ManifestParseError;
 
@@ -34,11 +38,7 @@ export const tryLoadProjectManifest = async function (
     assertIsError(error);
     if (error.code === "ENOENT")
       return Err(new RequiredFileNotFoundError(manifestPath));
-    else {
-      log.error("manifest", `failed to parse manifest at ${manifestPath}`);
-      log.error("manifest", error.message);
-      return Err(new ManifestParseError());
-    }
+    else return Err(new ManifestParseError(manifestPath, error));
   }
 };
 

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -32,10 +32,9 @@ export const tryLoadProjectManifest = async function (
     return Ok(JSON.parse(text) as UnityProjectManifest);
   } catch (error) {
     assertIsError(error);
-    if (error.code === "ENOENT") {
-      log.error("manifest", `manifest at ${manifestPath} does not exist`);
+    if (error.code === "ENOENT")
       return Err(new RequiredFileNotFoundError(manifestPath));
-    } else {
+    else {
       log.error("manifest", `failed to parse manifest at ${manifestPath}`);
       log.error("manifest", error.message);
       return Err(new ManifestParseError());

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import { assertIsError } from "./error-type-guards";
-import log from "../logger";
 import {
   manifestPathFor,
   pruneManifest,

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -12,8 +12,8 @@ import { RequiredFileNotFoundError } from "../common-errors";
 import { Err, Ok, Result } from "ts-results-es";
 
 export class ManifestParseError extends CustomError {
-  constructor(readonly path: string, cause: Error) {
-    super("A project-manifest could not be parsed", { cause });
+  constructor(readonly path: string, readonly cause: Error) {
+    super("A project-manifest could not be parsed");
   }
 }
 

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -56,7 +56,6 @@ describe("project-manifest io", () => {
     expect(manifestResult).toBeError((error) =>
       expect(error).toBeInstanceOf(RequiredFileNotFoundError)
     );
-    expect(mockConsole).toHaveLineIncluding("out", "does not exist");
   });
   it("wrong json content", async () => {
     const manifestPath = manifestPathFor(mockProject.projectPath);

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -67,7 +67,6 @@ describe("project-manifest io", () => {
     expect(manifestResult).toBeError((error) =>
       expect(error).toBeInstanceOf(ManifestParseError)
     );
-    expect(mockConsole).toHaveLineIncluding("out", "failed to parse");
   });
   it("saveManifest", async () => {
     let manifest = (

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -1,5 +1,3 @@
-import { attachMockConsole, MockConsole } from "./mock-console";
-
 import {
   ManifestParseError,
   tryLoadProjectManifest,
@@ -21,20 +19,14 @@ import { exampleRegistryUrl } from "./mock-registry";
 import { RequiredFileNotFoundError } from "../src/common-errors";
 
 describe("project-manifest io", () => {
-  let mockConsole: MockConsole = null!;
   let mockProject: MockUnityProject = null!;
 
   beforeAll(async () => {
     mockProject = await setupUnityProject({});
   });
 
-  beforeEach(() => {
-    mockConsole = attachMockConsole();
-  });
-
   afterEach(async () => {
     await mockProject.reset();
-    mockConsole.detach();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Currently, logging logic is spread out across the whole project. In my opinion logging should only be done in the cli parts of the application to make the rest more technology agnostic and testable.

This PR moves logging for `project-manifest-io` into utility functions which are used from cmd functions instead of directly inside the io functions.

I plan to do more refactors for other parts of the project with the goal of only having logs inside cmd functions.