### PR TITLE
refactor: use null return for npmrc load

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -18,7 +18,7 @@ import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
 import { tryGetNpmrcPath, tryLoadNpmrc, trySaveNpmrc } from "./io/npmrc-io";
-import { setToken } from "./domain/npmrc";
+import { emptyNpmrc, setToken } from "./domain/npmrc";
 
 export type LoginError =
   | EnvParseError
@@ -124,7 +124,7 @@ const writeNpmToken = async function (registry: RegistryUrl, token: string) {
   (
     await new AsyncResult(tryGetNpmrcPath()).andThen((configPath) =>
       tryLoadNpmrc(configPath)
-        .or(Ok([]))
+        .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
         .map((npmrc) => setToken(npmrc, registry, token))
         .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
         .map(() => log.notice("config", `saved to npm config: ${configPath}`))

--- a/test/npmrc-io.test.ts
+++ b/test/npmrc-io.test.ts
@@ -64,7 +64,7 @@ describe("npmrc-io", () => {
       );
     });
 
-    it("should fail for missing file", async () => {
+    it("should be null for missing file", async () => {
       const path = "/invalid/path/.npmrc";
       const expected = new NotFoundError(path);
       jest
@@ -73,7 +73,7 @@ describe("npmrc-io", () => {
 
       const result = await tryLoadNpmrc(path).promise;
 
-      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+      expect(result).toBeOk((actual) => expect(actual).toBeNull());
     });
   });
 


### PR DESCRIPTION
Currently the case where an npmrc does not exist ist expressed by an error-response. But there not being an npmrc is a pretty common situation, so instead it should be expressed as part of the ok-result. Refactor to return ok-null if the npmrc is not found.