### PR TITLE
refactor: strong child-process error

### DIFF
--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -4,6 +4,7 @@ import {
   GetUpmConfigDirError,
   tryGetUpmConfigDir,
   tryStoreUpmAuth,
+  UpmAuthStoreError,
 } from "../io/upm-config-io";
 import { EnvParseError, parseEnv } from "../utils/env";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "../domain/upm-config";
@@ -16,7 +17,6 @@ import {
 } from "./prompts";
 import { CmdOptions } from "./options";
 import { Ok, Result } from "ts-results-es";
-import { IOError } from "../common-errors";
 import { NpmrcLoadError, NpmrcSaveError } from "../io/npmrc-io";
 import { tryUpdateUserNpmrcToken } from "../services/npmrc-token-update-service";
 
@@ -26,10 +26,10 @@ import { tryUpdateUserNpmrcToken } from "../services/npmrc-token-update-service"
 export type LoginError =
   | EnvParseError
   | GetUpmConfigDirError
-  | IOError
   | AuthenticationError
   | NpmrcLoadError
-  | NpmrcSaveError;
+  | NpmrcSaveError
+  | UpmAuthStoreError;
 
 /**
  * Options for logging in a user. These come from the CLI.

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -91,6 +91,11 @@ export const tryLoadUpmConfig = (
 };
 
 /**
+ * Errors which may occur when saving a UPM-config file.
+ */
+export type UpmConfigSaveError = IOError;
+
+/**
  * Save the upm config.
  * @param config The config to save.
  * @param configDir The directory in which to save the config.
@@ -99,11 +104,16 @@ export const tryLoadUpmConfig = (
 export const trySaveUpmConfig = (
   config: UPMConfig,
   configDir: string
-): AsyncResult<string, IOError> => {
+): AsyncResult<string, UpmConfigSaveError> => {
   const configPath = path.join(configDir, configFileName);
   const content = TOML.stringify(config);
   return tryWriteTextToFile(configPath, content).map(() => configPath);
 };
+
+/**
+ * Errors which may occur when storing an {@link UpmAuth} to the file-system.
+ */
+export type UpmAuthStoreError = UpmConfigLoadError | IOError;
 
 /**
  * Stores authentication information in the projects upm config.
@@ -112,7 +122,7 @@ export const tryStoreUpmAuth = function (
   configDir: string,
   registry: RegistryUrl,
   auth: UpmAuth
-): AsyncResult<void, IOError | Error> {
+): AsyncResult<void, UpmAuthStoreError> {
   return tryLoadUpmConfig(configDir)
     .mapErr((error) => {
       assertIsError(error);

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -124,10 +124,6 @@ export const tryStoreUpmAuth = function (
   auth: UpmAuth
 ): AsyncResult<void, UpmAuthStoreError> {
   return tryLoadUpmConfig(configDir)
-    .mapErr((error) => {
-      assertIsError(error);
-      return error;
-    })
     .map((maybeConfig) => maybeConfig || {})
     .map((config) => addAuth(registry, auth, config))
     .andThen((config) => trySaveUpmConfig(config, configDir))

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,6 +4,7 @@ import {
   GetUpmConfigDirError,
   tryGetUpmConfigDir,
   tryLoadUpmConfig,
+  UpmConfigLoadError,
 } from "../io/upm-config-io";
 import path from "path";
 import fs from "fs";
@@ -38,6 +39,7 @@ export type Env = Readonly<{
 export type EnvParseError =
   | NotFoundError
   | GetUpmConfigDirError
+  | UpmConfigLoadError
   | ProjectVersionLoadError;
 
 function determineCwd(options: CmdOptions): Result<string, NotFoundError> {

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,10 +1,21 @@
 import childProcess from "child_process";
 import { AsyncResult, Err, Ok } from "ts-results-es";
+import { CustomError } from "ts-custom-error";
 
 /**
  * Error that might occur when running a child process.
  */
-export type ChildProcessError = childProcess.ExecException;
+export class ChildProcessError extends CustomError {
+  private readonly _class = "ChildProcessError";
+  constructor(
+    /**
+     * The internal error that caused this error.
+     */
+    readonly cause: childProcess.ExecException | NodeJS.ErrnoException
+  ) {
+    super();
+  }
+}
 
 /**
  * @param command A shell command to execute.
@@ -19,11 +30,11 @@ export default function execute(
     new Promise(function (resolve) {
       childProcess.exec(command, function (error, stdout, stderr) {
         if (error) {
-          resolve(Err(error));
+          resolve(Err(new ChildProcessError(error)));
           return;
         }
         if (stderr) {
-          resolve(Err(new Error(stderr)));
+          resolve(Err(new ChildProcessError(new Error(stderr))));
           return;
         }
         resolve(Ok(trim ? stdout.trim() : stdout));

--- a/test/wsl.test.ts
+++ b/test/wsl.test.ts
@@ -1,6 +1,7 @@
 import * as processModule from "../src/utils/process";
 import { tryGetWslPath } from "../src/io/wls";
 import { Err, Ok } from "ts-results-es";
+import { ChildProcessError } from "../src/utils/process";
 
 jest.mock("is-wsl", () => ({
   __esModule: true,
@@ -24,7 +25,9 @@ describe("wsl", () => {
       jest
         .spyOn(processModule, "default")
         .mockReturnValue(
-          Err({ name: "Error", message: "It failed" }).toAsyncResult()
+          Err(
+            new ChildProcessError({ name: "Error", message: "It failed" })
+          ).toAsyncResult()
         );
 
       const result = await tryGetWslPath("SOMEVAR").promise;


### PR DESCRIPTION
`ChildProcessError`was just an alias to `childProcess.ExecException` which intern was basically just `Error` with a few extra optional properties. This caused `ChildProcessError` to basically be equal to `Error` which prevented TS  from doing some type-checking magic as it was equal to every other error type in the project (because they are also all subtypes of `Error`).

To prevent this made `ChildProcessError` a proper class.