### PR TITLE
test: use consistent test lables

### DIFF
--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -154,7 +154,7 @@ describe("cmd-add.ts", () => {
       await mockProject.restore();
     });
 
-    it("add pkg", async function () {
+    it("should add packument without version", async function () {
       const addResult = await add(packageA, options);
       expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
@@ -163,7 +163,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg@1.0.0", async function () {
+    it("should add packument with semantic version", async function () {
       const addResult = await add(
         makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
@@ -175,7 +175,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg@latest", async function () {
+    it("should add packument with latest tag", async function () {
       const addResult = await add(
         makePackageReference(packageA, "latest"),
         options
@@ -187,7 +187,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg@0.1.0 then pkg@1.0.0", async function () {
+    it("should override packument with lower version", async function () {
       const addResult1 = await add(
         makePackageReference(packageA, makeSemanticVersion("0.1.0")),
         options
@@ -204,7 +204,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "modified ");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add exited pkg version", async function () {
+    it("should have no effect to add same packument twice", async function () {
       const addResult1 = await add(
         makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
@@ -221,7 +221,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "existed ");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg@not-exist-version", async function () {
+    it("should fail to add packument with unknown version", async function () {
       const addResult = await add(
         makePackageReference(packageA, makeSemanticVersion("2.0.0")),
         options
@@ -237,7 +237,7 @@ describe("cmd-add.ts", () => {
 
       expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
     });
-    it("add pkg@http", async function () {
+    it("should add packument with http version", async function () {
       const gitUrl = "https://github.com/yo/com.base.package-a" as PackageUrl;
       const addResult = await add(
         makePackageReference(packageA, gitUrl),
@@ -253,7 +253,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg@git", async function () {
+    it("should add packument with git version", async function () {
       const gitUrl = "git@github.com:yo/com.base.package-a" as PackageUrl;
       const addResult = await add(
         makePackageReference(packageA, gitUrl),
@@ -269,7 +269,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg@file", async function () {
+    it("should add packument with file version", async function () {
       const fileUrl = "file../yo/com.base.package-a" as PackageUrl;
       const addResult = await add(
         makePackageReference(packageA, fileUrl),
@@ -285,7 +285,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg-not-exist", async function () {
+    it("should fail for unknown packument", async function () {
       const addResult = await add(packageMissing, options);
       expect(addResult).toBeError();
       await mockProject.tryAssertManifest((manifest) =>
@@ -293,7 +293,7 @@ describe("cmd-add.ts", () => {
       );
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
-    it("add more than one pkgs", async function () {
+    it("should be able to add multiple packuments", async function () {
       const addResult = await add([packageA, packageB], options);
       expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
@@ -309,7 +309,7 @@ describe("cmd-add.ts", () => {
       );
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg from upstream", async function () {
+    it("should add upstream packument", async function () {
       const addResult = await add(packageUp, upstreamOptions);
       expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
@@ -321,7 +321,7 @@ describe("cmd-add.ts", () => {
       );
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg-not-exist from upstream", async function () {
+    it("should fail for unknown upstream packument", async function () {
       const addResult = await add(packageMissing, upstreamOptions);
       expect(addResult).toBeError();
       await mockProject.tryAssertManifest((manifest) =>
@@ -329,7 +329,7 @@ describe("cmd-add.ts", () => {
       );
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
-    it("add pkg with nested dependencies", async function () {
+    it("should add packument dependencies", async function () {
       const addResult = await add(
         makePackageReference(packageC, "latest"),
         upstreamOptions
@@ -341,7 +341,7 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg with tests", async function () {
+    it("should packument to testables when requested", async function () {
       const addResult = await add(packageA, testableOptions);
       expect(addResult).toBeOk();
       await mockProject.tryAssertManifest((manifest) =>
@@ -350,13 +350,13 @@ describe("cmd-add.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg with lower editor version", async function () {
+    it("should add packument with lower editor-version", async function () {
       const addResult = await add(packageLowerEditor, testableOptions);
       expect(addResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "added");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("add pkg with higher editor version", async function () {
+    it("should fail to add packument with higher editor-version", async function () {
       const addResult = await add(packageHigherEditor, testableOptions);
       expect(addResult).toBeError();
       expect(mockConsole).toHaveLineIncluding(
@@ -364,7 +364,7 @@ describe("cmd-add.ts", () => {
         "requires 2020.2 but found 2019.2.13f1"
       );
     });
-    it("force add pkg with higher editor version", async function () {
+    it("should add packument with higher editor-version when forced", async function () {
       const addResult = await add(packageHigherEditor, forceOptions);
       expect(addResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
@@ -372,12 +372,12 @@ describe("cmd-add.ts", () => {
         "requires 2020.2 but found 2019.2.13f1"
       );
     });
-    it("add pkg with wrong editor version", async function () {
+    it("should not add packument with bad editor-version", async function () {
       const addResult = await add(packageWrongEditor, testableOptions);
       expect(addResult).toBeError();
       expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");
     });
-    it("force add pkg with wrong editor version", async function () {
+    it("should add packument with bad editor-version when forced", async function () {
       const addResult = await add(packageWrongEditor, forceOptions);
       expect(addResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "2020 is not valid");

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -64,12 +64,12 @@ describe("cmd-deps.ts", () => {
       await mockProject.restore();
     });
 
-    it("deps pkg", async function () {
+    it("should print direct dependencies", async function () {
       const depsResult = await deps(remotePackumentA.name, options);
       expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
-    it("deps pkg --deep", async function () {
+    it("should print all dependencies when requested", async function () {
       const depsResult = await deps(remotePackumentA.name, {
         ...options,
         deep: true,
@@ -78,7 +78,7 @@ describe("cmd-deps.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentUp.name);
     });
-    it("deps pkg@latest", async function () {
+    it("should print correct dependencies for latest tag", async function () {
       const depsResult = await deps(
         makePackageReference(remotePackumentA.name, "latest"),
         options
@@ -86,7 +86,7 @@ describe("cmd-deps.ts", () => {
       expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
-    it("deps pkg@1.0.0", async function () {
+    it("should print correct dependencies for semantic version", async function () {
       const depsResult = await deps(
         makePackageReference(remotePackumentA.name, "1.0.0"),
         options
@@ -94,7 +94,7 @@ describe("cmd-deps.ts", () => {
       expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", remotePackumentB.name);
     });
-    it("deps pkg@not-exist-version", async function () {
+    it("should print no dependencies for unknown version", async function () {
       const depsResult = await deps(
         makePackageReference(remotePackumentA.name, "2.0.0"),
         options
@@ -102,12 +102,12 @@ describe("cmd-deps.ts", () => {
       expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "is not a valid choice");
     });
-    it("deps pkg-not-exist", async function () {
+    it("should print no dependencies for unknown packument", async function () {
       const depsResult = await deps(makeDomainName("pkg-not-exist"), options);
       expect(depsResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "not found");
     });
-    it("deps pkg upstream", async function () {
+    it("should print dependencies for upstream packuments", async function () {
       const depsResult = await deps(remotePackumentUp.name, options);
       expect(depsResult).toBeOk();
     });

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -39,7 +39,7 @@ describe("cmd-remove.ts", () => {
       await mockProject.restore();
     });
 
-    it("remove pkg", async function () {
+    it("should remove packument without version", async function () {
       const options = {
         _global: {
           registry: exampleRegistryUrl,
@@ -54,7 +54,7 @@ describe("cmd-remove.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "removed ");
       expect(mockConsole).toHaveLineIncluding("out", "open Unity");
     });
-    it("remove pkg@1.0.0", async function () {
+    it("should remove packument with semantic version", async function () {
       const options = {
         _global: {
           registry: exampleRegistryUrl,
@@ -73,7 +73,7 @@ describe("cmd-remove.ts", () => {
         "do not specify a version"
       );
     });
-    it("remove pkg-not-exist", async function () {
+    it("should fail for uninstalled packument", async function () {
       const options = {
         _global: {
           registry: exampleRegistryUrl,
@@ -86,7 +86,7 @@ describe("cmd-remove.ts", () => {
       });
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
-    it("remove more than one pkgs", async function () {
+    it("should remove multiple packuments", async function () {
       const options = {
         _global: {
           registry: exampleRegistryUrl,

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -84,14 +84,14 @@ describe("cmd-search.ts", () => {
     afterEach(function () {
       stopMockRegistry();
     });
-    it("simple", async function () {
+    it("should print packument information", async function () {
       const searchResult = await search("package-a", options);
       expect(searchResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "package-a");
       expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
       expect(mockConsole).toHaveLineIncluding("out", "2019-10-02");
     });
-    it("pkg not exist", async function () {
+    it("should notify of unknown packument", async function () {
       const searchResult = await search("pkg-not-exist", options);
       expect(searchResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding("out", "No matches found");
@@ -131,7 +131,7 @@ describe("cmd-search.ts", () => {
     afterEach(function () {
       stopMockRegistry();
     });
-    it("from remote", async function () {
+    it("should print packument information", async function () {
       nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
         "Content-Type": "application/json",
       });
@@ -145,7 +145,7 @@ describe("cmd-search.ts", () => {
       expect(mockConsole).toHaveLineIncluding("out", "1.0.0");
       expect(mockConsole).toHaveLineIncluding("out", "2019-10-02");
     });
-    it("pkg not exist", async function () {
+    it("should notify of unknown packument", async function () {
       nock(exampleRegistryUrl).get("/-/all").reply(200, allResult, {
         "Content-Type": "application/json",
       });

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -123,7 +123,7 @@ describe("cmd-view.ts", () => {
       await mockProject.restore();
     });
 
-    it("view pkg", async function () {
+    it("should print information for packument without version", async function () {
       const viewResult = await view(packageA, options);
       expect(viewResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
@@ -131,7 +131,7 @@ describe("cmd-view.ts", () => {
         "com.example.package-a@1.0.0"
       );
     });
-    it("view pkg@1.0.0", async function () {
+    it("should print information for packument with semantic version", async function () {
       const viewResult = await view(
         makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
@@ -142,12 +142,12 @@ describe("cmd-view.ts", () => {
         "do not specify a version"
       );
     });
-    it("view pkg-not-exist", async function () {
+    it("should fail for unknown packument", async function () {
       const viewResult = await view(packageMissing, options);
       expect(viewResult).toBeError();
       expect(mockConsole).toHaveLineIncluding("out", "package not found");
     });
-    it("view pkg from upstream", async function () {
+    it("should print information for upstream packument", async function () {
       const viewResult = await view(packageUp, upstreamOptions);
       expect(viewResult).toBeOk();
       expect(mockConsole).toHaveLineIncluding(
@@ -155,7 +155,7 @@ describe("cmd-view.ts", () => {
         "com.example.package-up@1.0.0"
       );
     });
-    it("view pkg-not-exist from upstream", async function () {
+    it("should fail for unknown upstream packument", async function () {
       const viewResult = await view(packageMissing, upstreamOptions);
       expect(viewResult).toBeError();
       expect(mockConsole).toHaveLineIncluding("out", "package not found");

--- a/test/domain-name.test.ts
+++ b/test/domain-name.test.ts
@@ -12,7 +12,7 @@ describe("domain-name", () => {
       "com.openupm",
       "at.ac.my-school",
       "dev.comradevanti123",
-    ])(`"%s" should be domain-name`, (s) => {
+    ])(`should be ok for "%s"`, (s) => {
       expect(isDomainName(s)).toBeTruthy();
     });
 
@@ -27,7 +27,7 @@ describe("domain-name", () => {
       "com.-unity",
       // No trailing hyphens
       "com.unity-",
-    ])(`"%s" should not be domain-name`, (s) => {
+    ])(`should not be ok for "%s"`, (s) => {
       expect(isDomainName(s)).toBeFalsy();
     });
   });

--- a/test/editor-version.test.ts
+++ b/test/editor-version.test.ts
@@ -7,12 +7,12 @@ import assert from "assert";
 
 describe("editor-version", () => {
   describe("parseEditorVersion", () => {
-    it("test x.y", () => {
+    it("should parse x.y", () => {
       const version = tryParseEditorVersion("2019.2");
       assert(version !== null);
       expect(version).toEqual({ major: 2019, minor: 2 });
     });
-    it("test x.y.z", () => {
+    it("should parse x.y.z", () => {
       const version = tryParseEditorVersion("2019.2.1");
       assert(version !== null);
       expect(version).toEqual({
@@ -21,7 +21,7 @@ describe("editor-version", () => {
         patch: 1,
       });
     });
-    it("test x.y.zan", () => {
+    it("should parse x.y.zan", () => {
       const version = tryParseEditorVersion("2019.2.1a5");
       assert(version !== null);
       expect(version).toEqual({
@@ -32,7 +32,7 @@ describe("editor-version", () => {
         build: 5,
       });
     });
-    it("test x.y.zbn", () => {
+    it("should parse x.y.zbn", () => {
       const version = tryParseEditorVersion("2019.2.1b5");
       assert(version !== null);
       expect(version).toEqual({
@@ -43,7 +43,7 @@ describe("editor-version", () => {
         build: 5,
       });
     });
-    it("test x.y.zfn", () => {
+    it("should parse x.y.zfn", () => {
       const version = tryParseEditorVersion("2019.2.1f5");
       assert(version !== null);
       expect(version).toEqual({
@@ -54,7 +54,7 @@ describe("editor-version", () => {
         build: 5,
       });
     });
-    it("test x.y.zcn", () => {
+    it("should parse x.y.zcn", () => {
       const version = tryParseEditorVersion("2019.2.1f1c5");
       assert(version !== null);
       expect(version).toEqual({
@@ -67,7 +67,7 @@ describe("editor-version", () => {
         locBuild: 5,
       });
     });
-    it("test invalid version", () => {
+    it("should not parse invalid version", () => {
       expect(tryParseEditorVersion("2019") === null).toBeTruthy();
     });
   });
@@ -78,7 +78,7 @@ describe("editor-version", () => {
       ["2019.1.1", "2019.1.1"],
       ["2019.1.1f1", "2019.1.1f1"],
       ["2019.1.1f1c1", "2019.1.1f1c1"],
-    ])(`%s == %s`, function (a, b) {
+    ])(`should be equal %s and %s`, function (a, b) {
       expect(
         compareEditorVersion(
           tryParseEditorVersion(a)!,
@@ -90,7 +90,7 @@ describe("editor-version", () => {
     it.each([
       ["2019.2", "2019.1"],
       ["2020.1", "2019.1"],
-    ])(`%s > %s`, function (a, b) {
+    ])(`should be greater for %s and %s`, function (a, b) {
       expect(
         compareEditorVersion(
           tryParseEditorVersion(a)!,
@@ -107,7 +107,7 @@ describe("editor-version", () => {
       ["2019.1.1a1", "2020.1.1b1"],
       ["2019.1.1b1", "2020.1.1f1"],
       ["2019.1.1f1", "2020.1.1f1c1"],
-    ])(`%s < %s`, function (a, b) {
+    ])(`should be less for %s and %s`, function (a, b) {
       expect(
         compareEditorVersion(
           tryParseEditorVersion(a)!,

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -29,7 +29,7 @@ describe("registry-client", () => {
       stopMockRegistry();
     });
 
-    it("simple", async function () {
+    it("should get known packument", async function () {
       const packumentRemote = buildPackument(packageA);
       registerRemotePackument(packumentRemote);
 
@@ -41,7 +41,7 @@ describe("registry-client", () => {
       );
     });
 
-    it("404", async function () {
+    it("should fail for unknown packument", async function () {
       registerMissingPackument(packageA);
 
       const result = await client.tryFetchPackument(exampleRegistry, packageA)

--- a/test/package-id.test.ts
+++ b/test/package-id.test.ts
@@ -15,7 +15,7 @@ describe("package-id", () => {
       // Incomplete version
       "com.my-package@1",
       "com.my-package@1.2",
-    ])(`"%s" should not be package-id`, (s) => {
+    ])(`should not be ok for "%s"`, (s) => {
       expect(isPackageId(s)).toBeFalsy();
     });
   });

--- a/test/package-reference.test.ts
+++ b/test/package-reference.test.ts
@@ -11,7 +11,7 @@ describe("package-reference", () => {
       "com.abc.my-package@1.2.3",
       "com.abc.my-package@file://./my-package",
       "com.abc.my-package@latest",
-    ])(`"%s" should be package-reference`, (input) => {
+    ])(`should be ok for "%s"`, (input) => {
       expect(isPackageReference(input)).toBeTruthy();
     });
 

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,10 +1,9 @@
 import { tryGetLatestVersion } from "../src/types/packument";
-
 import { makeSemanticVersion } from "../src/types/semantic-version";
 
 describe("packument", () => {
   describe("tryGetLatestVersion", () => {
-    it("from dist-tags", async function () {
+    it("should get version from dist-tags", async function () {
       const version = tryGetLatestVersion({
         "dist-tags": { latest: makeSemanticVersion("1.0.0") },
       });

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -33,7 +33,7 @@ describe("project-manifest io", () => {
     await mockProject.restore();
   });
 
-  it("loadManifest", async () => {
+  it("should load valid manifest", async () => {
     const manifestResult = await tryLoadProjectManifest(mockProject.projectPath)
       .promise;
 
@@ -41,7 +41,7 @@ describe("project-manifest io", () => {
       expect(manifest).toEqual({ dependencies: {} })
     );
   });
-  it("no manifest file", async () => {
+  it("should fail when manifest is missing", async () => {
     const manifestResult = await tryLoadProjectManifest("/invalid-path")
       .promise;
 
@@ -49,7 +49,7 @@ describe("project-manifest io", () => {
       expect(error).toBeInstanceOf(NotFoundError)
     );
   });
-  it("wrong json content", async () => {
+  it("should fail when manifest has invalid json", async () => {
     const manifestPath = manifestPathFor(mockProject.projectPath);
     fse.writeFileSync(manifestPath, "invalid data");
 
@@ -59,7 +59,7 @@ describe("project-manifest io", () => {
       expect(error).toBeInstanceOf(FileParseError)
     );
   });
-  it("saveManifest", async () => {
+  it("should save manifest", async () => {
     let manifest = (
       await tryLoadProjectManifest(mockProject.projectPath).promise
     ).unwrap();
@@ -77,7 +77,7 @@ describe("project-manifest io", () => {
     ).unwrap();
     expect(manifest2).toEqual(manifest);
   });
-  it("manifest-path is correct", () => {
+  it("should determine correct manifest path", () => {
     const manifestPath = manifestPathFor("test-openupm-cli");
     const expected = path.join("test-openupm-cli", "Packages", "manifest.json");
     expect(manifestPath).toEqual(expected);


### PR DESCRIPTION
jest tests usually have the format of `it("should ...")`. Currently not all tests have this format.

Made a pass over all tests and standardize the labels.