### PR TITLE
test: rename describe blocks

### DIFF
--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../src/domain/project-manifest";
 import { mockUpmConfig } from "./upm-config-io.mock";
 
-describe("cmd-add.ts", () => {
+describe("cmd-add", () => {
   const packageMissing = makeDomainName("pkg-not-exist");
   const packageA = makeDomainName("com.base.package-a");
   const packageB = makeDomainName("com.base.package-b");

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -9,7 +9,7 @@ import { mockResolvedPackuments } from "./packument-resolving.mock";
 import { unityRegistryUrl } from "../src/domain/registry-url";
 import {mockUpmConfig} from "./upm-config-io.mock";
 
-describe("cmd-deps.ts", () => {
+describe("cmd-deps", () => {
   const options: DepsOptions = {
     _global: {
       registry: exampleRegistryUrl,

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -16,7 +16,7 @@ const packageA = makeDomainName("com.example.package-a");
 const packageB = makeDomainName("com.example.package-b");
 const missingPackage = makeDomainName("pkg-not-exist");
 
-describe("cmd-remove.ts", () => {
+describe("cmd-remove", () => {
   describe("remove", () => {
     const defaultManifest = buildProjectManifest((manifest) =>
       manifest

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -13,7 +13,7 @@ import { MockUnityProject, setupUnityProject } from "./setup/unity-project";
 import { spyOnLog } from "./log.mock";
 import { mockUpmConfig } from "./upm-config-io.mock";
 
-describe("cmd-search.ts", () => {
+describe("cmd-search", () => {
   let mockProject: MockUnityProject = null!;
 
   const options: SearchOptions = {

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -19,7 +19,7 @@ const packageA = makeDomainName("com.example.package-a");
 const packageUp = makeDomainName("com.example.package-up");
 const packageMissing = makeDomainName("pkg-not-exist");
 
-describe("cmd-view.ts", () => {
+describe("cmd-view", () => {
   const options: ViewOptions = {
     _global: {
       color: false,


### PR DESCRIPTION
Remove `.ts` from describe block names. For consistency.