### PR TITLE
refactor: use async-result type

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -119,7 +119,7 @@ const npmLogin = function (
  * Write npm token to .npmrc.
  * @throws {Error} An unhandled error occurred.
  */
-const writeNpmToken = async function (registry: RegistryUrl, token: string) {
+async function writeNpmToken(registry: RegistryUrl, token: string) {
   // read config
   (
     await new AsyncResult(tryGetNpmrcPath()).andThen((configPath) =>
@@ -130,4 +130,4 @@ const writeNpmToken = async function (registry: RegistryUrl, token: string) {
         .map(() => log.notice("config", `saved to npm config: ${configPath}`))
     ).promise
   ).unwrap();
-};
+}

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -79,7 +79,7 @@ export const login = async function (
     const token = result.value;
 
     // write npm token
-    await writeNpmToken(loginRegistry, token);
+    await writeNpmToken(loginRegistry, token).promise;
     const storeResult = await tryStoreUpmAuth(configDir, loginRegistry, {
       email,
       alwaysAuth,
@@ -117,17 +117,16 @@ const npmLogin = function (
 
 /**
  * Write npm token to .npmrc.
- * @throws {Error} An unhandled error occurred.
  */
-async function writeNpmToken(registry: RegistryUrl, token: string) {
+function writeNpmToken(registry: RegistryUrl, token: string) {
   // read config
-  (
-    await new AsyncResult(tryGetNpmrcPath()).andThen((configPath) =>
+  return tryGetNpmrcPath()
+    .toAsyncResult()
+    .andThen((configPath) =>
       tryLoadNpmrc(configPath)
         .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
         .map((npmrc) => setToken(npmrc, registry, token))
         .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
         .map(() => log.notice("config", `saved to npm config: ${configPath}`))
-    ).promise
-  ).unwrap();
+    );
 }


### PR DESCRIPTION
Use the `AsyncResult` type for a function return instead of `Promise<Result>`.