### PR TITLE
refactor: pull up log

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -204,6 +204,10 @@ export const add = async function (
       }
       // pkgsInScope
       if (!isUpstreamPackage) {
+        log.verbose(
+          "dependency",
+          `fetch: ${makePackageReference(name, requestedVersion)}`
+        );
         const [depsValid, depsInvalid] = await fetchPackageDependencies(
           env.registry,
           env.upstreamRegistry,

--- a/src/cmd-deps.ts
+++ b/src/cmd-deps.ts
@@ -48,12 +48,17 @@ export const deps = async function (
   if (version !== undefined && isPackageUrl(version))
     throw new Error("Cannot get dependencies for url-version");
 
+  const deep = options.deep || false;
+  log.verbose(
+    "dependency",
+    `fetch: ${makePackageReference(name, version)}, deep=${deep}`
+  );
   const [depsValid, depsInvalid] = await fetchPackageDependencies(
     env.registry,
     env.upstreamRegistry,
     name,
     version,
-    options.deep || false,
+    deep,
     client
   );
   depsValid

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -75,10 +75,6 @@ export const fetchPackageDependencies = async function (
   deep: boolean,
   client: NpmClient
 ): Promise<[ValidDependency[], InvalidDependency[]]> {
-  log.verbose(
-    "dependency",
-    `fetch: ${makePackageReference(name, version)} deep=${deep}`
-  );
   // a list of pending dependency {name, version}
   const pendingList: NameVersionPair[] = [{ name, version }];
   // a list of processed dependency {name, version}


### PR DESCRIPTION
Continuation of #168. Moves one logging call up into the containing cmd-functions