### PR TITLE
refactor: npm-client test

### DIFF
--- a/src/types/another-npm-registry-client.d.ts
+++ b/src/types/another-npm-registry-client.d.ts
@@ -1,49 +1,49 @@
 declare module "another-npm-registry-client" {
   import { type Response } from "request";
 
-  namespace RegClient {
-    type NpmAuth =
-      | {
-          username: string;
-          password: string;
-          email: string;
-          alwaysAuth?: boolean;
-        }
-      | { token: string; alwaysAuth?: boolean };
+  type NpmAuth =
+    | {
+        username: string;
+        password: string;
+        email: string;
+        alwaysAuth?: boolean;
+      }
+    | { token: string; alwaysAuth?: boolean };
 
-    type AddUserParams = { auth: NpmAuth };
+  type AddUserParams = { auth: NpmAuth };
 
-    type GetParams = {
-      timeout?: number;
-      follow?: boolean;
-      staleOk?: boolean;
-      auth?: NpmAuth;
-      fullMetadata?: boolean;
-    };
+  type GetParams = {
+    timeout?: number;
+    follow?: boolean;
+    staleOk?: boolean;
+    auth?: NpmAuth;
+    fullMetadata?: boolean;
+  };
 
-    type AddUserResponse = { ok: true; token: string } | { ok: false };
+  type AddUserResponse = { ok: true; token: string } | { ok: false };
 
-    type ClientCallback<TData> = (
-      error: Error | null,
-      data: TData,
-      raw: string,
-      res: Response
-    ) => void;
+  type ClientCallback<TData> = (
+    error: Error | null,
+    data: TData,
+    raw: string,
+    res: Response
+  ) => void;
 
-    type Instance = {
-      get(
-        uri: string,
-        params: GetParams,
-        cb: ClientCallback<import("../domain/packument").UnityPackument>
-      ): void;
-      adduser(
-        uri: string,
-        params: AddUserParams,
-        cb: ClientCallback<AddUserResponse>
-      ): void;
-    };
-  }
+  type Instance = {
+    get(
+      uri: string,
+      params: GetParams,
+      cb: ClientCallback<import("../domain/packument").UnityPackument>
+    ): void;
+    adduser(
+      uri: string,
+      params: AddUserParams,
+      cb: ClientCallback<AddUserResponse>
+    ): void;
+  };
+}
 
-  const RegClient: new (...args: unknown[]) => RegClient.Instance;
+declare module "another-npm-registry-client" {
+  const RegClient: new (this: Instance, config?: { log: unknown }) => Instance;
   export = RegClient;
 }

--- a/test/npm-client.test.ts
+++ b/test/npm-client.test.ts
@@ -1,14 +1,13 @@
 import "assert";
-import {
-  exampleRegistryUrl,
-  registerMissingPackument,
-  registerRemotePackument,
-  startMockRegistry,
-  stopMockRegistry,
-} from "./mock-registry";
-import { buildPackument } from "./data-packument";
+import { exampleRegistryUrl } from "./mock-registry";
 import { makeDomainName } from "../src/domain/domain-name";
 import { makeNpmClient, Registry } from "../src/npm-client";
+import { UnityPackument } from "../src/domain/packument";
+import RegClient from "another-npm-registry-client";
+import { HttpErrorBase } from "npm-registry-fetch";
+import { buildPackument } from "./data-packument";
+
+jest.mock("another-npm-registry-client");
 
 const packageA = makeDomainName("package-a");
 
@@ -17,37 +16,64 @@ const exampleRegistry: Registry = {
   auth: null,
 };
 
-describe("registry-client", () => {
-  describe("fetchPackageInfo", () => {
-    const client = makeNpmClient();
+function mockRegClientGetResult(
+  error: HttpErrorBase | null,
+  packument: UnityPackument | null
+) {
+  jest.mocked(RegClient).mockImplementation(() => ({
+    adduser: () => undefined,
+    get: (_1, _2, cb) => {
+      cb(error, packument!, null!, null!);
+    },
+  }));
+}
 
-    beforeEach(function () {
-      startMockRegistry();
-    });
-
-    afterEach(function () {
-      stopMockRegistry();
-    });
-
-    it("should get known packument", async function () {
-      const packumentRemote = buildPackument(packageA);
-      registerRemotePackument(packumentRemote);
+describe("npm-client", () => {
+  describe("fetch packument", () => {
+    it("should get existing packument", async () => {
+      // TODO: Use prop test
+      const packument = buildPackument(packageA);
+      mockRegClientGetResult(null, packument);
+      const client = makeNpmClient();
 
       const result = await client.tryFetchPackument(exampleRegistry, packageA)
         .promise;
 
-      expect(result).toBeOk((packument) =>
-        expect(packument).toEqual(packumentRemote)
+      expect(result).toBeOk((actual) => expect(actual).toEqual(packument));
+    });
+
+    it("should not find unknown packument", async () => {
+      mockRegClientGetResult(
+        {
+          message: "not found",
+          name: "FakeError",
+          statusCode: 404,
+        } as HttpErrorBase,
+        null
       );
-    });
-
-    it("should fail for unknown packument", async function () {
-      registerMissingPackument(packageA);
+      const client = makeNpmClient();
 
       const result = await client.tryFetchPackument(exampleRegistry, packageA)
         .promise;
 
-      expect(result).toBeOk((packument) => expect(packument).toBeNull());
+      expect(result).toBeOk((actual) => expect(actual).toBeNull());
+    });
+
+    it("should fail for errors", async () => {
+      mockRegClientGetResult(
+        {
+          message: "Unauthorized",
+          name: "FakeError",
+          statusCode: 401,
+        } as HttpErrorBase,
+        null
+      );
+      const client = makeNpmClient();
+
+      const result = await client.tryFetchPackument(exampleRegistry, packageA)
+        .promise;
+
+      expect(result).toBeError();
     });
   });
 });


### PR DESCRIPTION
Mock the registry on a function level instead of redirecting network traffic. Also add test for errors.