### PR TITLE
refactor: differentiate node error

### DIFF
--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -8,7 +8,7 @@ export class IOError extends CustomError {
     /**
      * The actual error that caused the failure.
      */
-    cause?: Error
+    cause?: NodeJS.ErrnoException
   ) {
     super("An interaction with the file-system caused an error.", { cause });
   }

--- a/src/utils/error-type-guards.ts
+++ b/src/utils/error-type-guards.ts
@@ -1,5 +1,5 @@
 import { HttpErrorBase } from "npm-registry-fetch";
-import { AssertionError } from "assert";
+import assert, { AssertionError } from "assert";
 
 /*
  * Note: We are in a Node context, where Errors have the "code" property.
@@ -12,10 +12,10 @@ import ErrnoException = NodeJS.ErrnoException;
  * @throws {AssertionError} The given parameter is not an error.
  */
 export function assertIsError(x: unknown): asserts x is ErrnoException {
-  if (x === null || typeof x !== "object" || !("name" in x && "message" in x))
-    throw new AssertionError({
-      message: "Argument was not an error!",
-    });
+  assert(x !== null);
+  assert(typeof x === "object");
+  assert("name" in x);
+  assert("message" in x);
 }
 
 export function assertIsHttpError(x: unknown): asserts x is HttpErrorBase {

--- a/src/utils/error-type-guards.ts
+++ b/src/utils/error-type-guards.ts
@@ -1,21 +1,27 @@
 import { HttpErrorBase } from "npm-registry-fetch";
 import assert, { AssertionError } from "assert";
 
-/*
- * Note: We are in a Node context, where Errors have the "code" property.
- * We need to make sure we use Node's error type instead of the default one
- * @see https://dev.to/jdbar/the-problem-with-handling-node-js-errors-in-typescript-and-the-workaround-m64
- */
-import ErrnoException = NodeJS.ErrnoException;
-
 /**
  * @throws {AssertionError} The given parameter is not an error.
  */
-export function assertIsError(x: unknown): asserts x is ErrnoException {
+export function assertIsError(x: unknown): asserts x is Error {
   assert(x !== null);
   assert(typeof x === "object");
   assert("name" in x);
   assert("message" in x);
+}
+
+/**
+ * Asserts that a value is a Node.js error, i.e it includes properties
+ * such as `code`.
+ * @param x The value to check.
+ * @throws {AssertionError} The given parameter is not a node-error.
+ */
+export function assertIsNodeError(
+  x: unknown
+): asserts x is NodeJS.ErrnoException {
+  assertIsError(x);
+  assert("code" in x);
 }
 
 export function assertIsHttpError(x: unknown): asserts x is HttpErrorBase {

--- a/src/utils/file-io.ts
+++ b/src/utils/file-io.ts
@@ -2,7 +2,7 @@ import { AsyncResult, Result } from "ts-results-es";
 import fs from "fs/promises";
 import { CustomError } from "ts-custom-error";
 import { IOError } from "../common-errors";
-import { assertIsError } from "./error-type-guards";
+import { assertIsNodeError } from "./error-type-guards";
 import fse from "fs-extra";
 import path from "path";
 
@@ -42,7 +42,7 @@ export function tryReadTextFromFile(
   return new AsyncResult(
     Result.wrapAsync(() => fs.readFile(path, { encoding: "utf8" }))
   ).mapErr((error) => {
-    assertIsError(error);
+    assertIsNodeError(error);
     if (error.code === "ENOENT") return new NotFoundError(path);
     return new IOError(error);
   });
@@ -62,7 +62,7 @@ export function tryWriteTextToFile(
   )
     .andThen(() => Result.wrapAsync(() => fs.writeFile(filePath, content)))
     .mapErr((error) => {
-      assertIsError(error);
+      assertIsNodeError(error);
       return new IOError(error);
     });
 }


### PR DESCRIPTION
`assertIsError` function was used to assert that objects were Node.js errors. But this disregarded that not all errors that occur in the program are Node.js errors, such as the one resulting from `JSON.parse`.

Created a separate assertion specifically for Node errors.