### PR TITLE
refactor: change test to prop test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-jsdoc": "^47.0.2",
+        "fast-check": "^3.16.0",
         "jest": "^29.7.0",
         "nock": "^13.2.4",
         "prettier": "^2.8.8",
@@ -4563,6 +4564,28 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.16.0.tgz",
+      "integrity": "sha512-k8GtQHi4pJoRQ1gVDFQno+/FVkowo/ehiz/aCj9O/D7HRWb1sSFzNrw+iPVU8QlWtH+jNwbuN+dDVg3QkS56DQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -15354,6 +15377,15 @@
     },
     "extsprintf": {
       "version": "1.3.0"
+    },
+    "fast-check": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.16.0.tgz",
+      "integrity": "sha512-k8GtQHi4pJoRQ1gVDFQno+/FVkowo/ehiz/aCj9O/D7HRWb1sSFzNrw+iPVU8QlWtH+jNwbuN+dDVg3QkS56DQ==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^6.0.0"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jsdoc": "^47.0.2",
+    "fast-check": "^3.16.0",
     "jest": "^29.7.0",
     "nock": "^13.2.4",
     "prettier": "^2.8.8",

--- a/test/base64.test.ts
+++ b/test/base64.test.ts
@@ -1,11 +1,15 @@
 import { decodeBase64, encodeBase64 } from "../src/types/base64";
+import fc from "fast-check";
 
 describe("base 64", () => {
   it("should round-trip", () => {
-    const expected = "some text";
-    const encoded = encodeBase64(expected);
-    const actual = decodeBase64(encoded);
+    fc.assert(
+      fc.property(fc.string(), (expected) => {
+        const encoded = encodeBase64(expected);
+        const actual = decodeBase64(encoded);
 
-    expect(actual).toEqual(expected);
+        expect(actual).toEqual(expected);
+      })
+    );
   });
 });


### PR DESCRIPTION
Since base64 encode/decode roundtrip should work regardless of input, it's a perfect use-case for a property-based test.