### PR TITLE
tests: improve package-id tests

### DIFF
--- a/test/package-id.test.ts
+++ b/test/package-id.test.ts
@@ -2,20 +2,23 @@ import { isPackageId } from "../src/types/package-id";
 
 describe("package-id", () => {
   describe("validate", () => {
-    it("should be ok for valid string", () => {
-      const s = "com.my-package@1.2.3";
+    it("should be ok for name with semantic version", () => {
+      const s = "test@1.2.3";
       expect(isPackageId(s)).toBeTruthy();
     });
 
-    it.each([
-      "",
-      " ",
-      // Missing version
-      "com.my-package",
-      // Incomplete version
-      "com.my-package@1",
-      "com.my-package@1.2",
-    ])(`should not be ok for "%s"`, (s) => {
+    it("should not be ok for just name", () => {
+      const s = "test";
+      expect(isPackageId(s)).toBeFalsy();
+    });
+
+    it("should not be ok for invalid name", () => {
+      const s = "--test@1.2.3";
+      expect(isPackageId(s)).toBeFalsy();
+    });
+
+    it("should not be ok for invalid version", () => {
+      const s = "test@1.2.a";
       expect(isPackageId(s)).toBeFalsy();
     });
   });


### PR DESCRIPTION
Some of the tests for the `isPackageId` test basically tested the same scenario multiple times.

Improved these tests.