### PR TITLE
refactor: group io logic

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -6,7 +6,7 @@ import {
   ManifestSaveError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
-} from "./utils/project-manifest-io";
+} from "./io/project-manifest-io";
 import { EnvParseError, parseEnv } from "./utils/env";
 import {
   compareEditorVersion,

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -5,7 +5,7 @@ import {
   GetUpmConfigDirError,
   tryGetUpmConfigDir,
   tryStoreUpmAuth,
-} from "./utils/upm-config-io";
+} from "./io/upm-config-io";
 import { EnvParseError, parseEnv } from "./utils/env";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "./types/upm-config";
 import { coerceRegistryUrl, RegistryUrl } from "./types/registry-url";
@@ -18,7 +18,7 @@ import {
 import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
-import { tryReadTextFromFile, tryWriteTextToFile } from "./utils/file-io";
+import { tryReadTextFromFile, tryWriteTextToFile } from "./io/file-io";
 
 export type LoginError =
   | EnvParseError

--- a/src/cmd-remove.ts
+++ b/src/cmd-remove.ts
@@ -4,7 +4,7 @@ import {
   ManifestSaveError,
   tryLoadProjectManifest,
   trySaveProjectManifest,
-} from "./utils/project-manifest-io";
+} from "./io/project-manifest-io";
 import { EnvParseError, parseEnv } from "./utils/env";
 import {
   hasVersion,

--- a/src/error-logging.ts
+++ b/src/error-logging.ts
@@ -1,9 +1,6 @@
 import log from "./logger";
-import {
-  ManifestLoadError,
-  ManifestSaveError,
-} from "./utils/project-manifest-io";
-import { NotFoundError } from "./utils/file-io";
+import { ManifestLoadError, ManifestSaveError } from "./io/project-manifest-io";
+import { NotFoundError } from "./io/file-io";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.

--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -2,7 +2,7 @@ import { AsyncResult, Result } from "ts-results-es";
 import fs from "fs/promises";
 import { CustomError } from "ts-custom-error";
 import { IOError } from "../common-errors";
-import { assertIsNodeError } from "./error-type-guards";
+import { assertIsNodeError } from "../utils/error-type-guards";
 import fse from "fs-extra";
 import path from "path";
 

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -7,7 +7,7 @@ import {
   tryReadTextFromFile,
   tryWriteTextToFile,
 } from "./file-io";
-import { tryParseJson } from "./data-parsing";
+import { tryParseJson } from "../utils/data-parsing";
 
 export type ManifestLoadError = NotFoundError | FileParseError;
 

--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -4,7 +4,7 @@ import { AsyncResult, Err, Ok, Result } from "ts-results-es";
 import yaml from "yaml";
 import { FileParseError } from "../common-errors";
 import { FileReadError, tryReadTextFromFile } from "./file-io";
-import { assertIsError } from "./error-type-guards";
+import { assertIsError } from "../utils/error-type-guards";
 
 export type ProjectVersionLoadError = FileReadError | FileParseError;
 

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -2,13 +2,13 @@ import path from "path";
 import TOML from "@iarna/toml";
 import log from "../logger";
 import isWsl from "is-wsl";
-import execute from "./process";
+import execute from "../utils/process";
 import { addAuth, UpmAuth, UPMConfig } from "../types/upm-config";
 import { RegistryUrl } from "../types/registry-url";
 import { CustomError } from "ts-custom-error";
 import { IOError } from "../common-errors";
 import { AsyncResult, Result } from "ts-results-es";
-import { assertIsError } from "./error-type-guards";
+import { assertIsError } from "../utils/error-type-guards";
 import { tryReadTextFromFile, tryWriteTextToFile } from "./file-io";
 
 const configFileName = ".upmconfig.toml";

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,7 +4,7 @@ import {
   GetUpmConfigDirError,
   tryGetUpmConfigDir,
   tryLoadUpmConfig,
-} from "./upm-config-io";
+} from "../io/upm-config-io";
 import path from "path";
 import fs from "fs";
 import { coerceRegistryUrl, makeRegistryUrl } from "../types/registry-url";
