### PR TITLE
refactor: home-path logic

### DIFF
--- a/src/io/home.ts
+++ b/src/io/home.ts
@@ -1,0 +1,13 @@
+import { Err, Ok, Result } from "ts-results-es";
+import { RequiredEnvMissingError } from "./upm-config-io";
+import { tryGetEnv } from "../utils/env-util";
+
+/**
+ * Attempts to get the current users home-directory.
+ */
+export function tryGetHomePath(): Result<string, RequiredEnvMissingError> {
+  const homePath = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
+  if (homePath === null)
+    return Err(new RequiredEnvMissingError("USERPROFILE", "HOME"));
+  return Ok(homePath);
+}

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -11,6 +11,7 @@ import path from "path";
 import { RequiredEnvMissingError } from "./upm-config-io";
 import { tryGetEnv } from "../utils/env-util";
 import { IOError } from "../common-errors";
+import { tryGetHomePath } from "./home";
 
 /**
  * Error that might occur when loading a npmrc.
@@ -26,10 +27,7 @@ export type NpmrcSaveError = FileWriteError;
  * Tries to get the npmrc path based on env.
  */
 export function tryGetNpmrcPath(): Result<string, RequiredEnvMissingError> {
-  const dirPath = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
-  if (dirPath === null)
-    return Err(new RequiredEnvMissingError("USERPROFILE", "HOME"));
-  return Ok(path.join(dirPath, ".npmrc"));
+  return tryGetHomePath().map((homePath) => path.join(homePath, ".npmrc"));
 }
 
 /**

--- a/test/home.test.ts
+++ b/test/home.test.ts
@@ -1,0 +1,37 @@
+import path from "path";
+import { tryGetEnv } from "../src/utils/env-util";
+import { tryGetHomePath } from "../src/io/home";
+
+jest.mock("../src/utils/env-util");
+
+describe("home path", () => {
+  it("should be USERPROFILE if defined", () => {
+    const expected = path.join(path.sep, "user", "dir");
+    jest
+      .mocked(tryGetEnv)
+      .mockImplementation((key) => (key === "USERPROFILE" ? expected : null));
+
+    const result = tryGetHomePath();
+
+    expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
+  });
+
+  it("should be HOME if USERPROFILE is not defined", () => {
+    const expected = path.join(path.sep, "user", "dir");
+    jest
+      .mocked(tryGetEnv)
+      .mockImplementation((key) => (key === "HOME" ? expected : null));
+
+    const result = tryGetHomePath();
+
+    expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
+  });
+
+  it("should fail if HOME and USERPROFILE are not defined", () => {
+    jest.mocked(tryGetEnv).mockReturnValue(null);
+
+    const result = tryGetHomePath();
+
+    expect(result).toBeError();
+  });
+});

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -1,45 +1,31 @@
-import { runWithEnv } from "./mock-env";
 import {
   RequiredEnvMissingError,
   tryGetUpmConfigDir,
 } from "../src/io/upm-config-io";
+import { tryGetHomePath } from "../src/io/home";
+import { Err, Ok } from "ts-results-es";
+
+jest.mock("../src/io/home");
 
 describe("upm-config-io", () => {
   describe("get directory", () => {
     describe("no wsl and no system-user", () => {
-      it("should be USERPROFILE if defined", async function () {
-        const expected = "user/dir";
+      it("should be home path", async () => {
+        const expected = "/some/home/dir/";
+        jest.mocked(tryGetHomePath).mockReturnValue(Ok(expected));
 
-        const result = await runWithEnv(
-          {
-            USERPROFILE: expected,
-          },
-          () => tryGetUpmConfigDir(false, false).promise
-        );
+        const result = await tryGetUpmConfigDir(false, false).promise;
 
         expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
       });
-      it("should be HOME if defined and USERPROFILE is undefined", async function () {
-        const expected = "user/dir";
 
-        const result = await runWithEnv(
-          {
-            HOME: expected,
-          },
-          () => tryGetUpmConfigDir(false, false).promise
-        );
+      it("should fail if home could not be determined", async () => {
+        const expected = new RequiredEnvMissingError();
+        jest.mocked(tryGetHomePath).mockReturnValue(Err(expected));
 
-        expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
-      });
-      it("should fail if HOME and USERPROFILE and undefined", async function () {
-        const result = await runWithEnv(
-          {},
-          () => tryGetUpmConfigDir(false, false).promise
-        );
+        const result = await tryGetUpmConfigDir(false, false).promise;
 
-        expect(result).toBeError((error) =>
-          expect(error).toBeInstanceOf(RequiredEnvMissingError)
-        );
+        expect(result).toBeError((actual) => expect(actual).toEqual(expected));
       });
     });
   });


### PR DESCRIPTION
Both the code for determening npmrc and upmconfig paths basically use the same logic for finding the users home path. This leads to some code duplication.

Extract helper function for finding user-home path. Also adjust tests to deduplicate.