### PR TITLE
feat: atomic package add

### DIFF
--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -468,5 +468,25 @@ describe("cmd-add.ts", () => {
       expect(addResult).toBeOk();
       expect(warnSpy).toHaveLogLike("package.unity", "2020 is not valid");
     });
+
+    it("should perform multiple adds atomically", async () => {
+      mockResolvedPackuments(
+        [exampleRegistryUrl, remotePackumentA],
+        [exampleRegistryUrl, remotePackumentB]
+      );
+
+      const addResult = await add(
+        // Second package will fail.
+        // Because of this the whole operation should fail.
+        [packageA, packageMissing, packageB],
+        upstreamOptions
+      );
+
+      expect(addResult).toBeError();
+      // Since not all packages could be added, the manifest should not be modified.
+      await mockProject.tryAssertManifest((manifest) =>
+        expect(manifest).toEqual(defaultManifest)
+      );
+    });
   });
 });


### PR DESCRIPTION
Currently, when adding multiple packages using the `add` command, each will be added separately. That means, that if packages A, B and C are added and B fails for any reason, A and C will still be added to the manifest.

With this change add operations are now atomic. In the same scenario as before, the manifest would not be modified, since one of the packages could not be added.

A side-effect of this change is that `add` now only returns one error, instead of an array of them, since the first encountered error cancels the operation.

See #223