### PR TITLE
refactor: use async-result

### DIFF
--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -41,7 +41,7 @@ export function tryCreateProjectVersionTxt(
  */
 export function tryLoadProjectVersion(
   projectDirPath: string
-): Promise<Result<string, ProjectVersionLoadError>> {
+): AsyncResult<string, ProjectVersionLoadError> {
   const filePath = projectVersionTxtPathFor(projectDirPath);
 
   return tryReadTextFromFile(filePath)
@@ -63,5 +63,5 @@ export function tryLoadProjectVersion(
         return Err(new FileParseError(filePath, "Project-version"));
 
       return Ok(content.m_EditorVersion);
-    }).promise;
+    });
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -148,7 +148,7 @@ export const parseEnv = async function (
   const cwd = cwdResult.value;
 
   // editor version
-  const projectVersionLoadResult = await tryLoadProjectVersion(cwd);
+  const projectVersionLoadResult = await tryLoadProjectVersion(cwd).promise;
   if (projectVersionLoadResult.isErr()) {
     if (projectVersionLoadResult.error instanceof NotFoundError)
       log.warn(

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -54,7 +54,7 @@ describe("env", () => {
     // The project has a ProjectVersion.txt
     jest
       .mocked(tryLoadProjectVersion)
-      .mockResolvedValue(Ok(testProjectVersion));
+      .mockReturnValue(Ok(testProjectVersion).toAsyncResult());
   });
 
   describe("log-level", () => {
@@ -447,7 +447,9 @@ describe("env", () => {
 
     it("should be original string for non-release versions", async () => {
       const expected = "2022.3";
-      jest.mocked(tryLoadProjectVersion).mockResolvedValue(Ok(expected));
+      jest
+        .mocked(tryLoadProjectVersion)
+        .mockReturnValue(Ok(expected).toAsyncResult());
 
       const result = await parseEnv({
         _global: {},
@@ -460,7 +462,9 @@ describe("env", () => {
 
     it("should be original string for non-version string", async () => {
       const expected = "Bad version";
-      jest.mocked(tryLoadProjectVersion).mockResolvedValue(Ok(expected));
+      jest
+        .mocked(tryLoadProjectVersion)
+        .mockReturnValue(Ok(expected).toAsyncResult());
 
       const result = await parseEnv({
         _global: {},
@@ -473,7 +477,9 @@ describe("env", () => {
 
     it("should fail if ProjectVersion.txt could not be loaded", async () => {
       const expected = new IOError();
-      jest.mocked(tryLoadProjectVersion).mockResolvedValue(Err(expected));
+      jest
+        .mocked(tryLoadProjectVersion)
+        .mockReturnValue(Err(expected).toAsyncResult());
 
       const result = await parseEnv({
         _global: {},
@@ -485,8 +491,10 @@ describe("env", () => {
     it("should notify of missing ProjectVersion.txt", async () => {
       jest
         .mocked(tryLoadProjectVersion)
-        .mockResolvedValue(
-          Err(new NotFoundError("/some/path/ProjectVersion.txt"))
+        .mockReturnValue(
+          Err(
+            new NotFoundError("/some/path/ProjectVersion.txt")
+          ).toAsyncResult()
         );
       const logSpy = jest.spyOn(log, "warn");
 
@@ -503,13 +511,13 @@ describe("env", () => {
     it("should notify of parsing issue", async () => {
       jest
         .mocked(tryLoadProjectVersion)
-        .mockResolvedValue(
+        .mockReturnValue(
           Err(
             new FileParseError(
               "/some/path/ProjectVersion.txt",
               "ProjectVersion.txt"
             )
-          )
+          ).toAsyncResult()
         );
       const logSpy = jest.spyOn(log, "error");
 

--- a/test/project-version-io.test.ts
+++ b/test/project-version-io.test.ts
@@ -12,7 +12,7 @@ describe("project-version-io", () => {
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(Err(expected).toAsyncResult());
 
-      const result = await tryLoadProjectVersion("/some/bad/path");
+      const result = await tryLoadProjectVersion("/some/bad/path").promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
     });
@@ -22,7 +22,7 @@ describe("project-version-io", () => {
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(Ok("this is not valid yaml").toAsyncResult());
 
-      const result = await tryLoadProjectVersion("/some/path");
+      const result = await tryLoadProjectVersion("/some/path").promise;
 
       expect(result).toBeError((actual) =>
         expect(actual).toBeInstanceOf(FileParseError)
@@ -36,7 +36,7 @@ describe("project-version-io", () => {
           Ok("thisIsYaml: but not what we want").toAsyncResult()
         );
 
-      const result = await tryLoadProjectVersion("/some/path");
+      const result = await tryLoadProjectVersion("/some/path").promise;
 
       expect(result).toBeError((actual) =>
         expect(actual).toBeInstanceOf(FileParseError)
@@ -49,7 +49,7 @@ describe("project-version-io", () => {
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(Ok(`m_EditorVersion: ${expected}`).toAsyncResult());
 
-      const result = await tryLoadProjectVersion("/some/path");
+      const result = await tryLoadProjectVersion("/some/path").promise;
 
       expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
     });


### PR DESCRIPTION
The `tryLoadProjectVersion` was using a `Promise<Result>`.

Refactored to use `AsyncResult` like most of the project.