### PR TITLE
refactor: use result-type for file-reads

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -19,6 +19,7 @@ import {
 import { CmdOptions } from "./types/options";
 import { Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
+import { tryReadTextFromFile } from "./utils/file-io";
 
 export type LoginError =
   | EnvParseError
@@ -121,11 +122,11 @@ const npmLogin = async function (
  */
 const writeNpmToken = async function (registry: RegistryUrl, token: string) {
   const configPath = getNpmrcPath();
+
   // read config
-  let content = "";
-  if (fs.existsSync(configPath)) {
-    content = fs.readFileSync(configPath, { encoding: "utf-8" });
-  }
+  const readResult = await tryReadTextFromFile(configPath).promise;
+  const content = readResult.unwrapOr("");
+
   // write config
   const lines = generateNpmrcLines(content, registry, token);
   const newContent = lines.join("\n") + "\n";

--- a/src/utils/file-io.ts
+++ b/src/utils/file-io.ts
@@ -1,0 +1,42 @@
+import { AsyncResult, Result } from "ts-results-es";
+import fs from "fs/promises";
+import { CustomError } from "ts-custom-error";
+import { IOError } from "../common-errors";
+import { assertIsError } from "./error-type-guards";
+
+/**
+ * Error for when a file or directory did not exist.
+ */
+export class NotFoundError extends CustomError {
+  constructor(
+    /**
+     * The path to the missing file.
+     */
+    readonly path: string
+  ) {
+    super(
+      "An IO operation was performed on a file or directory which does not exist."
+    );
+  }
+}
+
+/**
+ * Error for when a file-read failed.
+ */
+export type FileReadError = NotFoundError | IOError;
+
+/**
+ * Attempts to read the content of a text file.
+ * @param path The path to the file.
+ */
+export function tryReadTextFromFile(
+  path: string
+): AsyncResult<string, FileReadError> {
+  return new AsyncResult(
+    Result.wrapAsync(() => fs.readFile(path, { encoding: "utf8" }))
+  ).mapErr((error) => {
+    assertIsError(error);
+    if (error.code === "ENOENT") return new NotFoundError(path);
+    return new IOError(error);
+  });
+}

--- a/src/utils/upm-config-io.ts
+++ b/src/utils/upm-config-io.ts
@@ -11,6 +11,7 @@ import { CustomError } from "ts-custom-error";
 import { IOError } from "../common-errors";
 import { AsyncResult, Result } from "ts-results-es";
 import { assertIsError } from "./error-type-guards";
+import { tryReadTextFromFile } from "./file-io";
 
 const configFileName = ".upmconfig.toml";
 
@@ -81,7 +82,11 @@ export const tryLoadUpmConfig = async (
 ): Promise<UPMConfig | null> => {
   const configPath = path.join(configDir, configFileName);
   try {
-    const content = await fs.readFile(configPath, "utf8");
+    // TODO:
+    //  Instead of unwrapping here and risking a throw that is then
+    //  immediately caught, we should make this function return a result
+    //  and use mapping.
+    const content = (await tryReadTextFromFile(configPath).promise).unwrap();
     const config = TOML.parse(content);
 
     // NOTE: We assume correct format

--- a/test/file-io.test.ts
+++ b/test/file-io.test.ts
@@ -1,0 +1,48 @@
+import fs from "fs/promises";
+import { NotFoundError, tryReadTextFromFile } from "../src/utils/file-io";
+import { IOError } from "../src/common-errors";
+
+jest.mock("fs/promises");
+
+function makeNodeError(code: string): NodeJS.ErrnoException {
+  const error = new Error() as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+describe("file-io", () => {
+  describe("read text", () => {
+    it("should produce text if file can be read", async () => {
+      const expected = "content";
+      const mockFsRead = jest.mocked(fs.readFile);
+      mockFsRead.mockResolvedValue(expected);
+
+      const result = await tryReadTextFromFile("path/to/file.txt").promise;
+
+      expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should notify of missing file", async () => {
+      const mockFsRead = jest.mocked(fs.readFile);
+      mockFsRead.mockRejectedValue(makeNodeError("ENOENT"));
+
+      const result = await tryReadTextFromFile("path/to/file.txt").promise;
+
+      expect(result).toBeError((error) =>
+        expect(error).toBeInstanceOf(NotFoundError)
+      );
+    });
+
+    it("should notify of other errors", async () => {
+      const mockFsRead = jest.mocked(fs.readFile);
+      // Example of a code we don't handle in a special way.
+      mockFsRead.mockRejectedValue(makeNodeError("EACCES"));
+
+      const result = await tryReadTextFromFile("path/to/file.txt").promise;
+
+      expect(result).toBeError((error) =>
+        expect(error).toBeInstanceOf(IOError)
+      );
+    });
+  });
+});


### PR DESCRIPTION
Currently different parts of the app use variations of `fs.readFile` for file-reading. In order to bring resulting errors into the result-based return values required for most functions they all have to do some form of try-catch. 

In order to deduplicate this, a utility function for file-reading was added which abstracts this away.

More PRs doing the same for other file-io functions coming soon.