### PR TITLE
refactor: use it.each

### DIFF
--- a/test/domain-name.test.ts
+++ b/test/domain-name.test.ts
@@ -6,17 +6,16 @@ import {
 
 describe("domain-name", () => {
   describe("validation", () => {
-    [
+    it.each([
       "com",
       "com.unity",
       "com.openupm",
       "at.ac.my-school",
       "dev.comradevanti123",
-    ].forEach((s) =>
-      it(`"${s}" should be domain-name`, () => {
-        expect(isDomainName(s)).toBeTruthy();
-      })
-    );
+    ])(`"%s" should be domain-name`, (s) => {
+      expect(isDomainName(s)).toBeTruthy();
+    });
+
     [
       "",
       " ",
@@ -34,6 +33,7 @@ describe("domain-name", () => {
       })
     );
   });
+
   describe("internal package", () => {
     it("test com.otherorg.software", () => {
       expect(

--- a/test/domain-name.test.ts
+++ b/test/domain-name.test.ts
@@ -16,7 +16,7 @@ describe("domain-name", () => {
       expect(isDomainName(s)).toBeTruthy();
     });
 
-    [
+    it.each([
       "",
       " ",
       // Invalid characters
@@ -27,11 +27,9 @@ describe("domain-name", () => {
       "com.-unity",
       // No trailing hyphens
       "com.unity-",
-    ].forEach((s) =>
-      it(`"${s}" should not be domain-name`, () => {
-        expect(isDomainName(s)).toBeFalsy();
-      })
-    );
+    ])(`"%s" should not be domain-name`, (s) => {
+      expect(isDomainName(s)).toBeFalsy();
+    });
   });
 
   describe("internal package", () => {

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -99,23 +99,21 @@ describe("editor-version", () => {
       ).toEqual(1);
     });
 
-    Array.of<[string, string]>(
+    it.each([
       ["2019.1", "2019.2"],
       ["2019.1", "2020.1"],
       ["2019.1", "2019.1.1"],
       ["2019.1.1", "2019.1.1f1"],
       ["2019.1.1a1", "2020.1.1b1"],
       ["2019.1.1b1", "2020.1.1f1"],
-      ["2019.1.1f1", "2020.1.1f1c1"]
-    ).forEach(([a, b]) =>
-      it(`${a} < ${b}`, function () {
-        expect(
-          compareEditorVersion(
-            tryParseEditorVersion(a)!,
-            tryParseEditorVersion(b)!
-          )
-        ).toEqual(-1);
-      })
-    );
+      ["2019.1.1f1", "2020.1.1f1c1"],
+    ])(`%s < %s`, function (a, b) {
+      expect(
+        compareEditorVersion(
+          tryParseEditorVersion(a)!,
+          tryParseEditorVersion(b)!
+        )
+      ).toEqual(-1);
+    });
   });
 });

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -73,21 +73,20 @@ describe("editor-version", () => {
   });
 
   describe("compareEditorVersion", () => {
-    Array.of<[string, string]>(
+    it.each([
       ["2019.1", "2019.1"],
       ["2019.1.1", "2019.1.1"],
       ["2019.1.1f1", "2019.1.1f1"],
-      ["2019.1.1f1c1", "2019.1.1f1c1"]
-    ).forEach(([a, b]) =>
-      it(`${a} == ${b}`, function () {
-        expect(
-          compareEditorVersion(
-            tryParseEditorVersion(a)!,
-            tryParseEditorVersion(b)!
-          )
-        ).toEqual(0);
-      })
-    );
+      ["2019.1.1f1c1", "2019.1.1f1c1"],
+    ])(`%s == %s`, function (a, b) {
+      expect(
+        compareEditorVersion(
+          tryParseEditorVersion(a)!,
+          tryParseEditorVersion(b)!
+        )
+      ).toEqual(0);
+    });
+
     Array.of<[string, string]>(
       ["2019.2", "2019.1"],
       ["2020.1", "2019.1"]

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -87,19 +87,18 @@ describe("editor-version", () => {
       ).toEqual(0);
     });
 
-    Array.of<[string, string]>(
+    it.each([
       ["2019.2", "2019.1"],
-      ["2020.1", "2019.1"]
-    ).forEach(([a, b]) =>
-      it(`${a} > ${b}`, function () {
-        expect(
-          compareEditorVersion(
-            tryParseEditorVersion(a)!,
-            tryParseEditorVersion(b)!
-          )
-        ).toEqual(1);
-      })
-    );
+      ["2020.1", "2019.1"],
+    ])(`%s > %s`, function (a, b) {
+      expect(
+        compareEditorVersion(
+          tryParseEditorVersion(a)!,
+          tryParseEditorVersion(b)!
+        )
+      ).toEqual(1);
+    });
+
     Array.of<[string, string]>(
       ["2019.1", "2019.2"],
       ["2019.1", "2020.1"],

--- a/test/package-id.test.ts
+++ b/test/package-id.test.ts
@@ -2,11 +2,10 @@ import { isPackageId } from "../src/types/package-id";
 
 describe("package-id", () => {
   describe("validate", () => {
-    ["com.my-package@1.2.3"].forEach((s) =>
-      it(`"${s}" should be package-id`, () => {
-        expect(isPackageId(s)).toBeTruthy();
-      })
-    );
+    it("should be ok for valid string", () => {
+      const s = "com.my-package@1.2.3";
+      expect(isPackageId(s)).toBeTruthy();
+    });
 
     [
       "",

--- a/test/package-id.test.ts
+++ b/test/package-id.test.ts
@@ -7,7 +7,7 @@ describe("package-id", () => {
       expect(isPackageId(s)).toBeTruthy();
     });
 
-    [
+    it.each([
       "",
       " ",
       // Missing version
@@ -15,10 +15,8 @@ describe("package-id", () => {
       // Incomplete version
       "com.my-package@1",
       "com.my-package@1.2",
-    ].forEach((s) =>
-      it(`"${s}" should not be package-id`, () => {
-        expect(isPackageId(s)).toBeFalsy();
-      })
-    );
+    ])(`"%s" should not be package-id`, (s) => {
+      expect(isPackageId(s)).toBeFalsy();
+    });
   });
 });

--- a/test/package-reference.test.ts
+++ b/test/package-reference.test.ts
@@ -6,16 +6,15 @@ import {
 
 describe("package-reference", () => {
   describe("validation", () => {
-    [
+    it.each([
       "com.abc.my-package",
       "com.abc.my-package@1.2.3",
       "com.abc.my-package@file://./my-package",
       "com.abc.my-package@latest",
-    ].forEach((input) =>
-      it(`"${input}" should be package-reference`, function () {
-        expect(isPackageReference(input)).toBeTruthy();
-      })
-    );
+    ])(`"%s" should be package-reference`, (input) => {
+      expect(isPackageReference(input)).toBeTruthy();
+    });
+
     [
       // Not valid domain name
       "-hello",

--- a/test/package-reference.test.ts
+++ b/test/package-reference.test.ts
@@ -15,14 +15,12 @@ describe("package-reference", () => {
       expect(isPackageReference(input)).toBeTruthy();
     });
 
-    [
+    it.each([
       // Not valid domain name
       "-hello",
-    ].forEach((input) =>
-      it(`"${input}" should not be package-reference`, function () {
-        expect(isPackageReference(input)).not.toBeTruthy();
-      })
-    );
+    ])(`"should not be ok for "%s"`, (input) => {
+      expect(isPackageReference(input)).not.toBeTruthy();
+    });
   });
 
   describe("split", () => {

--- a/test/package-url.test.ts
+++ b/test/package-url.test.ts
@@ -2,15 +2,13 @@ import { isPackageUrl } from "../src/types/package-url";
 
 describe("package-url", () => {
   describe("validation", () => {
-    [
+    it.each([
       "https://github.com/yo/com.base.package-a",
       "git@github.com:yo/com.base.package-a",
       "file../yo/com.base.package-a",
-    ].forEach((url) =>
-      it(`"${url}" is a package-url`, function () {
-        expect(isPackageUrl(url)).toBeTruthy();
-      })
-    );
+    ])(`should be ok for "%s"`, (url) => {
+      expect(isPackageUrl(url)).toBeTruthy();
+    });
 
     ["", "com.base.package.a"].forEach((url) =>
       it(`"${url}" is not a package-url`, function () {

--- a/test/package-url.test.ts
+++ b/test/package-url.test.ts
@@ -10,10 +10,8 @@ describe("package-url", () => {
       expect(isPackageUrl(url)).toBeTruthy();
     });
 
-    ["", "com.base.package.a"].forEach((url) =>
-      it(`"${url}" is not a package-url`, function () {
-        expect(isPackageUrl(url)).not.toBeTruthy();
-      })
-    );
+    it.each(["", "com.base.package.a"])(`should not be ok for "%s"`, (url) => {
+      expect(isPackageUrl(url)).not.toBeTruthy();
+    });
   });
 });

--- a/test/registry-url.test.ts
+++ b/test/registry-url.test.ts
@@ -8,21 +8,22 @@ describe("registry-url", () => {
         expect(isRegistryUrl(input)).toBeTruthy();
       }
     );
-    [
+
+    it.each([
       // Missing protocol
       "registry.npmjs.org/",
       // Trailing slash
       "http://registry.npmjs.org/",
-    ].forEach((input) =>
-      it(`"${input}" should not be registry-url`, function () {
-        expect(isRegistryUrl(input)).not.toBeTruthy();
-      })
-    );
+    ])(`"should not be ok for "%s"`, (input) => {
+      expect(isRegistryUrl(input)).not.toBeTruthy();
+    });
   });
+  
   describe("coerce", () => {
     it("should coerce urls without protocol", () => {
       expect(coerceRegistryUrl("test.com")).toEqual("http://test.com");
     });
+    
     it("should remove trailing slash", () => {
       expect(coerceRegistryUrl("http://test.com/")).toEqual("http://test.com");
     });

--- a/test/registry-url.test.ts
+++ b/test/registry-url.test.ts
@@ -2,11 +2,11 @@ import { coerceRegistryUrl, isRegistryUrl } from "../src/types/registry-url";
 
 describe("registry-url", () => {
   describe("validation", () => {
-    ["http://registry.npmjs.org", "https://registry.npmjs.org"].forEach(
-      (input) =>
-        it(`"${input}" should be registry-url`, function () {
-          expect(isRegistryUrl(input)).toBeTruthy();
-        })
+    it.each(["http://registry.npmjs.org", "https://registry.npmjs.org"])(
+      `"should be ok for "%s"`,
+      (input) => {
+        expect(isRegistryUrl(input)).toBeTruthy();
+      }
     );
     [
       // Missing protocol

--- a/test/semantic-version.test.ts
+++ b/test/semantic-version.test.ts
@@ -2,11 +2,10 @@ import { isSemanticVersion } from "../src/types/semantic-version";
 
 describe("semantic-version", () => {
   describe("validate", () => {
-    ["1.2.3", "1.2.3-alpha"].forEach((input) =>
-      it(`"${input}" is a semantic version`, function () {
-        expect(isSemanticVersion(input)).toBeTruthy();
-      })
-    );
+    it.each(["1.2.3", "1.2.3-alpha"])(`should be ok for "%s"`, (input) => {
+      expect(isSemanticVersion(input)).toBeTruthy();
+    });
+
     ["", " ", "wow", "1", "1.2"].forEach((input) =>
       it(`"${input}" is not a semantic version`, function () {
         expect(isSemanticVersion(input)).not.toBeTruthy();

--- a/test/semantic-version.test.ts
+++ b/test/semantic-version.test.ts
@@ -6,10 +6,11 @@ describe("semantic-version", () => {
       expect(isSemanticVersion(input)).toBeTruthy();
     });
 
-    ["", " ", "wow", "1", "1.2"].forEach((input) =>
-      it(`"${input}" is not a semantic version`, function () {
+    it.each(["", " ", "wow", "1", "1.2"])(
+      `shout not be ok for "%s"`,
+      (input) => {
         expect(isSemanticVersion(input)).not.toBeTruthy();
-      })
+      }
     );
   });
 });


### PR DESCRIPTION
Mocha does not have a builtin parameterized test feature. Because of this we used a `forEach` loop for these tests.

jest does have a builtin feature for this. This PR changes the tests to use it. Also rewords a few of the descriptions.