### PR TITLE
refactor: extract npmrc-io

### DIFF
--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -1,0 +1,22 @@
+import { AsyncResult } from "ts-results-es";
+import { FileReadError, tryReadTextFromFile } from "./file-io";
+import { EOL } from "node:os";
+
+/**
+ * The content lines of a npmrc file.
+ */
+export type Npmrc = ReadonlyArray<string>;
+
+/**
+ * Error that might occur when loading a npmrc.
+ */
+export type NpmrcLoadError = FileReadError;
+
+/**
+ * Attempts to load an .npmrc. It will only load simple key-value pairs. That
+ * means no objects and no arrays.
+ * @param path The path to load from.
+ */
+export function tryLoadNpmrc(path: string): AsyncResult<Npmrc, NpmrcLoadError> {
+  return tryReadTextFromFile(path).map((content) => content.split(EOL));
+}

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -1,5 +1,10 @@
 import { AsyncResult } from "ts-results-es";
-import { FileReadError, tryReadTextFromFile } from "./file-io";
+import {
+  FileReadError,
+  FileWriteError,
+  tryReadTextFromFile,
+  tryWriteTextToFile,
+} from "./file-io";
 import { EOL } from "node:os";
 
 /**
@@ -13,10 +18,28 @@ export type Npmrc = ReadonlyArray<string>;
 export type NpmrcLoadError = FileReadError;
 
 /**
+ * Error that might occur when saving a npmrc.
+ */
+export type NpmrcSaveError = FileWriteError;
+
+/**
  * Attempts to load an .npmrc. It will only load simple key-value pairs. That
  * means no objects and no arrays.
  * @param path The path to load from.
  */
 export function tryLoadNpmrc(path: string): AsyncResult<Npmrc, NpmrcLoadError> {
   return tryReadTextFromFile(path).map((content) => content.split(EOL));
+}
+
+/**
+ * Attempts to save a npmrc. Overwrites the content of the file.
+ * @param path The path to the file.
+ * @param npmrc The new lines for the file.
+ */
+export function trySaveNpmrc(
+  path: string,
+  npmrc: Npmrc
+): AsyncResult<void, NpmrcSaveError> {
+  const content = npmrc.join(EOL);
+  return tryWriteTextToFile(path, content);
 }

--- a/test/cmd-login.test.ts
+++ b/test/cmd-login.test.ts
@@ -9,7 +9,7 @@ describe("cmd-login.ts", () => {
     it("should append token to empty content", async function () {
       expect(
         generateNpmrcLines(
-          "",
+          [],
           makeRegistryUrl("http://registry.npmjs.org"),
           "123-456-789"
         )
@@ -18,7 +18,7 @@ describe("cmd-login.ts", () => {
     it("should append token to exist contents", async function () {
       expect(
         generateNpmrcLines(
-          "registry=https://registry.npmjs.org/",
+          ["registry=https://registry.npmjs.org/"],
           makeRegistryUrl(" registry(http://registry.npmjs.org"),
           "123-456-789"
         )
@@ -30,7 +30,11 @@ describe("cmd-login.ts", () => {
     it("should replace token to exist contents", async function () {
       expect(
         generateNpmrcLines(
-          "registry=https://registry.npmjs.org/\n//127.0.0.1:4873/:_authToken=blar-blar-blar\n//registry.npmjs.org/:_authToken=blar-blar-blar",
+          [
+            "registry=https://registry.npmjs.org/",
+            "//127.0.0.1:4873/:_authToken=blar-blar-blar",
+            "//registry.npmjs.org/:_authToken=blar-blar-blar",
+          ],
           makeRegistryUrl("http://registry.npmjs.org"),
           "123-456-789"
         )
@@ -43,7 +47,7 @@ describe("cmd-login.ts", () => {
     it("should handle registry without trailing slash", async function () {
       expect(
         generateNpmrcLines(
-          "",
+          [],
           makeRegistryUrl("http://registry.npmjs.org"),
           "123-456-789"
         )
@@ -52,14 +56,14 @@ describe("cmd-login.ts", () => {
     it("should quote token if necessary", async function () {
       expect(
         generateNpmrcLines(
-          "",
+          [],
           makeRegistryUrl("http://registry.npmjs.org"),
           "=123-456-789="
         )
       ).toEqual(['//registry.npmjs.org/:_authToken="=123-456-789="']);
       expect(
         generateNpmrcLines(
-          "",
+          [],
           makeRegistryUrl("http://registry.npmjs.org"),
           "?123-456-789?"
         )

--- a/test/npmrc-io.test.ts
+++ b/test/npmrc-io.test.ts
@@ -1,0 +1,35 @@
+import { NotFoundError, tryReadTextFromFile } from "../src/io/file-io";
+import { AsyncResult, Err, Ok } from "ts-results-es";
+import { EOL } from "node:os";
+import { tryLoadNpmrc } from "../src/io/npmrc-io";
+
+jest.mock("../src/io/file-io");
+
+describe("npmrc-io", () => {
+  describe("load", () => {
+    it("should be ok for valid file", async () => {
+      const fileContent = `key1 = value1${EOL}key2 = "value2"`;
+      jest
+        .mocked(tryReadTextFromFile)
+        .mockReturnValue(new AsyncResult(Ok(fileContent)));
+
+      const result = await tryLoadNpmrc("/valid/path/.npmrc").promise;
+
+      expect(result).toBeOk((actual) =>
+        expect(actual).toEqual(["key1 = value1", 'key2 = "value2"'])
+      );
+    });
+
+    it("should fail for missing file", async () => {
+      const path = "/invalid/path/.npmrc";
+      const expected = new NotFoundError(path);
+      jest
+        .mocked(tryReadTextFromFile)
+        .mockReturnValue(new AsyncResult(Err(expected)));
+
+      const result = await tryLoadNpmrc(path).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+  });
+});


### PR DESCRIPTION
Extract logic for loading and saving npmrc to it's own module.