### PR TITLE
test: improve project-manifest mock

### DIFF
--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -51,7 +51,7 @@ describe("cmd-remove.ts", () => {
       expect(noticeSpy).toHaveLogLike("manifest", "removed ");
       expect(noticeSpy).toHaveLogLike("", "open Unity");
     });
-    it("should remove packument with semantic version", async function () {
+    it("should fail to remove packument with semantic version", async function () {
       const warnSpy = spyOnLog("warn");
       const options = {
         _global: {

--- a/test/project-manifest-io.mock.ts
+++ b/test/project-manifest-io.mock.ts
@@ -1,0 +1,28 @@
+import * as projectManifestIoModule from "../src/io/project-manifest-io";
+import { UnityProjectManifest } from "../src/domain/project-manifest";
+import { Err, Ok } from "ts-results-es";
+import { NotFoundError } from "../src/io/file-io";
+import { manifestPathFor } from "../src/io/project-manifest-io";
+
+/**
+ * Mocks results for calls to {@link tryLoadProjectManifest}.
+ * @param manifest The manifest that should be returned. Null if there should
+ * be no manifest.
+ */
+export function mockProjectManifest(manifest: UnityProjectManifest | null) {
+  return jest
+    .spyOn(projectManifestIoModule, "tryLoadProjectManifest")
+    .mockImplementation((projectPath) => {
+      const manifestPath = manifestPathFor(projectPath);
+      return manifest === null
+        ? Err(new NotFoundError(manifestPath)).toAsyncResult()
+        : Ok(manifest).toAsyncResult();
+    });
+}
+
+/**
+ * Creates a spy for saved project-manifests.
+ */
+export function spyOnSavedManifest() {
+  return jest.spyOn(projectManifestIoModule, "trySaveProjectManifest");
+}

--- a/test/setup/unity-project.ts
+++ b/test/setup/unity-project.ts
@@ -5,10 +5,7 @@ import {
 import path from "path";
 import os from "os";
 import fse from "fs-extra";
-import {
-  tryLoadProjectManifest,
-  trySaveProjectManifest,
-} from "../../src/io/project-manifest-io";
+import { trySaveProjectManifest } from "../../src/io/project-manifest-io";
 import { mockEnv, MockEnvSession } from "../mock-env";
 import { UPMConfig } from "../../src/domain/upm-config";
 import { trySaveUpmConfig } from "../../src/io/upm-config-io";
@@ -22,14 +19,6 @@ export type MockUnityProject = {
    * The path to the projects root folder.
    */
   projectPath: string;
-  /**
-   * Runs an assertion function on the project manifest.
-   * @param assertFn An assertion function.
-   * @throws AssertionError if no manifest was found.
-   */
-  tryAssertManifest(
-    assertFn: (manifest: UnityProjectManifest) => void
-  ): Promise<void>;
 
   /**
    * Resets the mock-project to its original state.
@@ -128,16 +117,6 @@ export async function setupUnityProject(
     envSession?.unhook();
   }
 
-  async function tryAssertManifest(
-    assertFn: (manifest: UnityProjectManifest) => void
-  ) {
-    const manifestResult = await tryLoadProjectManifest(testProjectPath)
-      .promise;
-    expect(manifestResult).toBeOk((manifest) =>
-      assertFn(manifest as UnityProjectManifest)
-    );
-  }
-
   async function reset() {
     await restore();
     await setup();
@@ -146,7 +125,6 @@ export async function setupUnityProject(
   await setup();
   return {
     projectPath: testProjectPath,
-    tryAssertManifest,
     reset,
     restore,
   };


### PR DESCRIPTION
Currently testing operations that modify the project-manifest rely on mocking or actually using a file-system. This makes test-parallelization difficult as well as generally making it harder to write tests.

This change introduces a mocking mechanism for the project-manifest which does not rely on a file-system.