### PR TITLE
refactor: move function

### DIFF
--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -1,11 +1,10 @@
-import { DomainName } from "./domain-name";
-import { SemanticVersion } from "./semantic-version";
-import { PackageUrl } from "./package-url";
-import { ScopedRegistry } from "./scoped-registry";
-import { RegistryUrl } from "./registry-url";
-import path from "path";
-import { removeTrailingSlash } from "../utils/string-utils";
-import { removeRecordKey } from "../utils/record-utils";
+import {DomainName} from "./domain-name";
+import {SemanticVersion} from "./semantic-version";
+import {PackageUrl} from "./package-url";
+import {ScopedRegistry} from "./scoped-registry";
+import {RegistryUrl} from "./registry-url";
+import {removeTrailingSlash} from "../utils/string-utils";
+import {removeRecordKey} from "../utils/record-utils";
 
 /**
  * The content of the project-manifest (manifest.json) of a Unity project.
@@ -155,15 +154,6 @@ export function addTestable(
     ...manifest,
     testables: [...(manifest.testables ?? []), name].sort(),
   };
-}
-
-/**
- * Determines the path to the package manifest based on the project
- * directory.
- * @param projectPath The root path of the Unity project.
- */
-export function manifestPathFor(projectPath: string): string {
-  return path.join(projectPath, "Packages/manifest.json");
 }
 
 /**

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -10,7 +10,6 @@ import fs from "fs";
 import { coerceRegistryUrl, makeRegistryUrl } from "../types/registry-url";
 import { tryGetAuthForRegistry } from "../types/upm-config";
 import { CmdOptions } from "../types/options";
-import { manifestPathFor } from "../types/project-manifest";
 import { Registry } from "../npm-client";
 import { CustomError } from "ts-custom-error";
 import { FileParseError, RequiredFileNotFoundError } from "../common-errors";
@@ -19,6 +18,7 @@ import {
   ProjectVersionLoadError,
   tryLoadProjectVersion,
 } from "./project-version-io";
+import {manifestPathFor} from "./project-manifest-io";
 
 export type Env = Readonly<{
   cwd: string;

--- a/src/utils/project-manifest-io.ts
+++ b/src/utils/project-manifest-io.ts
@@ -1,10 +1,6 @@
 import fs from "fs/promises";
 import { assertIsError } from "./error-type-guards";
-import {
-  manifestPathFor,
-  pruneManifest,
-  UnityProjectManifest,
-} from "../types/project-manifest";
+import { pruneManifest, UnityProjectManifest } from "../types/project-manifest";
 import fse from "fs-extra";
 import path from "path";
 import { FileParseError, RequiredFileNotFoundError } from "../common-errors";
@@ -13,6 +9,15 @@ import { AsyncResult, Result } from "ts-results-es";
 export type ManifestLoadError = RequiredFileNotFoundError | FileParseError;
 
 export type ManifestSaveError = Error;
+
+/**
+ * Determines the path to the package manifest based on the project
+ * directory.
+ * @param projectPath The root path of the Unity project.
+ */
+export function manifestPathFor(projectPath: string): string {
+  return path.join(projectPath, "Packages/manifest.json");
+}
 
 /**
  * Attempts to load the manifest for a Unity project.

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -4,8 +4,8 @@ import { makeRegistryUrl } from "../src/types/registry-url";
 import { TokenAuth, UPMConfig } from "../src/types/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
-import { manifestPathFor } from "../src/types/project-manifest";
 import fse from "fs-extra";
+import {manifestPathFor} from "../src/utils/project-manifest-io";
 
 const testUpmAuth: TokenAuth = {
   email: "test@mail.com",

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -1,12 +1,12 @@
 import {
-  tryLoadProjectManifest,
-  trySaveProjectManifest,
+    manifestPathFor,
+    tryLoadProjectManifest,
+    trySaveProjectManifest,
 } from "../src/utils/project-manifest-io";
 import { DomainName, makeDomainName } from "../src/types/domain-name";
 import { makeSemanticVersion } from "../src/types/semantic-version";
 import {
   addDependency,
-  manifestPathFor,
   mapScopedRegistry,
 } from "../src/types/project-manifest";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";


### PR DESCRIPTION
The `manifestPathFor` function not related to `UnityProjectManifests` themselves but to the IO of them. Moved into the corresponding module.