### PR TITLE
refactor: extract helper function

### DIFF
--- a/src/types/packument.ts
+++ b/src/types/packument.ts
@@ -100,3 +100,22 @@ export const tryGetLatestVersion = function (
   if (hasLatestDistTag(packument)) return packument["dist-tags"].latest;
   else if (packument.version) return packument.version;
 };
+
+/**
+ * Extracts the target editor-version, e.g. 2020.3.1, from a packument-version.
+ * @param packumentVersion The packument-version for which to get the editor.
+ * @returns The editor-version or null if the packument is compatible
+ * with all Unity version.
+ */
+export function targetEditorVersionFor(
+  packumentVersion: UnityPackumentVersion
+): string | null {
+  if (packumentVersion.unity === undefined) return null;
+
+  const majorMinor = packumentVersion.unity;
+  const release =
+    packumentVersion.unityRelease !== undefined
+      ? `.${packumentVersion.unityRelease}`
+      : "";
+  return `${majorMinor}${release}`;
+}

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,5 +1,11 @@
-import { tryGetLatestVersion } from "../src/types/packument";
+import {
+  targetEditorVersionFor,
+  tryGetLatestVersion,
+  UnityPackumentVersion,
+} from "../src/types/packument";
 import { makeSemanticVersion } from "../src/types/semantic-version";
+import fc from "fast-check";
+import { arbDomainName } from "./domain-name.arb";
 
 describe("packument", () => {
   describe("tryGetLatestVersion", () => {
@@ -8,6 +14,57 @@ describe("packument", () => {
         "dist-tags": { latest: makeSemanticVersion("1.0.0") },
       });
       expect(version).toEqual("1.0.0");
+    });
+  });
+
+  describe("determine editor-version", () => {
+    it("should get version without release", () => {
+      fc.assert(
+        fc.property(arbDomainName, (packumentName) => {
+          const expected = "2020.3";
+          const packumentVersion: UnityPackumentVersion = {
+            name: packumentName,
+            version: makeSemanticVersion("1.0.0"),
+            unity: expected,
+          };
+
+          const actual = targetEditorVersionFor(packumentVersion);
+
+          expect(actual).toEqual(expected);
+        })
+      );
+    });
+
+    it("should get version with release", () => {
+      fc.assert(
+        fc.property(arbDomainName, (packumentName) => {
+          const packumentVersion: UnityPackumentVersion = {
+            name: packumentName,
+            version: makeSemanticVersion("1.0.0"),
+            unity: "2020.3",
+            unityRelease: "1",
+          };
+
+          const actual = targetEditorVersionFor(packumentVersion);
+
+          expect(actual).toEqual("2020.3.1");
+        })
+      );
+    });
+
+    it("should be null for missing major.minor", () => {
+      fc.assert(
+        fc.property(arbDomainName, (packumentName) => {
+          const packumentVersion: UnityPackumentVersion = {
+            name: packumentName,
+            version: makeSemanticVersion("1.0.0"),
+          };
+
+          const actual = targetEditorVersionFor(packumentVersion);
+
+          expect(actual).toBeNull();
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Extract logic for getting the editor-version string, e.g. "2020.3.1f1", from a packument-version, into it's own function.