### PR TITLE
refactor: result json parse

### DIFF
--- a/src/utils/data-parsing.ts
+++ b/src/utils/data-parsing.ts
@@ -1,0 +1,10 @@
+import { AnyJson } from "@iarna/toml";
+import { Result } from "ts-results-es";
+
+/**
+ * Attempts to parse a json-string.
+ * @param json The string to be parsed.
+ */
+export function tryParseJson(json: string): Result<AnyJson, SyntaxError> {
+  return Result.wrap(() => JSON.parse(json));
+}

--- a/test/data-parsing.test.ts
+++ b/test/data-parsing.test.ts
@@ -1,0 +1,24 @@
+import { tryParseJson } from "../src/utils/data-parsing";
+
+describe("data-parsing", () => {
+  describe("json", () => {
+    it("should round-trip valid json", () => {
+      const expected = { test: 123 };
+      const json = JSON.stringify(expected);
+
+      const result = tryParseJson(json);
+
+      expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should notify of parse error", () => {
+      const json = "{ invalid json ";
+
+      const result = tryParseJson(json);
+
+      expect(result).toBeError((error) =>
+        expect(error).toBeInstanceOf(SyntaxError)
+      );
+    });
+  });
+});


### PR DESCRIPTION
Currently when we want to parse json we have to use `JSON.parse` and wrap the operation in a result manually.

This PR adds a result-based and type-safe json-parse function for convenience.