### PR TITLE
refactor: better typing for env editor-version

### DIFF
--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -12,7 +12,10 @@ import {
   PackageReference,
 } from "../domain/package-reference";
 import { removeScope } from "../domain/scoped-registry";
-import { mapScopedRegistry, removeDependency } from "../domain/project-manifest";
+import {
+  mapScopedRegistry,
+  removeDependency,
+} from "../domain/project-manifest";
 import { CmdOptions } from "./options";
 import { Err, Ok, Result } from "ts-results-es";
 

--- a/src/domain/editor-version.ts
+++ b/src/domain/editor-version.ts
@@ -60,11 +60,11 @@ function releaseValue(flag: ReleaseFlag): number {
   return 0;
 }
 
-export function isPatch(version: EditorVersion): version is PatchVersion {
+function isPatch(version: EditorVersion): version is PatchVersion {
   return "patch" in version;
 }
 
-function isRelease(version: EditorVersion): version is ReleaseVersion {
+export function isRelease(version: EditorVersion): version is ReleaseVersion {
   return isPatch(version) && "flag" in version;
 }
 

--- a/src/domain/editor-version.ts
+++ b/src/domain/editor-version.ts
@@ -13,7 +13,7 @@ type RegularVersion = {
   readonly minor: number;
 };
 
-type PatchVersion = RegularVersion & {
+export type PatchVersion = RegularVersion & {
   /**
    * A patch.
    */
@@ -60,7 +60,7 @@ function releaseValue(flag: ReleaseFlag): number {
   return 0;
 }
 
-function isPatch(version: EditorVersion): version is PatchVersion {
+export function isPatch(version: EditorVersion): version is PatchVersion {
   return "patch" in version;
 }
 

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -9,7 +9,6 @@ import { EOL } from "node:os";
 import { Npmrc } from "../domain/npmrc";
 import path from "path";
 import { RequiredEnvMissingError } from "./upm-config-io";
-import { tryGetEnv } from "../utils/env-util";
 import { IOError } from "../common-errors";
 import { tryGetHomePath } from "./special-paths";
 

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -2,21 +2,21 @@ import path from "path";
 import TOML from "@iarna/toml";
 import log from "../cli/logger";
 import isWsl from "is-wsl";
-import execute, {ChildProcessError} from "../utils/process";
-import {addAuth, UpmAuth, UPMConfig} from "../domain/upm-config";
-import {RegistryUrl} from "../domain/registry-url";
-import {CustomError} from "ts-custom-error";
-import {IOError} from "../common-errors";
-import {AsyncResult, Err, Ok} from "ts-results-es";
-import {assertIsError} from "../utils/error-type-guards";
+import execute, { ChildProcessError } from "../utils/process";
+import { addAuth, UpmAuth, UPMConfig } from "../domain/upm-config";
+import { RegistryUrl } from "../domain/registry-url";
+import { CustomError } from "ts-custom-error";
+import { IOError } from "../common-errors";
+import { AsyncResult, Err, Ok } from "ts-results-es";
+import { assertIsError } from "../utils/error-type-guards";
 import {
   NotFoundError,
   tryReadTextFromFile,
   tryWriteTextToFile,
 } from "./file-io";
-import {tryGetEnv} from "../utils/env-util";
-import {tryGetHomePath} from "./special-paths";
-import {TomlParseError, tryParseToml} from "../utils/data-parsing";
+import { tryGetEnv } from "../utils/env-util";
+import { tryGetHomePath } from "./special-paths";
+import { TomlParseError, tryParseToml } from "../utils/data-parsing";
 
 const configFileName = ".upmconfig.toml";
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -19,7 +19,12 @@ import {
 } from "../io/project-version-io";
 import { NotFoundError } from "../io/file-io";
 import { tryGetEnv } from "./env-util";
-import { EditorVersion, tryParseEditorVersion } from "../domain/editor-version";
+import {
+  EditorVersion,
+  isPatch,
+  PatchVersion,
+  tryParseEditorVersion,
+} from "../domain/editor-version";
 
 export type Env = Readonly<{
   cwd: string;
@@ -32,7 +37,7 @@ export type Env = Readonly<{
    * The current project's editor version. Either a parsed {@link EditorVersion}
    * object if parsing was successful or the unparsed string.
    */
-  editorVersion: EditorVersion | string;
+  editorVersion: PatchVersion | string;
 }>;
 
 export type EnvParseError =
@@ -156,9 +161,12 @@ export const parseEnv = async function (
       );
     return projectVersionLoadResult;
   }
+  const unparsedEditorVersion = projectVersionLoadResult.value;
+  const parsedEditorVersion = tryParseEditorVersion(unparsedEditorVersion);
   const editorVersion =
-    tryParseEditorVersion(projectVersionLoadResult.value) ??
-    projectVersionLoadResult.value;
+    parsedEditorVersion !== null && isPatch(parsedEditorVersion)
+      ? parsedEditorVersion
+      : unparsedEditorVersion;
 
   return Ok({
     cwd,

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -20,8 +20,8 @@ import {
 import { NotFoundError } from "../io/file-io";
 import { tryGetEnv } from "./env-util";
 import {
-  isPatch,
-  PatchVersion,
+  isRelease,
+  ReleaseVersion,
   tryParseEditorVersion,
 } from "../domain/editor-version";
 
@@ -36,7 +36,7 @@ export type Env = Readonly<{
    * The current project's editor version. Either a parsed {@link EditorVersion}
    * object if parsing was successful or the unparsed string.
    */
-  editorVersion: PatchVersion | string;
+  editorVersion: ReleaseVersion | string;
 }>;
 
 export type EnvParseError =
@@ -163,7 +163,7 @@ export const parseEnv = async function (
   const unparsedEditorVersion = projectVersionLoadResult.value;
   const parsedEditorVersion = tryParseEditorVersion(unparsedEditorVersion);
   const editorVersion =
-    parsedEditorVersion !== null && isPatch(parsedEditorVersion)
+    parsedEditorVersion !== null && isRelease(parsedEditorVersion)
       ? parsedEditorVersion
       : unparsedEditorVersion;
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -20,7 +20,6 @@ import {
 import { NotFoundError } from "../io/file-io";
 import { tryGetEnv } from "./env-util";
 import {
-  EditorVersion,
   isPatch,
   PatchVersion,
   tryParseEditorVersion,

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -441,7 +441,7 @@ describe("env", () => {
   });
 
   describe("editor-version", () => {
-    it("should be parsed object for valid versions", async () => {
+    it("should be parsed object for valid release versions", async () => {
       const result = await parseEnv({
         _global: {},
       });
@@ -451,7 +451,20 @@ describe("env", () => {
       );
     });
 
-    it("should be original string for invalid versions", async () => {
+    it("should be original string for non-release versions", async () => {
+      const expected = "2022.3";
+      jest.mocked(tryLoadProjectVersion).mockResolvedValue(Ok(expected));
+
+      const result = await parseEnv({
+        _global: {},
+      });
+
+      expect(result).toBeOk((env: Env) =>
+        expect(env.editorVersion).toEqual(expected)
+      );
+    });
+
+    it("should be original string for non-version string", async () => {
       const expected = "Bad version";
       jest.mocked(tryLoadProjectVersion).mockResolvedValue(Ok(expected));
 

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -35,7 +35,7 @@ const testUpmConfig: UPMConfig = {
   npmAuth: { [exampleRegistryUrl]: testUpmAuth },
 };
 
-const testProjectVersion = "2021.3";
+const testProjectVersion = "2021.3.1f1";
 
 describe("env", () => {
   beforeEach(() => {
@@ -447,7 +447,7 @@ describe("env", () => {
       });
 
       expect(result).toBeOk((env: Env) =>
-        expect(env.editorVersion).toEqual(makeEditorVersion(2021, 3))
+        expect(env.editorVersion).toEqual(makeEditorVersion(2021, 3, 1, "f", 1))
       );
     });
 


### PR DESCRIPTION
Env now enforces that the project editor-version must be a patch version (eg. 2022.1.2f1). From what I can see ProjectVersion.txt always only contains a patch-version anyway.