### PR TITLE
refactor: use async-result type

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -106,7 +106,7 @@ export const add = async function (
     const [name, requestedVersion] = splitPackageReference(pkg);
 
     // load manifest
-    const loadResult = await tryLoadProjectManifest(env.cwd);
+    const loadResult = await tryLoadProjectManifest(env.cwd).promise;
     if (loadResult.isErr()) {
       logManifestLoadError(loadResult.error);
 

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -123,14 +123,14 @@ export const add = async function (
         name,
         requestedVersion,
         env.registry
-      );
+      ).promise;
       if (resolveResult.isErr() && env.upstream) {
         resolveResult = await tryResolve(
           client,
           name,
           requestedVersion,
           env.upstreamRegistry
-        );
+        ).promise;
         if (resolveResult.isOk()) isUpstreamPackage = true;
       }
 

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -298,7 +298,8 @@ export const add = async function (
     if (options.test) manifest = addTestable(manifest, name);
     // save manifest
     if (dirty) {
-      const saveResult = await trySaveProjectManifest(env.cwd, manifest);
+      const saveResult = await trySaveProjectManifest(env.cwd, manifest)
+        .promise;
       if (saveResult.isErr()) {
         logManifestSaveError(saveResult.error);
         return saveResult;

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -69,7 +69,7 @@ export const login = async function (
       email,
       alwaysAuth,
       _auth,
-    } satisfies BasicAuth);
+    } satisfies BasicAuth).promise;
     if (result.isErr()) return result;
   } else {
     // npm login
@@ -83,7 +83,7 @@ export const login = async function (
       email,
       alwaysAuth,
       token,
-    } satisfies TokenAuth);
+    } satisfies TokenAuth).promise;
     if (storeResult.isErr()) return storeResult;
   }
 

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -57,7 +57,8 @@ export const login = async function (
 
   const alwaysAuth = options.alwaysAuth || false;
 
-  const configDirResult = await tryGetUpmConfigDir(env.wsl, env.systemUser);
+  const configDirResult = await tryGetUpmConfigDir(env.wsl, env.systemUser)
+    .promise;
   if (configDirResult.isErr()) return configDirResult;
   const configDir = configDirResult.value;
 

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -99,7 +99,8 @@ const npmLogin = async function (
   registry: RegistryUrl
 ): Promise<Result<string, AuthenticationError>> {
   const client = makeNpmClient();
-  const result = await client.addUser(registry, username, password, email);
+  const result = await client.addUser(registry, username, password, email)
+    .promise;
 
   if (result.isOk()) {
     log.notice("auth", `you are authenticated as '${username}'`);

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -72,7 +72,7 @@ export const remove = async function (
     });
 
     // save manifest
-    const saveResult = await trySaveProjectManifest(env.cwd, manifest);
+    const saveResult = await trySaveProjectManifest(env.cwd, manifest).promise;
     if (saveResult.isErr()) {
       logManifestSaveError(saveResult.error);
       return saveResult;

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -50,7 +50,7 @@ export const remove = async function (
       return Err(new PackageWithVersionError());
     }
     // load manifest
-    const manifestResult = await tryLoadProjectManifest(env.cwd);
+    const manifestResult = await tryLoadProjectManifest(env.cwd).promise;
     if (manifestResult.isErr()) {
       logManifestLoadError(manifestResult.error);
       return manifestResult;

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -33,7 +33,7 @@ const searchOld = async function (
   registry: Registry,
   keyword: string
 ): Promise<Result<SearchedPackument[], HttpErrorBase>> {
-  return (await npmClient.tryGetAll(registry)).map((allPackuments) => {
+  return (await npmClient.tryGetAll(registry).promise).map((allPackuments) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { _updated, ...packumentEntries } = allPackuments;
     const packuments = Object.values(packumentEntries);

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -21,7 +21,7 @@ const searchEndpoint = async function (
   registry: Registry,
   keyword: string
 ): Promise<Result<SearchedPackument[], HttpErrorBase>> {
-  const results = await npmClient.trySearch(registry, keyword);
+  const results = await npmClient.trySearch(registry, keyword).promise;
 
   if (results.isOk()) log.verbose("npmsearch", results.value.join(os.EOL));
 

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -7,7 +7,7 @@ import { makeNpmClient } from "./npm-client";
 import { hasVersion, PackageReference } from "./types/package-reference";
 import { CmdOptions } from "./types/options";
 import { recordKeys } from "./utils/record-utils";
-import { AsyncResult, Err, Ok, Result } from "ts-results-es";
+import { Err, Ok, Result } from "ts-results-es";
 
 import {
   PackageWithVersionError,
@@ -35,10 +35,12 @@ export const view = async function (
     return Err(new PackageWithVersionError());
   }
   // verify name
-  return await new AsyncResult(client.tryFetchPackument(env.registry, pkg))
+  return await client
+    .tryFetchPackument(env.registry, pkg)
     .andThen(async (packument) => {
       if (packument === null && env.upstream)
-        return await client.tryFetchPackument(env.upstreamRegistry, pkg);
+        return await client.tryFetchPackument(env.upstreamRegistry, pkg)
+          .promise;
       return Ok(packument);
     })
     .andThen((packument) => {

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -105,7 +105,7 @@ export const fetchPackageDependencies = async function (
     if (cacheResult.isOk()) return cacheResult;
 
     // Then registry
-    return await tryResolve(client, packumentName, version, registry);
+    return await tryResolve(client, packumentName, version, registry).promise;
   }
 
   while (pendingList.length > 0) {

--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -75,7 +75,7 @@ export interface NpmClient {
     username: string,
     email: string,
     password: string
-  ): Promise<Result<AuthenticationToken, AuthenticationError>>;
+  ): AsyncResult<AuthenticationToken, AuthenticationError>;
 
   /**
    * Attempts to search a npm registry.
@@ -142,24 +142,26 @@ export const makeNpmClient = (): NpmClient => {
     },
 
     addUser(registryUrl, username, email, password) {
-      return new Promise((resolve) => {
-        registryClient.adduser(
-          registryUrl,
-          { auth: { username, email, password } },
-          (error, responseData, _, response) => {
-            if (error !== null || !responseData.ok)
-              resolve(
-                Err(
-                  new AuthenticationError(
-                    response.statusCode,
-                    response.statusMessage
+      return new AsyncResult(
+        new Promise((resolve) => {
+          registryClient.adduser(
+            registryUrl,
+            { auth: { username, email, password } },
+            (error, responseData, _, response) => {
+              if (error !== null || !responseData.ok)
+                resolve(
+                  Err(
+                    new AuthenticationError(
+                      response.statusCode,
+                      response.statusMessage
+                    )
                   )
-                )
-              );
-            else resolve(Ok(responseData.token));
-          }
-        );
-      });
+                );
+              else resolve(Ok(responseData.token));
+            }
+          );
+        })
+      );
     },
 
     async trySearch(registry, keyword) {

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -122,18 +122,18 @@ export function tryResolveFromPackument(
  * @param requestedVersion The version that should be resolved.
  * @param source The registry to resolve the packument from.
  */
-export async function tryResolve(
+export function tryResolve(
   npmClient: NpmClient,
   packageName: DomainName,
   requestedVersion: ResolvableVersion,
   source: Registry
 ): Promise<Result<ResolvedPackument, PackumentResolveError | HttpErrorBase>> {
-  return (await npmClient.tryFetchPackument(source, packageName)).andThen(
-    (packument) => {
+  return npmClient
+    .tryFetchPackument(source, packageName)
+    .andThen((packument) => {
       if (packument === null) return Err(new PackumentNotFoundError());
       return tryResolveFromPackument(packument, requestedVersion, source.url);
-    }
-  );
+    }).promise;
 }
 
 /**

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -87,11 +87,11 @@ export const parseEnv = async function (
   if (options._global.systemUser) systemUser = true;
   if (options._global.wsl) wsl = true;
 
-  const configDirResult = await tryGetUpmConfigDir(wsl, systemUser).promise;
-  if (configDirResult.isErr()) return Err(configDirResult.error);
-  const configDir = configDirResult.value;
-
-  const upmConfig = await tryLoadUpmConfig(configDir);
+  const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).map(
+    tryLoadUpmConfig
+  ).promise;
+  if (upmConfigResult.isErr()) return upmConfigResult;
+  const upmConfig = upmConfigResult.value;
 
   if (upmConfig !== null && upmConfig.npmAuth !== undefined) {
     registry = {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -87,7 +87,7 @@ export const parseEnv = async function (
   if (options._global.systemUser) systemUser = true;
   if (options._global.wsl) wsl = true;
 
-  const configDirResult = await tryGetUpmConfigDir(wsl, systemUser);
+  const configDirResult = await tryGetUpmConfigDir(wsl, systemUser).promise;
   if (configDirResult.isErr()) return Err(configDirResult.error);
   const configDir = configDirResult.value;
 

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -9,7 +9,7 @@ import fse from "fs-extra";
 import path from "path";
 import { CustomError } from "ts-custom-error";
 import { RequiredFileNotFoundError } from "../common-errors";
-import { Err, Ok, Result } from "ts-results-es";
+import { AsyncResult, Err, Ok, Result } from "ts-results-es";
 
 export class ManifestParseError extends CustomError {
   constructor(readonly path: string, readonly cause: Error) {
@@ -25,20 +25,25 @@ export type ManifestSaveError = Error;
  * Attempts to load the manifest for a Unity project.
  * @param projectPath The path to the root of the project.
  */
-export const tryLoadProjectManifest = async function (
+export const tryLoadProjectManifest = function (
   projectPath: string
-): Promise<Result<UnityProjectManifest, ManifestLoadError>> {
+): AsyncResult<UnityProjectManifest, ManifestLoadError> {
   const manifestPath = manifestPathFor(projectPath);
-  try {
-    const text = await fs.readFile(manifestPath, { encoding: "utf8" });
-    // TODO: Actually validate the content of the file
-    return Ok(JSON.parse(text) as UnityProjectManifest);
-  } catch (error) {
-    assertIsError(error);
-    if (error.code === "ENOENT")
-      return Err(new RequiredFileNotFoundError(manifestPath));
-    else return Err(new ManifestParseError(manifestPath, error));
-  }
+  return (
+    new AsyncResult(
+      Result.wrapAsync(() => fs.readFile(manifestPath, { encoding: "utf8" }))
+    )
+      // TODO: Actually validate the content of the file
+      .andThen((text) =>
+        Result.wrap(() => JSON.parse(text) as UnityProjectManifest)
+      )
+      .mapErr((error) => {
+        assertIsError(error);
+        if (error.code === "ENOENT")
+          return new RequiredFileNotFoundError(manifestPath);
+        else return new ManifestParseError(manifestPath, error);
+      })
+  );
 };
 
 /**

--- a/src/utils/project-version-io.ts
+++ b/src/utils/project-version-io.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import fse from "fs-extra";
-import { assertIsError } from "./error-type-guards";
-import { Err, Ok, Result } from "ts-results-es";
+import { AsyncResult, Result } from "ts-results-es";
 
 /**
  * Creates a ProjectVersion.txt file for a Unity project.
@@ -9,21 +8,19 @@ import { Err, Ok, Result } from "ts-results-es";
  * @param projectDirPath The projects root folder.
  * @param version The editor-version to use.
  */
-export async function tryCreateProjectVersionTxt(
+export function tryCreateProjectVersionTxt(
   projectDirPath: string,
   version: string
-): Promise<Result<void, Error>> {
-  try {
-    const projectSettingsDir = path.join(projectDirPath, "ProjectSettings");
-    await fse.mkdirp(projectSettingsDir);
-    const data = `m_EditorVersion: ${version}`;
-    await fse.writeFile(
-      path.join(projectSettingsDir, "ProjectVersion.txt"),
-      data
-    );
-    return Ok(undefined);
-  } catch (error) {
-    assertIsError(error);
-    return Err(error);
-  }
+): AsyncResult<void, Error> {
+  return new AsyncResult(
+    Result.wrapAsync(async () => {
+      const projectSettingsDir = path.join(projectDirPath, "ProjectSettings");
+      await fse.mkdirp(projectSettingsDir);
+      const data = `m_EditorVersion: ${version}`;
+      await fse.writeFile(
+        path.join(projectSettingsDir, "ProjectVersion.txt"),
+        data
+      );
+    })
+  );
 }

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -31,7 +31,8 @@ describe("registry-client", function () {
 
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
-      const result = await client.tryFetchPackument(env.registry, packageA);
+      const result = await client.tryFetchPackument(env.registry, packageA)
+        .promise;
       expect(result).toBeOk((packument) =>
         expect(packument).toEqual(packumentRemote)
       );
@@ -42,7 +43,8 @@ describe("registry-client", function () {
       ).unwrap();
 
       registerMissingPackument(packageA);
-      const result = await client.tryFetchPackument(env.registry, packageA);
+      const result = await client.tryFetchPackument(env.registry, packageA)
+        .promise;
       expect(result).toBeOk((packument) => expect(packument).toBeNull());
     });
   });

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -34,16 +34,16 @@ describe("project-manifest io", () => {
   });
 
   it("loadManifest", async () => {
-    const manifestResult = await tryLoadProjectManifest(
-      mockProject.projectPath
-    );
+    const manifestResult = await tryLoadProjectManifest(mockProject.projectPath)
+      .promise;
 
     expect(manifestResult).toBeOk((manifest) =>
       expect(manifest).toEqual({ dependencies: {} })
     );
   });
   it("no manifest file", async () => {
-    const manifestResult = await tryLoadProjectManifest("/invalid-path");
+    const manifestResult = await tryLoadProjectManifest("/invalid-path")
+      .promise;
 
     expect(manifestResult).toBeError((error) =>
       expect(error).toBeInstanceOf(RequiredFileNotFoundError)
@@ -53,16 +53,15 @@ describe("project-manifest io", () => {
     const manifestPath = manifestPathFor(mockProject.projectPath);
     fse.writeFileSync(manifestPath, "invalid data");
 
-    const manifestResult = await tryLoadProjectManifest(
-      mockProject.projectPath
-    );
+    const manifestResult = await tryLoadProjectManifest(mockProject.projectPath)
+      .promise;
     expect(manifestResult).toBeError((error) =>
       expect(error).toBeInstanceOf(ManifestParseError)
     );
   });
   it("saveManifest", async () => {
     let manifest = (
-      await tryLoadProjectManifest(mockProject.projectPath)
+      await tryLoadProjectManifest(mockProject.projectPath).promise
     ).unwrap();
     expect(manifest).not.toHaveDependencies();
     manifest = addDependency(
@@ -74,7 +73,7 @@ describe("project-manifest io", () => {
       await trySaveProjectManifest(mockProject.projectPath, manifest)
     ).toBeOk();
     const manifest2 = (
-      await tryLoadProjectManifest(mockProject.projectPath)
+      await tryLoadProjectManifest(mockProject.projectPath).promise
     ).unwrap();
     expect(manifest2).toEqual(manifest);
   });
@@ -102,7 +101,7 @@ describe("project-manifest io", () => {
       await trySaveProjectManifest(mockProject.projectPath, initialManifest)
     ).toBeOk();
     const savedManifest = (
-      await tryLoadProjectManifest(mockProject.projectPath)
+      await tryLoadProjectManifest(mockProject.projectPath).promise
     ).unwrap();
 
     expect(savedManifest.scopedRegistries).toHaveLength(0);

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -70,7 +70,7 @@ describe("project-manifest io", () => {
       makeSemanticVersion("1.0.0")
     );
     expect(
-      await trySaveProjectManifest(mockProject.projectPath, manifest)
+      await trySaveProjectManifest(mockProject.projectPath, manifest).promise
     ).toBeOk();
     const manifest2 = (
       await tryLoadProjectManifest(mockProject.projectPath).promise
@@ -99,6 +99,7 @@ describe("project-manifest io", () => {
     // Save and load manifest
     expect(
       await trySaveProjectManifest(mockProject.projectPath, initialManifest)
+        .promise
     ).toBeOk();
     const savedManifest = (
       await tryLoadProjectManifest(mockProject.projectPath).promise

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -121,10 +121,8 @@ export async function setupUnityProject(
     // Project manifest
     if (config.manifest !== false) {
       const manifest = config.manifest ?? defaultManifest;
-      const manifestResult = await trySaveProjectManifest(
-        projectPath,
-        manifest
-      );
+      const manifestResult = await trySaveProjectManifest(projectPath, manifest)
+        .promise;
       if (manifestResult.isErr()) throw manifestResult.error;
     }
   }

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -115,7 +115,7 @@ export async function setupUnityProject(
     const projectVersionResult = await tryCreateProjectVersionTxt(
       projectPath,
       version
-    );
+    ).promise;
     if (projectVersionResult.isErr()) throw projectVersionResult.error;
 
     // Project manifest

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -107,7 +107,7 @@ export async function setupUnityProject(
 
     // Upmconfig
     const upmConfig = config.upmConfig ?? defaultUpmConfig;
-    const saveResult = await trySaveUpmConfig(upmConfig, rootPath);
+    const saveResult = await trySaveUpmConfig(upmConfig, rootPath).promise;
     if (saveResult.isErr()) throw saveResult.error;
 
     // Editor-version

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -138,7 +138,7 @@ export async function setupUnityProject(
   }
 
   function tryGetManifest() {
-    return tryLoadProjectManifest(projectPath);
+    return tryLoadProjectManifest(projectPath).promise;
   }
 
   async function tryAssertManifest(

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -14,7 +14,7 @@ describe("upm-config-io", function () {
           {
             USERPROFILE: expected,
           },
-          () => tryGetUpmConfigDir(false, false)
+          () => tryGetUpmConfigDir(false, false).promise
         );
 
         expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
@@ -26,14 +26,15 @@ describe("upm-config-io", function () {
           {
             HOME: expected,
           },
-          () => tryGetUpmConfigDir(false, false)
+          () => tryGetUpmConfigDir(false, false).promise
         );
 
         expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
       });
       it("should fail if HOME and USERPROFILE and undefined", async function () {
-        const result = await runWithEnv({}, () =>
-          tryGetUpmConfigDir(false, false)
+        const result = await runWithEnv(
+          {},
+          () => tryGetUpmConfigDir(false, false).promise
         );
 
         expect(result).toBeError((error) =>


### PR DESCRIPTION
`ts-results-es` includes an `AsyncResult` type which can replace `Promise<Result>` and allows for easier mapping.

This PR refactors return types to use `AsyncResult` in transformation-style functions.