### PR TITLE
refactor: editor-version env

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -10,6 +10,7 @@ import {
 import { EnvParseError, parseEnv } from "../utils/env";
 import {
   compareEditorVersion,
+  stringifyEditorVersion,
   tryParseEditorVersion,
 } from "../domain/editor-version";
 import { makeNpmClient } from "../npm-client";
@@ -156,10 +157,9 @@ export const add = async function (
       const targetEditorVersion = targetEditorVersionFor(packumentVersion);
       // verify editor version
       if (targetEditorVersion !== null) {
-        const editorVersionResult = tryParseEditorVersion(env.editorVersion);
         const requiredEditorVersionResult =
           tryParseEditorVersion(targetEditorVersion);
-        if (!editorVersionResult) {
+        if (typeof env.editorVersion === "string") {
           log.warn(
             "editor.version",
             `${env.editorVersion} is unknown, the editor version check is disabled`
@@ -178,16 +178,16 @@ export const add = async function (
           }
         }
         if (
-          editorVersionResult &&
+          typeof env.editorVersion !== "string" &&
           requiredEditorVersionResult &&
-          compareEditorVersion(
-            editorVersionResult,
-            requiredEditorVersionResult
-          ) < 0
+          compareEditorVersion(env.editorVersion, requiredEditorVersionResult) <
+            0
         ) {
           log.warn(
             "editor.version",
-            `requires ${targetEditorVersion} but found ${env.editorVersion}`
+            `requires ${targetEditorVersion} but found ${stringifyEditorVersion(
+              env.editorVersion
+            )}`
           );
           if (!options.force) {
             log.notice(

--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -156,47 +156,45 @@ export const add = async function (
       const targetEditorVersion = targetEditorVersionFor(packumentVersion);
       // verify editor version
       if (targetEditorVersion !== null) {
-        if (env.editorVersion) {
-          const editorVersionResult = tryParseEditorVersion(env.editorVersion);
-          const requiredEditorVersionResult =
-            tryParseEditorVersion(targetEditorVersion);
-          if (!editorVersionResult) {
-            log.warn(
-              "editor.version",
-              `${env.editorVersion} is unknown, the editor version check is disabled`
+        const editorVersionResult = tryParseEditorVersion(env.editorVersion);
+        const requiredEditorVersionResult =
+          tryParseEditorVersion(targetEditorVersion);
+        if (!editorVersionResult) {
+          log.warn(
+            "editor.version",
+            `${env.editorVersion} is unknown, the editor version check is disabled`
+          );
+        }
+        if (!requiredEditorVersionResult) {
+          log.warn("package.unity", `${targetEditorVersion} is not valid`);
+          if (!options.force) {
+            log.notice(
+              "suggest",
+              "contact the package author to fix the issue, or run with option -f to ignore the warning"
+            );
+            return Err(
+              new InvalidPackumentDataError("Editor-version not valid.")
             );
           }
-          if (!requiredEditorVersionResult) {
-            log.warn("package.unity", `${targetEditorVersion} is not valid`);
-            if (!options.force) {
-              log.notice(
-                "suggest",
-                "contact the package author to fix the issue, or run with option -f to ignore the warning"
-              );
-              return Err(
-                new InvalidPackumentDataError("Editor-version not valid.")
-              );
-            }
-          }
-          if (
-            editorVersionResult &&
-            requiredEditorVersionResult &&
-            compareEditorVersion(
-              editorVersionResult,
-              requiredEditorVersionResult
-            ) < 0
-          ) {
-            log.warn(
-              "editor.version",
-              `requires ${targetEditorVersion} but found ${env.editorVersion}`
+        }
+        if (
+          editorVersionResult &&
+          requiredEditorVersionResult &&
+          compareEditorVersion(
+            editorVersionResult,
+            requiredEditorVersionResult
+          ) < 0
+        ) {
+          log.warn(
+            "editor.version",
+            `requires ${targetEditorVersion} but found ${env.editorVersion}`
+          );
+          if (!options.force) {
+            log.notice(
+              "suggest",
+              `upgrade the editor to ${targetEditorVersion}, or run with option -f to ignore the warning`
             );
-            if (!options.force) {
-              log.notice(
-                "suggest",
-                `upgrade the editor to ${targetEditorVersion}, or run with option -f to ignore the warning`
-              );
-              return Err(new EditorIncompatibleError());
-            }
+            return Err(new EditorIncompatibleError());
           }
         }
       }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -27,7 +27,7 @@ export type Env = Readonly<{
   upstream: boolean;
   upstreamRegistry: Registry;
   registry: Registry;
-  editorVersion: string | null;
+  editorVersion: string;
 }>;
 
 export type EnvParseError =

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -19,6 +19,7 @@ import {
 } from "../io/project-version-io";
 import { NotFoundError } from "../io/file-io";
 import { tryGetEnv } from "./env-util";
+import { EditorVersion, tryParseEditorVersion } from "../domain/editor-version";
 
 export type Env = Readonly<{
   cwd: string;
@@ -27,7 +28,11 @@ export type Env = Readonly<{
   upstream: boolean;
   upstreamRegistry: Registry;
   registry: Registry;
-  editorVersion: string;
+  /**
+   * The current project's editor version. Either a parsed {@link EditorVersion}
+   * object if parsing was successful or the unparsed string.
+   */
+  editorVersion: EditorVersion | string;
 }>;
 
 export type EnvParseError =
@@ -151,7 +156,9 @@ export const parseEnv = async function (
       );
     return projectVersionLoadResult;
   }
-  const editorVersion = projectVersionLoadResult.value;
+  const editorVersion =
+    tryParseEditorVersion(projectVersionLoadResult.value) ??
+    projectVersionLoadResult.value;
 
   return Ok({
     cwd,

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -14,6 +14,7 @@ import { exampleRegistryUrl } from "./mock-registry";
 import fs from "fs";
 import { NotFoundError } from "../src/io/file-io";
 import { FileParseError, IOError } from "../src/common-errors";
+import { makeEditorVersion } from "../src/domain/editor-version";
 
 jest.mock("../src/io/project-version-io");
 jest.mock("../src/io/upm-config-io");
@@ -439,14 +440,27 @@ describe("env", () => {
     });
   });
 
-  describe("project-version", () => {
-    it("should use version from ProjectVersion.txt", async () => {
+  describe("editor-version", () => {
+    it("should be parsed object for valid versions", async () => {
       const result = await parseEnv({
         _global: {},
       });
 
       expect(result).toBeOk((env: Env) =>
-        expect(env.editorVersion).toEqual(testProjectVersion)
+        expect(env.editorVersion).toEqual(makeEditorVersion(2021, 3))
+      );
+    });
+
+    it("should be original string for invalid versions", async () => {
+      const expected = "Bad version";
+      jest.mocked(tryLoadProjectVersion).mockResolvedValue(Ok(expected));
+
+      const result = await parseEnv({
+        _global: {},
+      });
+
+      expect(result).toBeOk((env: Env) =>
+        expect(env.editorVersion).toEqual(expected)
       );
     });
 


### PR DESCRIPTION
This PR moves the logic for parsing the projects `EditorVersion` into `parseEnv`. That way it does not need to be repeated in cmds.

This also makes it easier to work on #225.