### PR TITLE
refactor: prefer null for return type

### DIFF
--- a/src/types/package-id.ts
+++ b/src/types/package-id.ts
@@ -15,9 +15,7 @@ export type PackageId = `${DomainName}@${SemanticVersion}`;
  */
 export function isPackageId(s: string): s is PackageId {
   const [name, version] = trySplitAtFirstOccurrenceOf(s, "@");
-  return (
-    isDomainName(name) && version !== undefined && isSemanticVersion(version)
-  );
+  return isDomainName(name) && version !== null && isSemanticVersion(version);
 }
 
 /**

--- a/src/types/package-reference.ts
+++ b/src/types/package-reference.ts
@@ -43,7 +43,7 @@ function isVersionReference(s: string): s is VersionReference {
 export function isPackageReference(s: string): s is PackageReference {
   const [name, version] = trySplitAtFirstOccurrenceOf(s, "@");
   return (
-    isDomainName(name) && (version === undefined || isVersionReference(version))
+    isDomainName(name) && (version === null || isVersionReference(version))
   );
 }
 
@@ -54,10 +54,11 @@ export function isPackageReference(s: string): s is PackageReference {
 export function splitPackageReference(
   reference: PackageReference
 ): [DomainName, VersionReference | undefined] {
-  return trySplitAtFirstOccurrenceOf(reference, "@") as [
+  const [name, version] = trySplitAtFirstOccurrenceOf(reference, "@") as [
     DomainName,
-    VersionReference | undefined
+    VersionReference | null
   ];
+  return [name, version ?? undefined];
 }
 
 /**

--- a/src/types/upm-config.ts
+++ b/src/types/upm-config.ts
@@ -91,7 +91,7 @@ export function encodeBasicAuth(username: string, password: string): Base64 {
 export function tryDecodeBasicAuth(base64: Base64): [string, string] | null {
   const text = decodeBase64(base64);
   const [username, password] = trySplitAtFirstOccurrenceOf(text, ":");
-  if (password === undefined) return null;
+  if (password === null) return null;
   return [username, password];
 }
 

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,9 +1,9 @@
 export function trySplitAtFirstOccurrenceOf(
   s: string,
   split: string
-): [string, string | undefined] {
+): [string, string | null] {
   const elements = s.split(split);
-  if (elements.length === 1) return [s, undefined];
+  if (elements.length === 1) return [s, null];
   return [elements[0]!, elements.slice(1).join(split)];
 }
 


### PR DESCRIPTION
In general I prefer to represent missing values using `null` instead of `undefined`. Refactor a function return to use `null`.