### PR TITLE
conf: parallelize tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "test:full": "cross-env NODE_ENV=test jest --runInBand",
+    "test:full": "cross-env NODE_ENV=test jest",
     "clean": "rimraf lib",
     "build": "npm run clean && tsc -p tsconfig.build.json",
     "build:watch": "tsc -w -p tsconfig.build.json",


### PR DESCRIPTION
Until now we had to run tests in sequence because they depended on the same base-dependencies (file-system, network).

Since now all tests are mocked to be completely independent, we can run them in parallel. This improves speed.