### PR TITLE
refactor: rename function

### DIFF
--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -128,12 +128,12 @@ export function mapScopedRegistry(
 }
 
 /**
- * Adds a scoped-registry to the manifest.
- * NOTE: Does not check if a scoped-registry with the same name already exists.
+ * Sets a scoped-registry in the manifest. If no scoped-registry with
+ * the given url exists yet, it is added, otherwise it is overwritten.
  * @param manifest The manifest.
  * @param scopedRegistry The scoped-registry.
  */
-export function addScopedRegistry(
+export function setScopedRegistry(
   manifest: UnityProjectManifest,
   scopedRegistry: ScopedRegistry
 ): UnityProjectManifest {

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -1,6 +1,6 @@
 import {
   addDependency,
-  addScopedRegistry,
+  setScopedRegistry,
   addTestable,
   emptyProjectManifest,
   mapScopedRegistry,
@@ -68,7 +68,7 @@ describe("project-manifest", function () {
       const url = makeRegistryUrl("https://test.com");
       const expected = makeScopedRegistry("test", url);
 
-      manifest = addScopedRegistry(manifest, expected);
+      manifest = setScopedRegistry(manifest, expected);
 
       expect(tryGetScopedRegistryByUrl(manifest, url)).toEqual(expected);
     });
@@ -80,7 +80,7 @@ describe("project-manifest", function () {
         makeRegistryUrl("https://test2.com")
       );
 
-      manifest = addScopedRegistry(manifest, expected);
+      manifest = setScopedRegistry(manifest, expected);
 
       expect(tryGetScopedRegistryByUrl(manifest, url)).toBeNull();
     });
@@ -99,7 +99,7 @@ describe("project-manifest", function () {
     it("should have scoped-registry as input if found", () => {
       let manifest = emptyProjectManifest;
       const expected = makeScopedRegistry("test", exampleRegistryUrl);
-      manifest = addScopedRegistry(manifest, expected);
+      manifest = setScopedRegistry(manifest, expected);
 
       expect.assertions(1);
       mapScopedRegistry(manifest, exampleRegistryUrl, (registry) => {
@@ -111,7 +111,7 @@ describe("project-manifest", function () {
     it("should not have scoped-registry after returning null", () => {
       let manifest = emptyProjectManifest;
       const initial = makeScopedRegistry("test", exampleRegistryUrl);
-      manifest = addScopedRegistry(manifest, initial);
+      manifest = setScopedRegistry(manifest, initial);
 
       manifest = mapScopedRegistry(manifest, exampleRegistryUrl, () => null);
 
@@ -123,7 +123,7 @@ describe("project-manifest", function () {
       let manifest = emptyProjectManifest;
       const initial = makeScopedRegistry("test", exampleRegistryUrl);
       const expected = addScope(initial, makeDomainName("wow"));
-      manifest = addScopedRegistry(manifest, initial);
+      manifest = setScopedRegistry(manifest, initial);
 
       manifest = mapScopedRegistry(
         manifest,


### PR DESCRIPTION
Rename function to better describe it's behaviour. The `addScopedRegistry` function can not only be used to add a scoped-registry to a manifest, but also to replace it. Changed name and documentation to reflect this.