### PR TITLE
refactor: split env parse

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -65,31 +65,17 @@ function determinePrimaryRegistry(
   options: CmdOptions,
   upmConfig: UPMConfig | null
 ): Registry {
-  let registry: Registry = {
-    url: makeRegistryUrl("https://package.openupm.com"),
-    auth: null,
-  };
+  const url =
+    options._global.registry !== undefined
+      ? coerceRegistryUrl(options._global.registry)
+      : options._global.cn === true
+      ? makeRegistryUrl("https://package.openupm.cn")
+      : makeRegistryUrl("https://package.openupm.com");
 
-  if (options._global.cn === true)
-    registry = {
-      url: makeRegistryUrl("https://package.openupm.cn"),
-      auth: null,
-    };
+  const auth =
+    upmConfig !== null ? tryGetAuthForRegistry(upmConfig, url) : null;
 
-  if (options._global.registry) {
-    registry = {
-      url: coerceRegistryUrl(options._global.registry),
-      auth: null,
-    };
-  }
-
-  if (upmConfig !== null)
-    registry = {
-      url: registry.url,
-      auth: tryGetAuthForRegistry(upmConfig, registry.url),
-    };
-
-  return registry;
+  return { url, auth };
 }
 
 /**

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -116,8 +116,6 @@ export const parseEnv = async function (
   options: CmdOptions,
   checkPath: boolean
 ): Promise<Result<Env, EnvParseError>> {
-  // set defaults
-  let editorVersion: string | null = null;
   // log level
   log.level = determineLogLevel(options);
   // color
@@ -148,7 +146,7 @@ export const parseEnv = async function (
   if (!checkPath)
     return Ok({
       cwd: "",
-      editorVersion,
+      editorVersion: null,
       registry,
       systemUser,
       upstream,
@@ -189,7 +187,7 @@ export const parseEnv = async function (
       );
     return projectVersionLoadResult;
   }
-  editorVersion = projectVersionLoadResult.value;
+  const editorVersion = projectVersionLoadResult.value;
 
   // return
   return Ok({

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -113,7 +113,6 @@ export const parseEnv = async function (
   checkPath: boolean
 ): Promise<Result<Env, EnvParseError>> {
   // set defaults
-  let upstream = true;
   let systemUser = false;
   let editorVersion: string | null = null;
   // log level
@@ -125,7 +124,7 @@ export const parseEnv = async function (
     log.disableColor();
   }
   // upstream
-  upstream = determineUseUpstream(options);
+  const upstream = determineUseUpstream(options);
   // region cn
   if (options._global.cn === true) log.notice("region", "cn");
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -97,6 +97,10 @@ function determineLogLevel(options: CmdOptions): "verbose" | "notice" {
   return options._global.verbose ? "verbose" : "notice";
 }
 
+function determineUseColor(options: CmdOptions): boolean {
+  return options._global.color !== false && process.env.NODE_ENV !== "test";
+}
+
 /**
  * Attempts to parse env.
  */
