### PR TITLE
refactor: strong error types

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -44,20 +44,22 @@ import { logManifestLoadError, logManifestSaveError } from "../error-logging";
 import { targetEditorVersionFor } from "../domain/packument";
 
 export class InvalidPackumentDataError extends CustomError {
+  private readonly _class = "InvalidPackumentDataError";
   constructor(readonly issue: string) {
     super("A packument object was malformed.");
   }
 }
 
 export class EditorIncompatibleError extends CustomError {
+  private readonly _class = "EditorIncompatibleError";
   constructor() {
     super(
       "A packuments target editor-version was not compatible with the installed editor-version."
     );
   }
 }
-
 export class UnresolvedDependencyError extends CustomError {
+  private readonly _class = "UnresolvedDependencyError";
   constructor() {
     super("A packuments dependency could not be resolved.");
   }

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -5,6 +5,7 @@ import { EditorVersion } from "./domain/editor-version";
  * Generic IO error for when interacting with the file-system failed.
  */
 export class IOError extends CustomError {
+  private readonly _class = "CustomError";
   constructor(
     /**
      * The actual error that caused the failure.
@@ -64,6 +65,7 @@ export class FileParseError extends CustomError {
  * Error for when OpenUPM was used with an editor-version that is not supported.
  */
 export class EditorVersionNotSupportedError extends CustomError {
+  private readonly _class = "EditorVersionNotSupportedError";
   constructor(
     /**
      * The unsupported version.

--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -10,6 +10,7 @@ import path from "path";
  * Error for when a file or directory did not exist.
  */
 export class NotFoundError extends CustomError {
+  private readonly _class = "NotFoundError";
   constructor(
     /**
      * The path to the missing file.

--- a/src/io/special-paths.ts
+++ b/src/io/special-paths.ts
@@ -16,6 +16,7 @@ import { EditorVersionNotSupportedError } from "../common-errors";
  * Error for when a specific OS does not support a specific editor-version.
  */
 export class VersionNotSupportedOnOsError extends CustomError {
+  private readonly _class = "VersionNotSupportedOnOsError";
   constructor(
     /**
      * The version that is not supported.
@@ -34,6 +35,7 @@ export class VersionNotSupportedOnOsError extends CustomError {
  * Error for when Unity does not support an OS.
  */
 export class OSNotSupportedError extends CustomError {
+  private readonly _class = "OSNotSupportedError";
   constructor(
     /**
      * Name of the unsupported OS.

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -2,31 +2,33 @@ import path from "path";
 import TOML from "@iarna/toml";
 import log from "../cli/logger";
 import isWsl from "is-wsl";
-import execute, {ChildProcessError} from "../utils/process";
-import {addAuth, UpmAuth, UPMConfig} from "../domain/upm-config";
-import {RegistryUrl} from "../domain/registry-url";
-import {CustomError} from "ts-custom-error";
-import {IOError} from "../common-errors";
-import {AsyncResult, Err, Ok} from "ts-results-es";
-import {assertIsError} from "../utils/error-type-guards";
+import execute, { ChildProcessError } from "../utils/process";
+import { addAuth, UpmAuth, UPMConfig } from "../domain/upm-config";
+import { RegistryUrl } from "../domain/registry-url";
+import { CustomError } from "ts-custom-error";
+import { IOError } from "../common-errors";
+import { AsyncResult, Err, Ok } from "ts-results-es";
+import { assertIsError } from "../utils/error-type-guards";
 import {
   NotFoundError,
   tryReadTextFromFile,
   tryWriteTextToFile,
 } from "./file-io";
-import {tryGetEnv} from "../utils/env-util";
-import {tryGetHomePath} from "./special-paths";
-import {TomlParseError, tryParseToml} from "../utils/data-parsing";
+import { tryGetEnv } from "../utils/env-util";
+import { tryGetHomePath } from "./special-paths";
+import { TomlParseError, tryParseToml } from "../utils/data-parsing";
 
 const configFileName = ".upmconfig.toml";
 
 export class NoWslError extends CustomError {
+  private readonly _class = "NoWslError";
   constructor() {
     super("No WSL detected.");
   }
 }
 
 export class RequiredEnvMissingError extends CustomError {
+  private readonly _class = "RequiredEnvMissingError";
   constructor(...keyNames: string[]) {
     super(
       `Env was required to contain a value for one of the following keys, but all were missing: ${keyNames
@@ -122,7 +124,7 @@ export const tryStoreUpmAuth = function (
   configDir: string,
   registry: RegistryUrl,
   auth: UpmAuth
-): AsyncResult<void, IOError> {
+): AsyncResult<void, IOError | Error> {
   return tryLoadUpmConfig(configDir)
     .mapErr((error) => {
       assertIsError(error);

--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -14,6 +14,7 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
  * Error for when authentication failed.
  */
 export class AuthenticationError extends CustomError {
+  private readonly _class = "AuthenticationError";
   constructor(
     /**
      * The http-response code returned by the server.

--- a/src/packument-resolving.ts
+++ b/src/packument-resolving.ts
@@ -47,6 +47,7 @@ interface ResolvedPackument {
  * had no versions.
  */
 export class NoVersionsError extends CustomError {
+  private readonly _class = "NoVersionsError";
   constructor() {
     super("A packument contained no versions");
   }
@@ -57,6 +58,7 @@ export class NoVersionsError extends CustomError {
  * requested version did not exist.
  */
 export class VersionNotFoundError extends CustomError {
+  private readonly _class = "VersionNotFoundError";
   constructor(
     /**
      * The version that was requested.

--- a/src/services/builtin-packages.ts
+++ b/src/services/builtin-packages.ts
@@ -14,6 +14,7 @@ import { IOError } from "../common-errors";
  * Error for when an editor-version is not installed.
  */
 export class EditorNotInstalledError extends CustomError {
+  private readonly _class = "EditorNotInstalledError";
   constructor(
     /**
      * The version that is not installed.


### PR DESCRIPTION
Because of TS' structural typing some error types were actually considered the same type, especially the empty ones. This interfered with TS' ability to warn of unhandled errors.

To fix this a private unique field was added to all error types to better distinguish them.