### PR TITLE
refactor: merge properties

### DIFF
--- a/src/cmd-add.ts
+++ b/src/cmd-add.ts
@@ -124,7 +124,7 @@ export const add = async function (
         requestedVersion,
         env.registry
       ).promise;
-      if (resolveResult.isErr() && env.upstream) {
+      if (resolveResult.isErr() && env.upstreamRegistry !== null) {
         resolveResult = await tryResolve(
           client,
           name,

--- a/src/cmd-view.ts
+++ b/src/cmd-view.ts
@@ -38,7 +38,7 @@ export const view = async function (
   return await client
     .tryFetchPackument(env.registry, pkg)
     .andThen(async (packument) => {
-      if (packument === null && env.upstream)
+      if (packument === null && env.upstreamRegistry !== null)
         return await client.tryFetchPackument(env.upstreamRegistry, pkg)
           .promise;
       return Ok(packument);

--- a/src/dependency-resolving.ts
+++ b/src/dependency-resolving.ts
@@ -69,7 +69,7 @@ type NameVersionPair = Readonly<{
  */
 export const fetchPackageDependencies = async function (
   registry: Registry,
-  upstreamRegistry: Registry,
+  upstreamRegistry: Registry | null,
   name: DomainName,
   version: SemanticVersion | "latest" | undefined,
   deep: boolean,
@@ -126,7 +126,7 @@ export const fetchPackageDependencies = async function (
           entry.version
         );
         // Then upstream registry
-        if (resolveResult.isErr()) {
+        if (resolveResult.isErr() && upstreamRegistry !== null) {
           const upstreamResult = await tryResolveFromRegistry(
             upstreamRegistry,
             entry.name,

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -23,8 +23,7 @@ export type Env = Readonly<{
   cwd: string;
   systemUser: boolean;
   wsl: boolean;
-  upstream: boolean;
-  upstreamRegistry: Registry;
+  upstreamRegistry: Registry | null;
   registry: Registry;
   editorVersion: string | null;
 }>;
@@ -107,9 +106,6 @@ export const parseEnv = async function (
     log.disableColor();
   }
 
-  // upstream
-  const upstream = determineUseUpstream(options);
-
   // region cn
   if (options._global.cn === true) log.notice("region", "cn");
 
@@ -125,7 +121,12 @@ export const parseEnv = async function (
   const upmConfig = upmConfigResult.value;
 
   const registry = determinePrimaryRegistry(options, upmConfig);
-  const upstreamRegistry = determineUpstreamRegistry(options);
+
+  // upstream
+  const useUpstream = determineUseUpstream(options);
+  const upstreamRegistry = useUpstream
+    ? determineUpstreamRegistry(options)
+    : null;
 
   // cwd
   const cwdResult = determineCwd(options);
@@ -157,7 +158,6 @@ export const parseEnv = async function (
     editorVersion,
     registry,
     systemUser,
-    upstream,
     upstreamRegistry,
     wsl,
   });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -130,36 +130,6 @@ describe("env", () => {
     });
   });
 
-  describe("use upstream", () => {
-    it("should use upstream if upstream option is true", async () => {
-      const result = await parseEnv({
-        _global: {
-          upstream: true,
-        },
-      });
-
-      expect(result).toBeOk((env: Env) => expect(env.upstream).toBeTruthy());
-    });
-
-    it("should use upstream if upstream option is missing", async () => {
-      const result = await parseEnv({
-        _global: {},
-      });
-
-      expect(result).toBeOk((env: Env) => expect(env.upstream).toBeTruthy());
-    });
-
-    it("should not use upstream if upstream option is false", async () => {
-      const result = await parseEnv({
-        _global: {
-          upstream: false,
-        },
-      });
-
-      expect(result).toBeOk((env: Env) => expect(env.upstream).toBeFalsy());
-    });
-  });
-
   describe("region log", () => {
     it("should notify of china region if cn option is true", async () => {
       const logSpy = jest.spyOn(log, "notice");
@@ -344,11 +314,45 @@ describe("env", () => {
   });
 
   describe("upstream registry", () => {
+    it("should use upstream if upstream option is true", async () => {
+      const result = await parseEnv({
+        _global: {
+          upstream: true,
+        },
+      });
+
+      expect(result).toBeOk((env: Env) =>
+        expect(env.upstreamRegistry).not.toBeNull()
+      );
+    });
+
+    it("should use upstream if upstream option is missing", async () => {
+      const result = await parseEnv({
+        _global: {},
+      });
+
+      expect(result).toBeOk((env: Env) =>
+        expect(env.upstreamRegistry).not.toBeNull()
+      );
+    });
+
+    it("should not use upstream if upstream option is false", async () => {
+      const result = await parseEnv({
+        _global: {
+          upstream: false,
+        },
+      });
+
+      expect(result).toBeOk((env: Env) =>
+        expect(env.upstreamRegistry).toBeNull()
+      );
+    });
+
     it("should be global unity by default", async () => {
       const result = await parseEnv({ _global: {} });
 
       expect(result).toBeOk((env: Env) =>
-        expect(env.upstreamRegistry.url).toEqual("https://packages.unity.com")
+        expect(env.upstreamRegistry!.url).toEqual("https://packages.unity.com")
       );
     });
 
@@ -360,7 +364,7 @@ describe("env", () => {
       });
 
       expect(result).toBeOk((env: Env) =>
-        expect(env.upstreamRegistry.url).toEqual("https://packages.unity.cn")
+        expect(env.upstreamRegistry!.url).toEqual("https://packages.unity.cn")
       );
     });
 
@@ -370,7 +374,7 @@ describe("env", () => {
       });
 
       expect(result).toBeOk((env: Env) =>
-        expect(env.upstreamRegistry.auth).toEqual(null)
+        expect(env.upstreamRegistry!.auth).toEqual(null)
       );
     });
   });


### PR DESCRIPTION
Currently Env had the `upstreamRegistry` property plus the `upstream` property on it. `upstreamRegistry` was always filled and then `upstream` indicated whether it should be used.

This information can be encoded more directly by making `upstreamRegistry` optional. Now if it is null, it is clear we should not use it. This also makes it easier for a future change which will allow to use n registries.

The only place where this change might potentially break something is in dependency resolving. There the upstream registry was used no matter what value is in `upstream`. Tests still are green but maybe I missed something. @favoyang do you have any input on this?