@@ -16,8 +16,8 @@ import { Err, Ok, Result } from "ts-results-es";
 import {
   ProjectVersionLoadError,
   tryLoadProjectVersion,
-} from "./project-version-io";
-import { NotFoundError } from "./file-io";
+} from "../io/project-version-io";
+import { NotFoundError } from "../io/file-io";
 
 export type Env = Readonly<{
   cwd: string;

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -2,21 +2,21 @@ import { TokenAuth, UPMConfig } from "../src/types/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
 import { Env, parseEnv } from "../src/utils/env";
 import log from "../src/logger";
-import { tryLoadProjectVersion } from "../src/utils/project-version-io";
+import { tryLoadProjectVersion } from "../src/io/project-version-io";
 import { Err, Ok } from "ts-results-es";
 import {
   NoWslError,
   tryGetUpmConfigDir,
   tryLoadUpmConfig,
-} from "../src/utils/upm-config-io";
+} from "../src/io/upm-config-io";
 import { testRootPath } from "./setup/unity-project";
 import { exampleRegistryUrl } from "./mock-registry";
 import fs from "fs";
-import { NotFoundError } from "../src/utils/file-io";
+import { NotFoundError } from "../src/io/file-io";
 import { FileParseError, IOError } from "../src/common-errors";
 
-jest.mock("../src/utils/project-version-io");
-jest.mock("../src/utils/upm-config-io");
+jest.mock("../src/io/project-version-io");
+jest.mock("../src/io/upm-config-io");
 jest.mock("fs");
 jest.spyOn(process, "cwd");
 

--- a/test/file-io.test.ts
+++ b/test/file-io.test.ts
@@ -3,7 +3,7 @@ import {
   NotFoundError,
   tryReadTextFromFile,
   tryWriteTextToFile,
-} from "../src/utils/file-io";
+} from "../src/io/file-io";
 import { IOError } from "../src/common-errors";
 import fse from "fs-extra";
 import mocked = jest.mocked;

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -2,7 +2,7 @@ import {
   manifestPathFor,
   tryLoadProjectManifest,
   trySaveProjectManifest,
-} from "../src/utils/project-manifest-io";
+} from "../src/io/project-manifest-io";
 import { DomainName, makeDomainName } from "../src/types/domain-name";
 import { makeSemanticVersion } from "../src/types/semantic-version";
 import {
@@ -16,7 +16,7 @@ import { buildProjectManifest } from "./data-project-manifest";
 import { removeScope } from "../src/types/scoped-registry";
 import { exampleRegistryUrl } from "./mock-registry";
 import { FileParseError } from "../src/common-errors";
-import { NotFoundError } from "../src/utils/file-io";
+import { NotFoundError } from "../src/io/file-io";
 
 describe("project-manifest io", () => {
   let mockProject: MockUnityProject = null!;

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -8,11 +8,11 @@ import fse from "fs-extra";
 import {
   tryLoadProjectManifest,
   trySaveProjectManifest,
-} from "../../src/utils/project-manifest-io";
+} from "../../src/io/project-manifest-io";
 import { mockEnv, MockEnvSession } from "../mock-env";
 import { UPMConfig } from "../../src/types/upm-config";
-import { trySaveUpmConfig } from "../../src/utils/upm-config-io";
-import { tryCreateProjectVersionTxt } from "../../src/utils/project-version-io";
+import { trySaveUpmConfig } from "../../src/io/upm-config-io";
+import { tryCreateProjectVersionTxt } from "../../src/io/project-version-io";
 
 /**
  * A mock Unity project for testing.

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -2,7 +2,7 @@ import { runWithEnv } from "./mock-env";
 import {
   RequiredEnvMissingError,
   tryGetUpmConfigDir,
-} from "../src/utils/upm-config-io";
+} from "../src/io/upm-config-io";
 
 describe("upm-config-io", () => {
   describe("get directory", () => {


### PR DESCRIPTION
Currently io logic was mixed in with other stuff in the utils folder. Now that we have a few io related modules it makes sense to group them in a folder.

Moved all io related modules in the an `io` folder.