### PR TITLE
refactor: editor-version-comparison

### DIFF
--- a/src/types/editor-version.ts
+++ b/src/types/editor-version.ts
@@ -101,22 +101,6 @@ export const compareEditorVersion = function (
   }
   return 0;
 };
-/**
- * Attempts to compare two unparsed editor versions for ordering.
- * @param a The first version.
- * @param b The second version.
- * @returns A number indicating the ordering or null if either version could
- * not be parsed.
- */
-export const tryCompareEditorVersion = function (
-  a: string,
-  b: string
-): -1 | 0 | 1 | null {
-  const verA = tryParseEditorVersion(a);
-  const verB = tryParseEditorVersion(b);
-  if (verA === null || verB === null) return null;
-  return compareEditorVersion(verA, verB);
-};
 
 /**
  * Attempts to parse editor version string to groups.

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -1,5 +1,5 @@
 import {
-  tryCompareEditorVersion,
+  compareEditorVersion,
   tryParseEditorVersion,
 } from "../src/types/editor-version";
 
@@ -80,7 +80,12 @@ describe("editor-version", function () {
       ["2019.1.1f1c1", "2019.1.1f1c1"]
     ).forEach(([a, b]) =>
       it(`${a} == ${b}`, function () {
-        expect(tryCompareEditorVersion(a, b)).toEqual(0);
+        expect(
+          compareEditorVersion(
+            tryParseEditorVersion(a)!,
+            tryParseEditorVersion(b)!
+          )
+        ).toEqual(0);
       })
     );
     Array.of<[string, string]>(
@@ -88,7 +93,12 @@ describe("editor-version", function () {
       ["2020.1", "2019.1"]
     ).forEach(([a, b]) =>
       it(`${a} > ${b}`, function () {
-        expect(tryCompareEditorVersion(a, b)).toEqual(1);
+        expect(
+          compareEditorVersion(
+            tryParseEditorVersion(a)!,
+            tryParseEditorVersion(b)!
+          )
+        ).toEqual(1);
       })
     );
     Array.of<[string, string]>(
@@ -101,16 +111,12 @@ describe("editor-version", function () {
       ["2019.1.1f1", "2020.1.1f1c1"]
     ).forEach(([a, b]) =>
       it(`${a} < ${b}`, function () {
-        expect(tryCompareEditorVersion(a, b)).toEqual(-1);
-      })
-    );
-
-    Array.of<[string, string]>(
-      ["2019.1", "not-a-version"],
-      ["not-a-version", "2020.1"]
-    ).forEach(([a, b]) =>
-      it(`should not be able to compare ${a} and ${b}`, function () {
-        expect(tryCompareEditorVersion(a, b)).toBeNull();
+        expect(
+          compareEditorVersion(
+            tryParseEditorVersion(a)!,
+            tryParseEditorVersion(b)!
+          )
+        ).toEqual(-1);
       })
     );
   });


### PR DESCRIPTION
Instead of having a function which attempts to compare unparsed editor-versions and fails if either is not a valid one, we should just use the one that expects an editor-version and parse before.