### PR TITLE
test: mock packument-resolve

### DIFF
--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -1,17 +1,12 @@
 import { deps, DepsOptions } from "../src/cli/cmd-deps";
-import {
-  exampleRegistryUrl,
-  registerMissingPackument,
-  registerRemotePackument,
-  registerRemoteUpstreamPackument,
-  startMockRegistry,
-  stopMockRegistry,
-} from "./mock-registry";
+import { exampleRegistryUrl } from "./mock-registry";
 import { buildPackument } from "./data-packument";
 import { makeDomainName } from "../src/domain/domain-name";
 import { makePackageReference } from "../src/domain/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import { spyOnLog } from "./log.mock";
+import { mockResolvedPackuments } from "./packument-resolving.mock";
+import { unityRegistryUrl } from "../src/domain/registry-url";
 
 describe("cmd-deps.ts", () => {
   const options: DepsOptions = {
@@ -45,17 +40,16 @@ describe("cmd-deps.ts", () => {
       mockProject = await setupUnityProject({});
     });
 
-    beforeEach(function () {
-      startMockRegistry();
-      registerRemotePackument(remotePackumentA);
-      registerRemotePackument(remotePackumentB);
-      registerMissingPackument("pkg-not-exist");
-      registerRemoteUpstreamPackument(remotePackumentUp);
+    beforeEach(() => {
+      mockResolvedPackuments(
+        [exampleRegistryUrl, remotePackumentA],
+        [exampleRegistryUrl, remotePackumentB],
+        [unityRegistryUrl, remotePackumentUp]
+      );
     });
 
     afterEach(async function () {
       await mockProject.reset();
-      stopMockRegistry();
     });
 
     afterAll(async function () {
@@ -125,6 +119,7 @@ describe("cmd-deps.ts", () => {
     });
     it("should print dependencies for upstream packuments", async function () {
       const depsResult = await deps(remotePackumentUp.name, options);
+
       expect(depsResult).toBeOk();
     });
   });

--- a/test/packument-resolving.mock.ts
+++ b/test/packument-resolving.mock.ts
@@ -1,0 +1,33 @@
+import * as resolveModule from "../src/packument-resolving";
+import { tryResolveFromPackument } from "../src/packument-resolving";
+import { Err } from "ts-results-es";
+import { PackumentNotFoundError } from "../src/common-errors";
+import { UnityPackument } from "../src/domain/packument";
+import { RegistryUrl } from "../src/domain/registry-url";
+
+type MockEntry = [RegistryUrl, UnityPackument];
+
+/**
+ * Mocks the results of {@link tryResolve}.
+ * @param entries The entries of the mocked registry. Each entry contains
+ * the url under which the packument is registered and the packument. All
+ * packuments not given in this list are assumed to not exist.
+ */
+export function mockResolvedPackuments(...entries: MockEntry[]) {
+  jest
+    .spyOn(resolveModule, "tryResolve")
+    .mockImplementation((_, name, requestedVersion, registry) => {
+      const matchingEntry = entries.find(
+        (entry) => entry[0] === registry.url && entry[1].name === name
+      );
+      if (matchingEntry === undefined)
+        return Err(new PackumentNotFoundError()).toAsyncResult();
+
+      const resolvedVersionResult = tryResolveFromPackument(
+        matchingEntry[1],
+        requestedVersion,
+        matchingEntry[0]
+      );
+      return resolvedVersionResult.toAsyncResult();
+    });
+}


### PR DESCRIPTION
This PR introduces mocking logic for the `packument-resolving/tryResove` function. This can be used instead of mocking network traffic with nock.

Replaced mocking logic in tests, where applicable.