### PR TITLE
refactor: extract env utility

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -20,6 +20,7 @@ import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
 import { tryLoadNpmrc, trySaveNpmrc } from "./io/npmrc-io";
 import { setToken } from "./domain/npmrc";
+import { tryGetEnv } from "./utils/env-util";
 
 export type LoginError =
   | EnvParseError
@@ -139,9 +140,7 @@ const writeNpmToken = async function (registry: RegistryUrl, token: string) {
  * @throws {Error} Home-path could not be determined.
  */
 export const getNpmrcPath = function () {
-  const dirPath = process.env.USERPROFILE
-    ? process.env.USERPROFILE
-    : process.env.HOME;
-  if (dirPath === undefined) throw new Error("Could not determine home path");
+  const dirPath = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
+  if (dirPath === null) throw new Error("Could not determine home path");
   return path.join(dirPath, ".npmrc");
 };

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -10,6 +10,7 @@ import { IOError } from "../common-errors";
 import { AsyncResult, Result } from "ts-results-es";
 import { assertIsError } from "../utils/error-type-guards";
 import { tryReadTextFromFile, tryWriteTextToFile } from "./file-io";
+import { tryGetEnv } from "../utils/env-util";
 
 const configFileName = ".upmconfig.toml";
 
@@ -57,12 +58,13 @@ export const tryGetUpmConfigDir = (
           });
         }
       } else if (systemUser) {
-        if (!process.env.ALLUSERSPROFILE)
+        const profilePath = tryGetEnv("ALLUSERSPROFILE");
+        if (profilePath === null)
           throw new RequiredEnvMissingError("ALLUSERSPROFILE");
-        return path.join(process.env.ALLUSERSPROFILE, systemUserSubPath);
+        return path.join(profilePath, systemUserSubPath);
       } else {
-        const dirName = process.env.USERPROFILE ?? process.env.HOME;
-        if (dirName === undefined)
+        const dirName = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
+        if (dirName === null)
           throw new RequiredEnvMissingError("USERPROFILE", "HOME");
         return dirName;
       }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,7 @@
 import npmlog from "npmlog";
+import { tryGetEnv } from "./utils/env-util";
 
-if (process.env.NODE_ENV === "test") {
+if (tryGetEnv("NODE_ENV") === "test") {
   npmlog.stream = process.stdout;
   npmlog.disableColor();
 }

--- a/src/utils/env-util.ts
+++ b/src/utils/env-util.ts
@@ -1,0 +1,7 @@
+/**
+ * Attempts to get the value for an env key.
+ * @param key The key to search.
+ */
+export function tryGetEnv(key: string): string | null {
+  return process.env[key] ?? null;
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -18,6 +18,7 @@ import {
   tryLoadProjectVersion,
 } from "../io/project-version-io";
 import { NotFoundError } from "../io/file-io";
+import { tryGetEnv } from "./env-util";
 
 export type Env = Readonly<{
   cwd: string;
@@ -80,7 +81,7 @@ function determineLogLevel(options: CmdOptions): "verbose" | "notice" {
 }
 
 function determineUseColor(options: CmdOptions): boolean {
-  return options._global.color !== false && process.env.NODE_ENV !== "test";
+  return options._global.color !== false && tryGetEnv("NODE_ENV") !== "test";
 }
 
 function determineUseUpstream(options: CmdOptions): boolean {


### PR DESCRIPTION
Extract utility function for getting env variables. This allows for easier mocking.