### PR TITLE
refactor: mock upm-config-io

### DIFF
--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -18,6 +18,7 @@ import {
   addDependency,
   emptyProjectManifest,
 } from "../src/domain/project-manifest";
+import { mockUpmConfig } from "./upm-config-io.mock";
 
 describe("cmd-add.ts", () => {
   const packageMissing = makeDomainName("pkg-not-exist");
@@ -130,6 +131,7 @@ describe("cmd-add.ts", () => {
 
     beforeEach(() => {
       mockProjectManifest(emptyProjectManifest);
+      mockUpmConfig(null);
     });
 
     beforeAll(async function () {

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -7,6 +7,7 @@ import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import { spyOnLog } from "./log.mock";
 import { mockResolvedPackuments } from "./packument-resolving.mock";
 import { unityRegistryUrl } from "../src/domain/registry-url";
+import {mockUpmConfig} from "./upm-config-io.mock";
 
 describe("cmd-deps.ts", () => {
   const options: DepsOptions = {
@@ -46,6 +47,7 @@ describe("cmd-deps.ts", () => {
         [exampleRegistryUrl, remotePackumentB],
         [unityRegistryUrl, remotePackumentUp]
       );
+      mockUpmConfig(null);
     });
 
     afterEach(async function () {

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -10,6 +10,7 @@ import {
   mockProjectManifest,
   spyOnSavedManifest,
 } from "./project-manifest-io.mock";
+import { mockUpmConfig } from "./upm-config-io.mock";
 
 const packageA = makeDomainName("com.example.package-a");
 const packageB = makeDomainName("com.example.package-b");
@@ -25,9 +26,13 @@ describe("cmd-remove.ts", () => {
 
     let mockProject: MockUnityProject = null!;
 
+    beforeEach(() => {
+      mockProjectManifest(defaultManifest);
+      mockUpmConfig(null);
+    });
+
     beforeAll(async function () {
       mockProject = await setupUnityProject({ manifest: defaultManifest });
-      mockProjectManifest(defaultManifest);
     });
 
     afterEach(async function () {

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -11,6 +11,7 @@ import { makeDomainName } from "../src/domain/domain-name";
 import { makeSemanticVersion } from "../src/domain/semantic-version";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import { spyOnLog } from "./log.mock";
+import { mockUpmConfig } from "./upm-config-io.mock";
 
 describe("cmd-search.ts", () => {
   let mockProject: MockUnityProject = null!;
@@ -21,6 +22,10 @@ describe("cmd-search.ts", () => {
       upstream: false,
     },
   };
+
+  beforeEach(() => {
+    mockUpmConfig(null);
+  });
 
   beforeAll(async function () {
     mockProject = await setupUnityProject({});

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -13,6 +13,7 @@ import { makeSemanticVersion } from "../src/domain/semantic-version";
 import { makePackageReference } from "../src/domain/package-reference";
 import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import { spyOnLog } from "./log.mock";
+import {mockUpmConfig} from "./upm-config-io.mock";
 
 const packageA = makeDomainName("com.example.package-a");
 const packageUp = makeDomainName("com.example.package-up");
@@ -106,6 +107,7 @@ describe("cmd-view.ts", () => {
     });
 
     beforeEach(function () {
+      mockUpmConfig(null);
       startMockRegistry();
       registerRemotePackument(remotePackumentA);
       registerMissingPackument(packageMissing);

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -4,17 +4,15 @@ import { Env, parseEnv } from "../src/utils/env";
 import log from "../src/cli/logger";
 import { tryLoadProjectVersion } from "../src/io/project-version-io";
 import { Err, Ok } from "ts-results-es";
-import {
-  tryGetUpmConfigDir,
-  tryLoadUpmConfig,
-} from "../src/io/upm-config-io";
+import { tryGetUpmConfigDir } from "../src/io/upm-config-io";
 import { testRootPath } from "./setup/unity-project";
 import { exampleRegistryUrl } from "./mock-registry";
 import fs from "fs";
 import { NotFoundError } from "../src/io/file-io";
 import { FileParseError, IOError } from "../src/common-errors";
 import { makeEditorVersion } from "../src/domain/editor-version";
-import {NoWslError} from "../src/io/wls";
+import { NoWslError } from "../src/io/wls";
+import { mockUpmConfig } from "./upm-config-io.mock";
 
 jest.mock("../src/io/project-version-io");
 jest.mock("../src/io/upm-config-io");
@@ -51,7 +49,7 @@ describe("env", () => {
     jest
       .mocked(tryGetUpmConfigDir)
       .mockReturnValue(Ok(testRootPath).toAsyncResult());
-    jest.mocked(tryLoadUpmConfig).mockReturnValue(Ok(null).toAsyncResult());
+    mockUpmConfig(null);
 
     // The project has a ProjectVersion.txt
     jest
@@ -314,11 +312,9 @@ describe("env", () => {
     });
 
     it("should have no auth if upm-config had no entry for the url", async () => {
-      jest.mocked(tryLoadUpmConfig).mockReturnValue(
-        Ok({
-          npmAuth: {},
-        }).toAsyncResult()
-      );
+      mockUpmConfig({
+        npmAuth: {},
+      });
 
       const result = await parseEnv({
         _global: {
@@ -332,9 +328,7 @@ describe("env", () => {
     });
 
     it("should have auth if upm-config had entry for the url", async () => {
-      jest
-        .mocked(tryLoadUpmConfig)
-        .mockReturnValue(Ok(testUpmConfig).toAsyncResult());
+      mockUpmConfig(testUpmConfig);
 
       const result = await parseEnv({
         _global: {

--- a/test/upm-config-io.mock.ts
+++ b/test/upm-config-io.mock.ts
@@ -1,0 +1,13 @@
+import { UPMConfig } from "../src/domain/upm-config";
+import * as upmConfigIoModule from "../src/io/upm-config-io";
+import { Ok } from "ts-results-es";
+
+/**
+ * Mocks return value for calls to {@link tryLoadUpmConfig}.
+ * @param config The upm-config that should be returned.
+ */
+export function mockUpmConfig(config: UPMConfig | null) {
+  jest
+    .spyOn(upmConfigIoModule, "tryLoadUpmConfig")
+    .mockReturnValue(Ok(config).toAsyncResult());
+}


### PR DESCRIPTION
Currently when mocking upm-config in tests we do this by using a file-system and actually creating the upm-config file.

This change introduces a mocking mechanism which does not involve a file-system.

