### PR TITLE
refactor: extract npm-token update service

### DIFF
--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -17,7 +17,7 @@ import {
 import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
-import { writeNpmToken } from "./io/npmrc-io";
+import { tryUpdateAuthToken } from "./io/npmrc-io";
 
 export type LoginError =
   | EnvParseError
@@ -78,7 +78,7 @@ export const login = async function (
     const token = result.value;
 
     // write npm token
-    await writeNpmToken(loginRegistry, token).promise;
+    await tryUpdateAuthToken(loginRegistry, token).promise;
     const storeResult = await tryStoreUpmAuth(configDir, loginRegistry, {
       email,
       alwaysAuth,

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -17,14 +17,16 @@ import {
 import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
-import { tryUpdateAuthToken, UpdateNpmAuthTokenError } from "./io/npmrc-io";
+import { NpmrcLoadError, NpmrcSaveError } from "./io/npmrc-io";
+import { tryUpdateNpmrcToken } from "./services/npmrc-token-update-service";
 
 export type LoginError =
   | EnvParseError
   | GetUpmConfigDirError
   | IOError
   | AuthenticationError
-  | UpdateNpmAuthTokenError;
+  | NpmrcLoadError
+  | NpmrcSaveError;
 
 export type LoginOptions = CmdOptions<{
   username?: string;
@@ -79,7 +81,7 @@ export const login = async function (
     const token = result.value;
 
     // write npm token
-    const updateResult = await tryUpdateAuthToken(loginRegistry, token).promise;
+    const updateResult = await tryUpdateNpmrcToken(loginRegistry, token).promise;
     if (updateResult.isErr()) return updateResult;
     updateResult.map((configPath) =>
       log.notice("config", `saved to npm config: ${configPath}`)

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -17,7 +17,13 @@ import {
 import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
-import { tryGetNpmrcPath, tryLoadNpmrc, trySaveNpmrc } from "./io/npmrc-io";
+import {
+  NpmrcLoadError,
+  NpmrcSaveError,
+  tryGetNpmrcPath,
+  tryLoadNpmrc,
+  trySaveNpmrc,
+} from "./io/npmrc-io";
 import { emptyNpmrc, setToken } from "./domain/npmrc";
 
 export type LoginError =
@@ -118,7 +124,10 @@ const npmLogin = function (
 /**
  * Write npm token to .npmrc.
  */
-function writeNpmToken(registry: RegistryUrl, token: string) {
+function writeNpmToken(
+  registry: RegistryUrl,
+  token: string
+): AsyncResult<void, NpmrcLoadError | NpmrcSaveError> {
   // read config
   return tryGetNpmrcPath()
     .toAsyncResult()

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -78,7 +78,9 @@ export const login = async function (
     const token = result.value;
 
     // write npm token
-    await tryUpdateAuthToken(loginRegistry, token).promise;
+    await tryUpdateAuthToken(loginRegistry, token).map((configPath) =>
+      log.notice("config", `saved to npm config: ${configPath}`)
+    ).promise;
     const storeResult = await tryStoreUpmAuth(configDir, loginRegistry, {
       email,
       alwaysAuth,

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -18,7 +18,7 @@ import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
 import { NpmrcLoadError, NpmrcSaveError } from "./io/npmrc-io";
-import { tryUpdateNpmrcToken } from "./services/npmrc-token-update-service";
+import { tryUpdateUserNpmrcToken } from "./services/npmrc-token-update-service";
 
 export type LoginError =
   | EnvParseError
@@ -81,7 +81,7 @@ export const login = async function (
     const token = result.value;
 
     // write npm token
-    const updateResult = await tryUpdateNpmrcToken(loginRegistry, token).promise;
+    const updateResult = await tryUpdateUserNpmrcToken(loginRegistry, token).promise;
     if (updateResult.isErr()) return updateResult;
     updateResult.map((configPath) =>
       log.notice("config", `saved to npm config: ${configPath}`)

--- a/src/cmd-login.ts
+++ b/src/cmd-login.ts
@@ -17,14 +17,7 @@ import {
 import { CmdOptions } from "./types/options";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { IOError } from "./common-errors";
-import {
-  NpmrcLoadError,
-  NpmrcSaveError,
-  tryGetNpmrcPath,
-  tryLoadNpmrc,
-  trySaveNpmrc,
-} from "./io/npmrc-io";
-import { emptyNpmrc, setToken } from "./domain/npmrc";
+import { writeNpmToken } from "./io/npmrc-io";
 
 export type LoginError =
   | EnvParseError
@@ -120,22 +113,3 @@ const npmLogin = function (
       return error;
     });
 };
-
-/**
- * Write npm token to .npmrc.
- */
-function writeNpmToken(
-  registry: RegistryUrl,
-  token: string
-): AsyncResult<void, NpmrcLoadError | NpmrcSaveError> {
-  // read config
-  return tryGetNpmrcPath()
-    .toAsyncResult()
-    .andThen((configPath) =>
-      tryLoadNpmrc(configPath)
-        .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
-        .map((npmrc) => setToken(npmrc, registry, token))
-        .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
-        .map(() => log.notice("config", `saved to npm config: ${configPath}`))
-    );
-}

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -12,7 +12,6 @@ import { RequiredEnvMissingError } from "./upm-config-io";
 import { tryGetEnv } from "../utils/env-util";
 import { IOError } from "../common-errors";
 import { RegistryUrl } from "../domain/registry-url";
-import log from "../logger";
 
 /**
  * Error that might occur when loading a npmrc.
@@ -64,11 +63,12 @@ export function trySaveNpmrc(
 
 /**
  * Attempts to update the npm-auth token inside the users npmrc file.
+ * @returns The path to which the config was saved.
  */
 export function tryUpdateAuthToken(
   registry: RegistryUrl,
   token: string
-): AsyncResult<void, NpmrcLoadError | NpmrcSaveError> {
+): AsyncResult<string, NpmrcLoadError | NpmrcSaveError> {
   // read config
   return tryGetNpmrcPath()
     .toAsyncResult()
@@ -77,6 +77,6 @@ export function tryUpdateAuthToken(
         .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
         .map((npmrc) => setToken(npmrc, registry, token))
         .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
-        .map(() => log.notice("config", `saved to npm config: ${configPath}`))
+        .map(() => configPath)
     );
 }

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -6,12 +6,11 @@ import {
   tryWriteTextToFile,
 } from "./file-io";
 import { EOL } from "node:os";
-import { emptyNpmrc, Npmrc, setToken } from "../domain/npmrc";
+import { Npmrc } from "../domain/npmrc";
 import path from "path";
 import { RequiredEnvMissingError } from "./upm-config-io";
 import { tryGetEnv } from "../utils/env-util";
 import { IOError } from "../common-errors";
-import { RegistryUrl } from "../domain/registry-url";
 
 /**
  * Error that might occur when loading a npmrc.
@@ -22,11 +21,6 @@ export type NpmrcLoadError = IOError;
  * Error that might occur when saving a npmrc.
  */
 export type NpmrcSaveError = FileWriteError;
-
-/**
- * Error that might occur when updating a token inside a npmrc.
- */
-export type UpdateNpmAuthTokenError = NpmrcLoadError | NpmrcSaveError;
 
 /**
  * Tries to get the npmrc path based on env.
@@ -64,24 +58,4 @@ export function trySaveNpmrc(
 ): AsyncResult<void, NpmrcSaveError> {
   const content = npmrc.join(EOL);
   return tryWriteTextToFile(path, content);
-}
-
-/**
- * Attempts to update the npm-auth token inside the users npmrc file.
- * @returns The path to which the config was saved.
- */
-export function tryUpdateAuthToken(
-  registry: RegistryUrl,
-  token: string
-): AsyncResult<string, UpdateNpmAuthTokenError> {
-  // read config
-  return tryGetNpmrcPath()
-    .toAsyncResult()
-    .andThen((configPath) =>
-      tryLoadNpmrc(configPath)
-        .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
-        .map((npmrc) => setToken(npmrc, registry, token))
-        .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
-        .map(() => configPath)
-    );
 }

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -24,6 +24,11 @@ export type NpmrcLoadError = IOError;
 export type NpmrcSaveError = FileWriteError;
 
 /**
+ * Error that might occur when updating a token inside a npmrc.
+ */
+export type UpdateNpmAuthTokenError = NpmrcLoadError | NpmrcSaveError;
+
+/**
  * Tries to get the npmrc path based on env.
  */
 export function tryGetNpmrcPath(): Result<string, RequiredEnvMissingError> {
@@ -68,7 +73,7 @@ export function trySaveNpmrc(
 export function tryUpdateAuthToken(
   registry: RegistryUrl,
   token: string
-): AsyncResult<string, NpmrcLoadError | NpmrcSaveError> {
+): AsyncResult<string, UpdateNpmAuthTokenError> {
   // read config
   return tryGetNpmrcPath()
     .toAsyncResult()

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -63,9 +63,9 @@ export function trySaveNpmrc(
 }
 
 /**
- * Write npm token to .npmrc.
+ * Attempts to update the npm-auth token inside the users npmrc file.
  */
-export function writeNpmToken(
+export function tryUpdateAuthToken(
   registry: RegistryUrl,
   token: string
 ): AsyncResult<void, NpmrcLoadError | NpmrcSaveError> {

--- a/src/services/npmrc-token-update-service.ts
+++ b/src/services/npmrc-token-update-service.ts
@@ -19,10 +19,10 @@ export type NpmrcAuthTokenUpdateError =
   | NpmrcSaveError;
 
 /**
- * Attempts to update the npm-auth token inside the users npmrc file.
+ * Attempts to update the user-wide npm-auth token inside the users npmrc file.
  * @returns The path to which the config was saved.
  */
-export function tryUpdateNpmrcToken(
+export function tryUpdateUserNpmrcToken(
   registry: RegistryUrl,
   token: string
 ): AsyncResult<string, NpmrcAuthTokenUpdateError> {

--- a/src/services/npmrc-token-update-service.ts
+++ b/src/services/npmrc-token-update-service.ts
@@ -1,0 +1,39 @@
+import { RegistryUrl } from "../domain/registry-url";
+import { AsyncResult } from "ts-results-es";
+import {
+  NpmrcLoadError,
+  NpmrcSaveError,
+  tryGetNpmrcPath,
+  tryLoadNpmrc,
+  trySaveNpmrc,
+} from "../io/npmrc-io";
+import { emptyNpmrc, setToken } from "../domain/npmrc";
+import { RequiredEnvMissingError } from "../io/upm-config-io";
+
+/**
+ * Error that might occur when updating an auth-token inside a npmrc file.
+ */
+export type NpmrcAuthTokenUpdateError =
+  | RequiredEnvMissingError
+  | NpmrcLoadError
+  | NpmrcSaveError;
+
+/**
+ * Attempts to update the npm-auth token inside the users npmrc file.
+ * @returns The path to which the config was saved.
+ */
+export function tryUpdateNpmrcToken(
+  registry: RegistryUrl,
+  token: string
+): AsyncResult<string, NpmrcAuthTokenUpdateError> {
+  // read config
+  return tryGetNpmrcPath()
+    .toAsyncResult()
+    .andThen((configPath) =>
+      tryLoadNpmrc(configPath)
+        .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
+        .map((npmrc) => setToken(npmrc, registry, token))
+        .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
+        .map(() => configPath)
+    );
+}

--- a/test/npmrc-token-update-service.test.ts
+++ b/test/npmrc-token-update-service.test.ts
@@ -1,0 +1,97 @@
+import {
+  tryGetNpmrcPath,
+  tryLoadNpmrc,
+  trySaveNpmrc,
+} from "../src/io/npmrc-io";
+import { AsyncResult, Err, Ok } from "ts-results-es";
+import { RequiredEnvMissingError } from "../src/io/upm-config-io";
+import { exampleRegistryUrl } from "./mock-registry";
+import { tryUpdateUserNpmrcToken } from "../src/services/npmrc-token-update-service";
+import { IOError } from "../src/common-errors";
+import { emptyNpmrc, setToken } from "../src/domain/npmrc";
+
+const exampleNpmrcPath = "/users/someuser/.npmrc";
+
+jest.mock("../src/io/npmrc-io");
+
+describe("npmrc-token-update service", () => {
+  describe("user-wide", () => {
+    beforeEach(() => {
+      // Mock defaults
+      jest.mocked(tryGetNpmrcPath).mockReturnValue(Ok(exampleNpmrcPath));
+      jest.mocked(tryLoadNpmrc).mockReturnValue(new AsyncResult(Ok(null)));
+      jest.mocked(trySaveNpmrc).mockReturnValue(new AsyncResult(Ok(undefined)));
+    });
+
+    it("should fail if path could not be determined", async () => {
+      const expected = new RequiredEnvMissingError();
+      jest.mocked(tryGetNpmrcPath).mockReturnValue(Err(expected));
+
+      const result = await tryUpdateUserNpmrcToken(
+        exampleRegistryUrl,
+        "some token"
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should fail if npmrc load failed", async () => {
+      const expected = new IOError();
+      jest.mocked(tryLoadNpmrc).mockReturnValue(new AsyncResult(Err(expected)));
+
+      const result = await tryUpdateUserNpmrcToken(
+        exampleRegistryUrl,
+        "some token"
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should fail if npmrc save failed", async () => {
+      const expected = new IOError();
+      jest.mocked(trySaveNpmrc).mockReturnValue(new AsyncResult(Err(expected)));
+
+      const result = await tryUpdateUserNpmrcToken(
+        exampleRegistryUrl,
+        "some token"
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should return npmrc path", async () => {
+      const result = await tryUpdateUserNpmrcToken(
+        exampleRegistryUrl,
+        "some token"
+      ).promise;
+
+      expect(result).toBeOk((actual) =>
+        expect(actual).toEqual(exampleNpmrcPath)
+      );
+    });
+
+    it("should create npmrc if missing", async () => {
+      const expected = setToken(emptyNpmrc, exampleRegistryUrl, "some token");
+      const saveSpy = jest.mocked(trySaveNpmrc);
+
+      await tryUpdateUserNpmrcToken(exampleRegistryUrl, "some token").promise;
+
+      expect(saveSpy).toHaveBeenCalledWith(exampleNpmrcPath, expected);
+    });
+
+    it("should update npmrc if already exists", async () => {
+      const initial = setToken(
+        emptyNpmrc,
+        exampleRegistryUrl,
+        "some old token"
+      );
+      const expected = setToken(initial, exampleRegistryUrl, "some token");
+      jest.mocked(tryLoadNpmrc).mockReturnValue(new AsyncResult(Ok(initial)));
+      const saveSpy = jest.mocked(trySaveNpmrc);
+
+      await tryUpdateUserNpmrcToken(exampleRegistryUrl, "some token").promise;
+
+      expect(saveSpy).toHaveBeenCalledWith(exampleNpmrcPath, expected);
+    });
+  });
+});


### PR DESCRIPTION
The logic to update npm-tokens inside a npmrc was part of the cmd-login module. It is my goal to only have cli relevant logic inside the cmd modules. So, I wanted to move this logic somewhere else.

Moved it to it's own service module. I want to have more service modules in the future, to encapsulate business logic that should not be inside cmd modules. Also added tests for it.