@@ -111,8 +115,7 @@ export const parseEnv = async function (
   // log level
   log.level = determineLogLevel(options);
   // color
-  const useColor =
-    options._global.color !== false && process.env.NODE_ENV !== "test";
+  const useColor = determineUseColor(options);
   if (!useColor) {
     chalk.level = 0;
     log.disableColor();

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -118,14 +118,17 @@ export const parseEnv = async function (
 ): Promise<Result<Env, EnvParseError>> {
   // log level
   log.level = determineLogLevel(options);
+
   // color
   const useColor = determineUseColor(options);
   if (!useColor) {
     chalk.level = 0;
     log.disableColor();
   }
+
   // upstream
   const upstream = determineUseUpstream(options);
+
   // region cn
   if (options._global.cn === true) log.notice("region", "cn");
 
@@ -133,6 +136,7 @@ export const parseEnv = async function (
   const systemUser = determineIsSystemUser(options);
   const wsl = determineWsl(options);
 
+  // registries
   const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).map(
     tryLoadUpmConfig
   ).promise;
@@ -189,7 +193,6 @@ export const parseEnv = async function (
   }
   const editorVersion = projectVersionLoadResult.value;
 
-  // return
   return Ok({
     cwd,
     editorVersion,

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -57,6 +57,10 @@ function determineCwd(options: CmdOptions): Result<string, CwdNotFoundError> {
   return Ok(cwd);
 }
 
+function determineWsl(options: CmdOptions): boolean {
+  return options._global.wsl === true;
+}
+
 /**
  * Attempts to parse env.
  */
@@ -110,7 +114,7 @@ export const parseEnv = async function (
 
   // auth
   if (options._global.systemUser) systemUser = true;
-  if (options._global.wsl) wsl = true;
+  wsl = determineWsl(options);
 
   const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).map(
     tryLoadUpmConfig

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -79,7 +79,6 @@ export const parseEnv = async function (
     auth: null,
   };
   let systemUser = false;
-  let wsl = false;
   let editorVersion: string | null = null;
   // log level
   log.level = options._global.verbose ? "verbose" : "notice";
@@ -114,7 +113,7 @@ export const parseEnv = async function (
 
   // auth
   if (options._global.systemUser) systemUser = true;
-  wsl = determineWsl(options);
+  const wsl = determineWsl(options);
 
   const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).map(
     tryLoadUpmConfig

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -117,7 +117,6 @@ export const parseEnv = async function (
   checkPath: boolean
 ): Promise<Result<Env, EnvParseError>> {
   // set defaults
-  let systemUser = false;
   let editorVersion: string | null = null;
   // log level
   log.level = determineLogLevel(options);
@@ -133,7 +132,7 @@ export const parseEnv = async function (
   if (options._global.cn === true) log.notice("region", "cn");
 
   // auth
-  systemUser = determineIsSystemUser(options);
+  const systemUser = determineIsSystemUser(options);
   const wsl = determineWsl(options);
 
   const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).map(

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -93,6 +93,10 @@ function determineUpstreamRegistry(
   return { url, auth };
 }
 
+function determineLogLevel(options: CmdOptions): "verbose" | "notice" {
+  return options._global.verbose ? "verbose" : "notice";
+}
+
 /**
  * Attempts to parse env.
  */
@@ -105,7 +109,7 @@ export const parseEnv = async function (
   let systemUser = false;
   let editorVersion: string | null = null;
   // log level
-  log.level = options._global.verbose ? "verbose" : "notice";
+  log.level = determineLogLevel(options);
   // color
   const useColor =
     options._global.color !== false && process.env.NODE_ENV !== "test";

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -101,6 +101,10 @@ function determineUseColor(options: CmdOptions): boolean {
   return options._global.color !== false && process.env.NODE_ENV !== "test";
 }
 
+function determineUseUpstream(options: CmdOptions): boolean {
+  return options._global.upstream !== false;
+}
+
 /**
  * Attempts to parse env.
  */
@@ -121,7 +125,7 @@ export const parseEnv = async function (
     log.disableColor();
   }
   // upstream
-  if (options._global.upstream === false) upstream = false;
+  upstream = determineUseUpstream(options);
   // region cn
   if (options._global.cn === true) log.notice("region", "cn");
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -69,7 +69,6 @@ export const parseEnv = async function (
     url: makeRegistryUrl("https://package.openupm.com"),
     auth: null,
   };
-  let cwd = "";
   let upstream = true;
   let upstreamRegistry: Registry = {
     url: makeRegistryUrl("https://packages.unity.com"),
@@ -132,7 +131,7 @@ export const parseEnv = async function (
   // return if no need to check path
   if (!checkPath)
     return Ok({
-      cwd,
+      cwd: "",
       editorVersion,
       registry,
       systemUser,
@@ -147,7 +146,7 @@ export const parseEnv = async function (
     log.error("env", `can not resolve path ${cwdResult.error.path}`);
     return cwdResult;
   }
-  cwd = cwdResult.value;
+  const cwd = cwdResult.value;
 
   // manifest path
   const manifestPath = manifestPathFor(cwd);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -105,6 +105,10 @@ function determineUseUpstream(options: CmdOptions): boolean {
   return options._global.upstream !== false;
 }
 
+function determineIsSystemUser(options: CmdOptions): boolean {
+  return options._global.systemUser === true;
+}
+
 /**
  * Attempts to parse env.
  */
@@ -129,7 +133,7 @@ export const parseEnv = async function (
   if (options._global.cn === true) log.notice("region", "cn");
 
   // auth
-  if (options._global.systemUser) systemUser = true;
+  systemUser = determineIsSystemUser(options);
   const wsl = determineWsl(options);
 
   const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).map(


### PR DESCRIPTION
Currently the `parseEnv` function is a bit of a mish-mash of high- and low-level logic, with logging and other stuff mixed in.

In a first step to clean up and also start splitting the function into more reusable parts, the logic for determining the individual properties of env were moved into separate functions.

This PR also makes the `parseEnv` function not use any `let` variables anymore.