### PR TITLE
refactor: env clean up

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,10 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   verbose: true,
+  clearMocks: true,
   setupFilesAfterEnv: [
-      "./test/mock-console-assertions.ts",
-      "./test/project-manifest-assertions.ts",
-      "./test/result-assertions.ts"
-  ]
+    "./test/mock-console-assertions.ts",
+    "./test/project-manifest-assertions.ts",
+    "./test/result-assertions.ts",
+  ],
 };

--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -85,7 +85,7 @@ export const add = async function (
 ): Promise<Result<void, AddError[]>> {
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
-  const envResult = await parseEnv(options, true);
+  const envResult = await parseEnv(options);
   if (envResult.isErr()) return Err([envResult.error]);
   const env = envResult.value;
 

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -37,7 +37,7 @@ export const deps = async function (
   options: DepsOptions
 ): Promise<Result<void, DepsError>> {
   // parse env
-  const envResult = await parseEnv(options, true);
+  const envResult = await parseEnv(options);
   if (envResult.isErr()) return envResult;
   const env = envResult.value;
 

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -41,7 +41,7 @@ export const login = async function (
   options: LoginOptions
 ): Promise<Result<void, LoginError>> {
   // parse env
-  const envResult = await parseEnv(options, true);
+  const envResult = await parseEnv(options);
   if (envResult.isErr()) return envResult;
   const env = envResult.value;
 

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -37,7 +37,7 @@ export const remove = async function (
 ): Promise<Result<void, RemoveError[]>> {
   if (!Array.isArray(pkgs)) pkgs = [pkgs];
   // parse env
-  const envResult = await parseEnv(options, true);
+  const envResult = await parseEnv(options);
   if (envResult.isErr()) return Err([envResult.error]);
   const env = envResult.value;
 

--- a/src/cmd-search.ts
+++ b/src/cmd-search.ts
@@ -53,7 +53,7 @@ export async function search(
   options: SearchOptions
 ): Promise<Result<void, SearchError>> {
   // parse env
-  const envResult = await parseEnv(options, true);
+  const envResult = await parseEnv(options);
   if (envResult.isErr()) return envResult;
   const env = envResult.value;
 

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -23,7 +23,7 @@ export const view = async function (
   options: ViewOptions
 ): Promise<Result<void, ViewError>> {
   // parse env
-  const envResult = await parseEnv(options, true);
+  const envResult = await parseEnv(options);
   if (envResult.isErr()) return envResult;
   const env = envResult.value;
 

--- a/src/types/project-manifest.ts
+++ b/src/types/project-manifest.ts
@@ -1,10 +1,10 @@
-import {DomainName} from "./domain-name";
-import {SemanticVersion} from "./semantic-version";
-import {PackageUrl} from "./package-url";
-import {ScopedRegistry} from "./scoped-registry";
-import {RegistryUrl} from "./registry-url";
-import {removeTrailingSlash} from "../utils/string-utils";
-import {removeRecordKey} from "../utils/record-utils";
+import { DomainName } from "./domain-name";
+import { SemanticVersion } from "./semantic-version";
+import { PackageUrl } from "./package-url";
+import { ScopedRegistry } from "./scoped-registry";
+import { RegistryUrl } from "./registry-url";
+import { removeTrailingSlash } from "../utils/string-utils";
+import { removeRecordKey } from "../utils/record-utils";
 
 /**
  * The content of the project-manifest (manifest.json) of a Unity project.

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -66,19 +66,13 @@ function determinePrimaryRegistry(
   return { url, auth };
 }
 
-function determineUpstreamRegistry(
-  options: CmdOptions,
-  upmConfig: UPMConfig | null
-): Registry {
+function determineUpstreamRegistry(options: CmdOptions): Registry {
   const url =
     options._global.cn === true
       ? makeRegistryUrl("https://packages.unity.cn")
       : makeRegistryUrl("https://packages.unity.com");
 
-  const auth =
-    upmConfig !== null ? tryGetAuthForRegistry(upmConfig, url) : null;
-
-  return { url, auth };
+  return { url, auth: null };
 }
 
 function determineLogLevel(options: CmdOptions): "verbose" | "notice" {
@@ -131,7 +125,7 @@ export const parseEnv = async function (
   const upmConfig = upmConfigResult.value;
 
   const registry = determinePrimaryRegistry(options, upmConfig);
-  const upstreamRegistry = determineUpstreamRegistry(options, upmConfig);
+  const upstreamRegistry = determineUpstreamRegistry(options);
 
   // cwd
   const cwdResult = determineCwd(options);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -17,7 +17,6 @@ import {
   ProjectVersionLoadError,
   tryLoadProjectVersion,
 } from "./project-version-io";
-import { manifestPathFor } from "./project-manifest-io";
 import { NotFoundError } from "./file-io";
 
 export type Env = Readonly<{
@@ -141,16 +140,6 @@ export const parseEnv = async function (
     return cwdResult;
   }
   const cwd = cwdResult.value;
-
-  // manifest path
-  const manifestPath = manifestPathFor(cwd);
-  if (!fs.existsSync(manifestPath)) {
-    log.error(
-      "manifest",
-      `can not locate manifest.json at path ${manifestPath}`
-    );
-    return Err(new NotFoundError(manifestPath));
-  }
 
   // editor version
   const projectVersionLoadResult = await tryLoadProjectVersion(cwd);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -102,8 +102,7 @@ function determineIsSystemUser(options: CmdOptions): boolean {
  * Attempts to parse env.
  */
 export const parseEnv = async function (
-  options: CmdOptions,
-  checkPath: boolean
+  options: CmdOptions
 ): Promise<Result<Env, EnvParseError>> {
   // log level
   log.level = determineLogLevel(options);
@@ -134,18 +133,6 @@ export const parseEnv = async function (
 
   const registry = determinePrimaryRegistry(options, upmConfig);
   const upstreamRegistry = determineUpstreamRegistry(options, upmConfig);
-
-  // return if no need to check path
-  if (!checkPath)
-    return Ok({
-      cwd: "",
-      editorVersion: null,
-      registry,
-      systemUser,
-      upstream,
-      upstreamRegistry,
-      wsl,
-    });
 
   // cwd
   const cwdResult = determineCwd(options);

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -46,24 +46,10 @@ describe("env", () => {
       await mockProject.restore();
     });
 
-    it("defaults", async function () {
-      const env = (await parseEnv({ _global: {} }, false)).unwrap();
-      expect(env.registry.url).toEqual("https://package.openupm.com");
-      expect(env.upstream).toBeTruthy();
-      expect(env.upstreamRegistry.url).toEqual("https://packages.unity.com");
-      expect(env.cwd).toEqual("");
-      expect(env.editorVersion === null).toBeTruthy();
-    });
-
-    it("check path", async function () {
-      const env = (await parseEnv({ _global: {} }, true)).unwrap();
-      expect(env.cwd).toEqual(mockProject.projectPath);
-    });
     it("can not resolve path", async function () {
-      const envResult = await parseEnv(
-        { _global: { chdir: "/path-not-exist" } },
-        true
-      );
+      const envResult = await parseEnv({
+        _global: { chdir: "/path-not-exist" },
+      });
       expect(envResult.isOk()).toBeFalsy();
       expect(mockConsole).toHaveLineIncluding("out", "can not resolve path");
     });
@@ -73,7 +59,7 @@ describe("env", () => {
       const manifestPath = manifestPathFor(mockProject.projectPath);
       fse.rmSync(manifestPath);
 
-      const envResult = await parseEnv({ _global: {} }, true);
+      const envResult = await parseEnv({ _global: {} });
       expect(envResult.isOk()).toBeFalsy();
       expect(mockConsole).toHaveLineIncluding(
         "out",
@@ -82,138 +68,109 @@ describe("env", () => {
     });
     it("custom registry", async function () {
       const env = (
-        await parseEnv(
-          { _global: { registry: "https://registry.npmjs.org" } },
-          false
-        )
+        await parseEnv({ _global: { registry: "https://registry.npmjs.org" } })
       ).unwrap();
 
       expect(env.registry.url).toEqual("https://registry.npmjs.org");
     });
     it("custom registry with splash", async function () {
       const env = (
-        await parseEnv(
-          { _global: { registry: "https://registry.npmjs.org/" } },
-          false
-        )
+        await parseEnv({ _global: { registry: "https://registry.npmjs.org/" } })
       ).unwrap();
 
       expect(env.registry.url).toEqual("https://registry.npmjs.org");
     });
     it("custom registry with extra path", async function () {
       const env = (
-        await parseEnv(
-          {
-            _global: {
-              registry: "https://registry.npmjs.org/some",
-            },
+        await parseEnv({
+          _global: {
+            registry: "https://registry.npmjs.org/some",
           },
-          false
-        )
+        })
       ).unwrap();
 
       expect(env.registry.url).toEqual("https://registry.npmjs.org/some");
     });
     it("custom registry with extra path and splash", async function () {
       const env = (
-        await parseEnv(
-          {
-            _global: {
-              registry: "https://registry.npmjs.org/some/",
-            },
+        await parseEnv({
+          _global: {
+            registry: "https://registry.npmjs.org/some/",
           },
-          false
-        )
+        })
       ).unwrap();
 
       expect(env.registry.url).toEqual("https://registry.npmjs.org/some");
     });
     it("custom registry without http", async function () {
       const env = (
-        await parseEnv({ _global: { registry: "registry.npmjs.org" } }, false)
+        await parseEnv({ _global: { registry: "registry.npmjs.org" } })
       ).unwrap();
 
       expect(env.registry.url).toEqual("http://registry.npmjs.org");
     });
     it("custom registry with ipv4+port", async function () {
       const env = (
-        await parseEnv(
-          { _global: { registry: "http://127.0.0.1:4873" } },
-          false
-        )
+        await parseEnv({ _global: { registry: "http://127.0.0.1:4873" } })
       ).unwrap();
 
       expect(env.registry.url).toEqual("http://127.0.0.1:4873");
     });
     it("custom registry with ipv6+port", async function () {
       const env = (
-        await parseEnv(
-          {
-            _global: { registry: "http://[1:2:3:4:5:6:7:8]:4873" },
-          },
-          false
-        )
+        await parseEnv({
+          _global: { registry: "http://[1:2:3:4:5:6:7:8]:4873" },
+        })
       ).unwrap();
 
       expect(env.registry.url).toEqual("http://[1:2:3:4:5:6:7:8]:4873");
     });
     it("should have registry auth if specified", async function () {
       const env = (
-        await parseEnv(
-          {
-            _global: {
-              registry: "registry.npmjs.org",
-            },
+        await parseEnv({
+          _global: {
+            registry: "registry.npmjs.org",
           },
-          true
-        )
+        })
       ).unwrap();
 
       expect(env.registry.auth).toEqual(testNpmAuth);
     });
     it("should not have unspecified registry auth", async function () {
       const env = (
-        await parseEnv(
-          {
-            _global: {
-              registry: "registry.other.org",
-            },
+        await parseEnv({
+          _global: {
+            registry: "registry.other.org",
           },
-          true
-        )
+        })
       ).unwrap();
 
       expect(env.registry.auth).toBeNull();
     });
     it("upstream", async function () {
-      const env = (
-        await parseEnv({ _global: { upstream: false } }, false)
-      ).unwrap();
+      const env = (await parseEnv({ _global: { upstream: false } })).unwrap();
 
       expect(env.upstream).not.toBeTruthy();
     });
     it("editorVersion", async function () {
-      const env = (await parseEnv({ _global: {} }, true)).unwrap();
+      const env = (await parseEnv({ _global: {} })).unwrap();
 
       expect(env.editorVersion).toEqual("2019.2.13f1");
     });
     it("region cn", async function () {
-      const env = (await parseEnv({ _global: { cn: true } }, false)).unwrap();
+      const env = (await parseEnv({ _global: { cn: true } })).unwrap();
 
       expect(env.registry.url).toEqual("https://package.openupm.cn");
       expect(env.upstreamRegistry.url).toEqual("https://packages.unity.cn");
     });
     it("region cn with a custom registry", async function () {
       const env = (
-        await parseEnv(
-          {
-            _global: {
-              cn: true,
-              registry: "https://reg.custom-package.com",
-            },
+        await parseEnv({
+          _global: {
+            cn: true,
+            registry: "https://reg.custom-package.com",
           },
-          false
-        )
+        })
       ).unwrap();
 
       expect(env.registry.url).toEqual("https://reg.custom-package.com");

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -19,7 +19,7 @@ declare global {
 
       toHaveScopedRegistries(): R;
 
-      toBeOk(valueAsserter?: (value: unknown) => void): R;
+      toBeOk<T>(valueAsserter?: (value: T) => void): R;
 
       toBeError(errorAsserter?: (error: Error) => void): R;
     }

--- a/test/project-manifest.test.ts
+++ b/test/project-manifest.test.ts
@@ -1,10 +1,10 @@
 import {
   addDependency,
-  setScopedRegistry,
   addTestable,
   emptyProjectManifest,
   mapScopedRegistry,
   removeDependency,
+  setScopedRegistry,
   tryGetScopedRegistryByUrl,
 } from "../src/types/project-manifest";
 import { makeDomainName } from "../src/types/domain-name";


### PR DESCRIPTION
Completely rewrites env tests with three major goals:

- Decouple from actual fs and process (Only use mocks)
- Exhaustively test all possible outputs (Including logs and errors)
- Shorten/de-duplicate test code

Also introduces some minor changes inside `parseEnv`. Please check commit messages for more details.