### PR TITLE
refactor: use result-type for return

### DIFF
--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -12,6 +12,7 @@ import { assertIsError } from "../utils/error-type-guards";
 import { tryReadTextFromFile, tryWriteTextToFile } from "./file-io";
 import { tryGetEnv } from "../utils/env-util";
 import { tryGetHomePath } from "./home";
+import { tryParseToml } from "../utils/data-parsing";
 
 const configFileName = ".upmconfig.toml";
 
@@ -87,7 +88,7 @@ export const tryLoadUpmConfig = async (
     //  immediately caught, we should make this function return a result
     //  and use mapping.
     const content = (await tryReadTextFromFile(configPath).promise).unwrap();
-    const config = TOML.parse(content);
+    const config = tryParseToml(content).unwrap();
 
     // NOTE: We assume correct format
     return config as UPMConfig;

--- a/src/utils/data-parsing.ts
+++ b/src/utils/data-parsing.ts
@@ -1,5 +1,7 @@
-import { AnyJson } from "@iarna/toml";
+import TOML, { AnyJson, JsonMap } from "@iarna/toml";
 import { Result } from "ts-results-es";
+
+export type TomlParseError = Error;
 
 /**
  * Attempts to parse a json-string.
@@ -7,4 +9,12 @@ import { Result } from "ts-results-es";
  */
 export function tryParseJson(json: string): Result<AnyJson, SyntaxError> {
   return Result.wrap(() => JSON.parse(json));
+}
+
+/**
+ * Attempts to parse a toml-string.
+ * @param toml The string to be parsed.
+ */
+export function tryParseToml(toml: string): Result<JsonMap, TomlParseError> {
+  return Result.wrap(() => TOML.parse(toml));
 }


### PR DESCRIPTION
Make a result-based toml parse function