### PR TITLE
refactor: inject services

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -43,7 +43,7 @@ import { HttpErrorBase } from "npm-registry-fetch";
 import { CustomError } from "ts-custom-error";
 import { logManifestLoadError, logManifestSaveError } from "./error-logging";
 import { targetEditorVersionFor } from "../domain/packument";
-import { makePackumentFetchService } from "../services/fetch-packument";
+import { FetchPackumentService } from "../services/fetch-packument";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";
@@ -60,6 +60,7 @@ export class EditorIncompatibleError extends CustomError {
     );
   }
 }
+
 export class UnresolvedDependencyError extends CustomError {
   private readonly _class = "UnresolvedDependencyError";
   constructor() {
@@ -83,245 +84,255 @@ export type AddError =
   | ManifestSaveError;
 
 /**
- * @throws {Error} An unhandled error occurred.
+ * Cmd-handler for adding packages.
+ * @param pkgs One or multiple references to packages to add.
+ * @param options Options specifying how to add the packages.
  */
-export const add = async function (
+type AddCmd = (
   pkgs: PackageReference | PackageReference[],
   options: AddOptions
-): Promise<Result<void, AddError>> {
-  if (!Array.isArray(pkgs)) pkgs = [pkgs];
-  // parse env
-  const envResult = await parseEnv(options);
-  if (envResult.isErr()) return envResult;
-  const env = envResult.value;
+) => Promise<Result<void, AddError>>;
 
-  const fetchService = makePackumentFetchService();
+/**
+ * Makes a {@link AddCmd} function.
+ */
+export function makeAddCmd(fetchService: FetchPackumentService): AddCmd {
+  return async (pkgs, options) => {
+    if (!Array.isArray(pkgs)) pkgs = [pkgs];
+    // parse env
+    const envResult = await parseEnv(options);
+    if (envResult.isErr()) return envResult;
+    const env = envResult.value;
 
-  const tryAddToManifest = async function (
-    manifest: UnityProjectManifest,
-    pkg: PackageReference
-  ): Promise<Result<[UnityProjectManifest, boolean], AddError>> {
-    // is upstream package flag
-    let isUpstreamPackage = false;
-    // parse name
-    const [name, requestedVersion] = splitPackageReference(pkg);
+    const tryAddToManifest = async function (
+      manifest: UnityProjectManifest,
+      pkg: PackageReference
+    ): Promise<Result<[UnityProjectManifest, boolean], AddError>> {
+      // is upstream package flag
+      let isUpstreamPackage = false;
+      // parse name
+      const [name, requestedVersion] = splitPackageReference(pkg);
 
-    // packages that added to scope registry
-    const pkgsInScope = Array.of<DomainName>();
-    let versionToAdd = requestedVersion;
-    if (requestedVersion === undefined || !isPackageUrl(requestedVersion)) {
-      let resolveResult = await tryResolve(
-        fetchService,
-        name,
-        requestedVersion,
-        env.registry
-      ).promise;
-      if (resolveResult.isErr() && env.upstream) {
-        resolveResult = await tryResolve(
+      // packages that added to scope registry
+      const pkgsInScope = Array.of<DomainName>();
+      let versionToAdd = requestedVersion;
+      if (requestedVersion === undefined || !isPackageUrl(requestedVersion)) {
+        let resolveResult = await tryResolve(
           fetchService,
           name,
           requestedVersion,
-          env.upstreamRegistry
+          env.registry
         ).promise;
-        if (resolveResult.isOk()) isUpstreamPackage = true;
-      }
-
-      if (resolveResult.isErr()) {
-        if (resolveResult.error instanceof PackumentNotFoundError)
-          log.error("404", `package not found: ${name}`);
-        else if (resolveResult.error instanceof VersionNotFoundError) {
-          const versionList = [...resolveResult.error.availableVersions]
-            .reverse()
-            .join(", ");
-          log.warn(
-            "404",
-            `version ${resolveResult.error.requestedVersion} is not a valid choice of: ${versionList}`
-          );
+        if (resolveResult.isErr() && env.upstream) {
+          resolveResult = await tryResolve(
+            fetchService,
+            name,
+            requestedVersion,
+            env.upstreamRegistry
+          ).promise;
+          if (resolveResult.isOk()) isUpstreamPackage = true;
         }
-        return resolveResult;
-      }
 
-      const packumentVersion = resolveResult.value.packumentVersion;
-      versionToAdd = packumentVersion.version;
-
-      const targetEditorVersion = targetEditorVersionFor(packumentVersion);
-      // verify editor version
-      if (targetEditorVersion !== null) {
-        const requiredEditorVersionResult =
-          tryParseEditorVersion(targetEditorVersion);
-        if (typeof env.editorVersion === "string") {
-          log.warn(
-            "editor.version",
-            `${env.editorVersion} is unknown, the editor version check is disabled`
-          );
-        }
-        if (!requiredEditorVersionResult) {
-          log.warn("package.unity", `${targetEditorVersion} is not valid`);
-          if (!options.force) {
-            log.notice(
-              "suggest",
-              "contact the package author to fix the issue, or run with option -f to ignore the warning"
-            );
-            return Err(
-              new InvalidPackumentDataError("Editor-version not valid.")
+        if (resolveResult.isErr()) {
+          if (resolveResult.error instanceof PackumentNotFoundError)
+            log.error("404", `package not found: ${name}`);
+          else if (resolveResult.error instanceof VersionNotFoundError) {
+            const versionList = [...resolveResult.error.availableVersions]
+              .reverse()
+              .join(", ");
+            log.warn(
+              "404",
+              `version ${resolveResult.error.requestedVersion} is not a valid choice of: ${versionList}`
             );
           }
+          return resolveResult;
         }
-        if (
-          typeof env.editorVersion !== "string" &&
-          requiredEditorVersionResult &&
-          compareEditorVersion(env.editorVersion, requiredEditorVersionResult) <
-            0
-        ) {
-          log.warn(
-            "editor.version",
-            `requires ${targetEditorVersion} but found ${stringifyEditorVersion(
-              env.editorVersion
-            )}`
-          );
-          if (!options.force) {
-            log.notice(
-              "suggest",
-              `upgrade the editor to ${targetEditorVersion}, or run with option -f to ignore the warning`
+
+        const packumentVersion = resolveResult.value.packumentVersion;
+        versionToAdd = packumentVersion.version;
+
+        const targetEditorVersion = targetEditorVersionFor(packumentVersion);
+        // verify editor version
+        if (targetEditorVersion !== null) {
+          const requiredEditorVersionResult =
+            tryParseEditorVersion(targetEditorVersion);
+          if (typeof env.editorVersion === "string") {
+            log.warn(
+              "editor.version",
+              `${env.editorVersion} is unknown, the editor version check is disabled`
             );
-            return Err(new EditorIncompatibleError());
           }
-        }
-      }
-      // pkgsInScope
-      if (!isUpstreamPackage) {
-        log.verbose(
-          "dependency",
-          `fetch: ${makePackageReference(name, requestedVersion)}`
-        );
-        const [depsValid, depsInvalid] = await fetchPackageDependencies(
-          env.registry,
-          env.upstreamRegistry,
-          name,
-          requestedVersion,
-          true,
-          fetchService
-        );
-        // add depsValid to pkgsInScope.
-        depsValid
-          .filter((x) => !x.upstream && !x.internal)
-          .map((x) => x.name)
-          .forEach((name) => pkgsInScope.push(name));
-        // print suggestion for depsInvalid
-        let isAnyDependencyUnresolved = false;
-        depsInvalid.forEach((depObj) => {
-          if (
-            depObj.reason instanceof PackumentNotFoundError ||
-            depObj.reason instanceof VersionNotFoundError
-          ) {
-            // Not sure why it thinks the manifest can be null here.
-            const resolvedVersion = manifest.dependencies[depObj.name];
-            const wasResolved = Boolean(resolvedVersion);
-            if (!wasResolved) {
-              isAnyDependencyUnresolved = true;
-              if (depObj.reason instanceof VersionNotFoundError)
-                log.notice(
-                  "suggest",
-                  `to install ${makePackageReference(
-                    depObj.name,
-                    depObj.reason.requestedVersion
-                  )} or a replaceable version manually`
-                );
+          if (!requiredEditorVersionResult) {
+            log.warn("package.unity", `${targetEditorVersion} is not valid`);
+            if (!options.force) {
+              log.notice(
+                "suggest",
+                "contact the package author to fix the issue, or run with option -f to ignore the warning"
+              );
+              return Err(
+                new InvalidPackumentDataError("Editor-version not valid.")
+              );
             }
           }
-        });
-        if (isAnyDependencyUnresolved) {
-          if (!options.force) {
-            log.error(
-              "missing dependencies",
-              "please resolve the issue or run with option -f to ignore the warning"
+          if (
+            typeof env.editorVersion !== "string" &&
+            requiredEditorVersionResult &&
+            compareEditorVersion(
+              env.editorVersion,
+              requiredEditorVersionResult
+            ) < 0
+          ) {
+            log.warn(
+              "editor.version",
+              `requires ${targetEditorVersion} but found ${stringifyEditorVersion(
+                env.editorVersion
+              )}`
             );
-            return Err(new UnresolvedDependencyError());
+            if (!options.force) {
+              log.notice(
+                "suggest",
+                `upgrade the editor to ${targetEditorVersion}, or run with option -f to ignore the warning`
+              );
+              return Err(new EditorIncompatibleError());
+            }
           }
         }
-      } else pkgsInScope.push(name);
+        // pkgsInScope
+        if (!isUpstreamPackage) {
+          log.verbose(
+            "dependency",
+            `fetch: ${makePackageReference(name, requestedVersion)}`
+          );
+          const [depsValid, depsInvalid] = await fetchPackageDependencies(
+            env.registry,
+            env.upstreamRegistry,
+            name,
+            requestedVersion,
+            true,
+            fetchService
+          );
+          // add depsValid to pkgsInScope.
+          depsValid
+            .filter((x) => !x.upstream && !x.internal)
+            .map((x) => x.name)
+            .forEach((name) => pkgsInScope.push(name));
+          // print suggestion for depsInvalid
+          let isAnyDependencyUnresolved = false;
+          depsInvalid.forEach((depObj) => {
+            if (
+              depObj.reason instanceof PackumentNotFoundError ||
+              depObj.reason instanceof VersionNotFoundError
+            ) {
+              // Not sure why it thinks the manifest can be null here.
+              const resolvedVersion = manifest.dependencies[depObj.name];
+              const wasResolved = Boolean(resolvedVersion);
+              if (!wasResolved) {
+                isAnyDependencyUnresolved = true;
+                if (depObj.reason instanceof VersionNotFoundError)
+                  log.notice(
+                    "suggest",
+                    `to install ${makePackageReference(
+                      depObj.name,
+                      depObj.reason.requestedVersion
+                    )} or a replaceable version manually`
+                  );
+              }
+            }
+          });
+          if (isAnyDependencyUnresolved) {
+            if (!options.force) {
+              log.error(
+                "missing dependencies",
+                "please resolve the issue or run with option -f to ignore the warning"
+              );
+              return Err(new UnresolvedDependencyError());
+            }
+          }
+        } else pkgsInScope.push(name);
+      }
+      // add to dependencies
+      const oldVersion = manifest.dependencies[name];
+      // Whether a change was made that requires overwriting the manifest
+      let dirty = false;
+      // I am not sure why we need this assertion. I'm pretty sure
+      // code-logic ensures the correct type.
+      manifest = addDependency(
+        manifest,
+        name,
+        versionToAdd as PackageUrl | SemanticVersion
+      );
+      if (!oldVersion) {
+        // Log the added package
+        log.notice(
+          "manifest",
+          `added ${makePackageReference(name, versionToAdd)}`
+        );
+        dirty = true;
+      } else if (oldVersion !== versionToAdd) {
+        // Log the modified package version
+        log.notice(
+          "manifest",
+          `modified ${name} ${oldVersion} => ${versionToAdd}`
+        );
+        dirty = true;
+      } else {
+        // Log the existed package
+        log.notice(
+          "manifest",
+          `existed ${makePackageReference(name, versionToAdd)}`
+        );
+      }
+
+      if (!isUpstreamPackage && pkgsInScope.length > 0) {
+        manifest = mapScopedRegistry(manifest, env.registry.url, (initial) => {
+          let updated = initial ?? makeEmptyScopedRegistryFor(env.registry.url);
+
+          updated = pkgsInScope.reduce(addScope, updated!);
+          dirty =
+            !areArraysEqual(updated!.scopes, initial?.scopes ?? []) || dirty;
+
+          return updated;
+        });
+      }
+      if (options.test) manifest = addTestable(manifest, name);
+
+      return Ok([manifest, dirty]);
+    };
+
+    // load manifest
+    const loadResult = await tryLoadProjectManifest(env.cwd).promise;
+    if (loadResult.isErr()) {
+      logManifestLoadError(loadResult.error);
+      return loadResult;
     }
-    // add to dependencies
-    const oldVersion = manifest.dependencies[name];
-    // Whether a change was made that requires overwriting the manifest
+    let manifest = loadResult.value;
+
+    // add
     let dirty = false;
-    // I am not sure why we need this assertion. I'm pretty sure
-    // code-logic ensures the correct type.
-    manifest = addDependency(
-      manifest,
-      name,
-      versionToAdd as PackageUrl | SemanticVersion
-    );
-    if (!oldVersion) {
-      // Log the added package
-      log.notice(
-        "manifest",
-        `added ${makePackageReference(name, versionToAdd)}`
-      );
-      dirty = true;
-    } else if (oldVersion !== versionToAdd) {
-      // Log the modified package version
-      log.notice(
-        "manifest",
-        `modified ${name} ${oldVersion} => ${versionToAdd}`
-      );
-      dirty = true;
-    } else {
-      // Log the existed package
-      log.notice(
-        "manifest",
-        `existed ${makePackageReference(name, versionToAdd)}`
-      );
+    for (const pkg of pkgs) {
+      const result = await tryAddToManifest(manifest, pkg);
+      if (result.isErr()) return result;
+
+      const [newManifest, manifestChanged] = result.value;
+      if (manifestChanged) {
+        manifest = newManifest;
+        dirty = true;
+      }
     }
 
-    if (!isUpstreamPackage && pkgsInScope.length > 0) {
-      manifest = mapScopedRegistry(manifest, env.registry.url, (initial) => {
-        let updated = initial ?? makeEmptyScopedRegistryFor(env.registry.url);
+    // Save manifest
+    if (dirty) {
+      const saveResult = await trySaveProjectManifest(env.cwd, manifest)
+        .promise;
+      if (saveResult.isErr()) {
+        logManifestSaveError(saveResult.error);
+        return saveResult;
+      }
 
-        updated = pkgsInScope.reduce(addScope, updated!);
-        dirty =
-          !areArraysEqual(updated!.scopes, initial?.scopes ?? []) || dirty;
-
-        return updated;
-      });
+      // print manifest notice
+      log.notice("", "please open Unity project to apply changes");
     }
-    if (options.test) manifest = addTestable(manifest, name);
 
-    return Ok([manifest, dirty]);
+    return Ok(undefined);
   };
-
-  // load manifest
-  const loadResult = await tryLoadProjectManifest(env.cwd).promise;
-  if (loadResult.isErr()) {
-    logManifestLoadError(loadResult.error);
-    return loadResult;
-  }
-  let manifest = loadResult.value;
-
-  // add
-  let dirty = false;
-  for (const pkg of pkgs) {
-    const result = await tryAddToManifest(manifest, pkg);
-    if (result.isErr()) return result;
-
-    const [newManifest, manifestChanged] = result.value;
-    if (manifestChanged) {
-      manifest = newManifest;
-      dirty = true;
-    }
-  }
-
-  // Save manifest
-  if (dirty) {
-    const saveResult = await trySaveProjectManifest(env.cwd, manifest).promise;
-    if (saveResult.isErr()) {
-      logManifestSaveError(saveResult.error);
-      return saveResult;
-    }
-
-    // print manifest notice
-    log.notice("", "please open Unity project to apply changes");
-  }
-
-  return Ok(undefined);
-};
+}

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -35,71 +35,83 @@ export type RemoveError =
 
 export type RemoveOptions = CmdOptions;
 
-export const remove = async function (
+/**
+ * Cmd-handler for removing packages.
+ * @param pkgs One or multiple package-references to remove.
+ * @param options Command options.
+ */
+export type RemoveCmd = (
   pkgs: PackageReference[] | PackageReference,
   options: RemoveOptions
-): Promise<Result<void, RemoveError>> {
-  if (!Array.isArray(pkgs)) pkgs = [pkgs];
-  // parse env
-  const envResult = await parseEnv(options);
-  if (envResult.isErr()) return envResult;
-  const env = envResult.value;
+) => Promise<Result<void, RemoveError>>;
 
-  const tryRemoveFromManifest = async function (
-    manifest: UnityProjectManifest,
-    pkg: PackageReference
-  ): Promise<Result<UnityProjectManifest, RemoveError>> {
-    // parse name
-    if (hasVersion(pkg)) {
-      log.warn("", `please do not specify a version (Write only '${pkg}').`);
-      return Err(new PackageWithVersionError());
+/**
+ * Makes a {@link RemoveCmd} function.
+ */
+export function makeRemoveCmd(): RemoveCmd {
+  return async (pkgs, options) => {
+    if (!Array.isArray(pkgs)) pkgs = [pkgs];
+    // parse env
+    const envResult = await parseEnv(options);
+    if (envResult.isErr()) return envResult;
+    const env = envResult.value;
+
+    const tryRemoveFromManifest = async function (
+      manifest: UnityProjectManifest,
+      pkg: PackageReference
+    ): Promise<Result<UnityProjectManifest, RemoveError>> {
+      // parse name
+      if (hasVersion(pkg)) {
+        log.warn("", `please do not specify a version (Write only '${pkg}').`);
+        return Err(new PackageWithVersionError());
+      }
+
+      // not found array
+      const versionInManifest = manifest.dependencies[pkg];
+      if (versionInManifest === undefined) {
+        log.error("404", `package not found: ${pkg}`);
+        return Err(new PackumentNotFoundError());
+      }
+
+      manifest = removeDependency(manifest, pkg);
+
+      manifest = mapScopedRegistry(manifest, env.registry.url, (initial) => {
+        if (initial === null) return null;
+        return removeScope(initial, pkg);
+      });
+
+      log.notice(
+        "manifest",
+        `removed ${makePackageReference(pkg, versionInManifest)}`
+      );
+      return Ok(manifest);
+    };
+
+    // load manifest
+    const manifestResult = await tryLoadProjectManifest(env.cwd).promise;
+    if (manifestResult.isErr()) {
+      logManifestLoadError(manifestResult.error);
+      return manifestResult;
+    }
+    let manifest = manifestResult.value;
+
+    // remove
+    for (const pkg of pkgs) {
+      const result = await tryRemoveFromManifest(manifest, pkg);
+      if (result.isErr()) return result;
+      manifest = result.value;
     }
 
-    // not found array
-    const versionInManifest = manifest.dependencies[pkg];
-    if (versionInManifest === undefined) {
-      log.error("404", `package not found: ${pkg}`);
-      return Err(new PackumentNotFoundError());
+    // save manifest
+    const saveResult = await trySaveProjectManifest(env.cwd, manifest).promise;
+    if (saveResult.isErr()) {
+      logManifestSaveError(saveResult.error);
+      return saveResult;
     }
 
-    manifest = removeDependency(manifest, pkg);
+    // print manifest notice
+    log.notice("", "please open Unity project to apply changes");
 
-    manifest = mapScopedRegistry(manifest, env.registry.url, (initial) => {
-      if (initial === null) return null;
-      return removeScope(initial, pkg);
-    });
-
-    log.notice(
-      "manifest",
-      `removed ${makePackageReference(pkg, versionInManifest)}`
-    );
-    return Ok(manifest);
+    return Ok(undefined);
   };
-
-  // load manifest
-  const manifestResult = await tryLoadProjectManifest(env.cwd).promise;
-  if (manifestResult.isErr()) {
-    logManifestLoadError(manifestResult.error);
-    return manifestResult;
-  }
-  let manifest = manifestResult.value;
-
-  // remove
-  for (const pkg of pkgs) {
-    const result = await tryRemoveFromManifest(manifest, pkg);
-    if (result.isErr()) return result;
-    manifest = result.value;
-  }
-
-  // save manifest
-  const saveResult = await trySaveProjectManifest(env.cwd, manifest).promise;
-  if (saveResult.isErr()) {
-    logManifestSaveError(saveResult.error);
-    return saveResult;
-  }
-
-  // print manifest notice
-  log.notice("", "please open Unity project to apply changes");
-
-  return Ok(undefined);
-};
+}

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -7,10 +7,9 @@ import { hasVersion, PackageReference } from "../domain/package-reference";
 import { CmdOptions } from "./options";
 import { recordKeys } from "../utils/record-utils";
 import { Err, Ok, Result } from "ts-results-es";
-
-import { PackageWithVersionError } from "../common-errors";
-import { makePackumentFetchService } from "../services/fetch-packument";
+import { FetchPackumentService } from "../services/fetch-packument";
 import { tryResolve } from "../packument-resolving";
+import { PackageWithVersionError } from "../common-errors";
 
 export type ViewOptions = CmdOptions;
 
@@ -98,14 +97,12 @@ const printInfo = function (packument: UnityPackument) {
 /**
  * Makes a {@link ViewCmd} function.
  */
-export function makeViewCmd(): ViewCmd {
+export function makeViewCmd(fetchService: FetchPackumentService): ViewCmd {
   return async (pkg, options) => {
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) return envResult;
     const env = envResult.value;
-
-    const fetchService = makePackumentFetchService();
 
     // parse name
     if (hasVersion(pkg)) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,9 +1,8 @@
 import { createCommand } from "@commander-js/extra-typings";
 import pkginfo from "pkginfo";
 import updateNotifier from "update-notifier";
-import { remove } from "./cmd-remove";
-import { view } from "./cmd-view";
-import { deps } from "./cmd-deps";
+import { makeRemoveCmd } from "./cmd-remove";
+import { makeDepsCmd } from "./cmd-deps";
 import { makeLoginCmd } from "./cmd-login";
 import log from "./logger";
 import { eachValue, mustBeParsable, mustSatisfy } from "./cli-parsing";
@@ -18,6 +17,7 @@ import { makeAddUserService } from "../services/add-user";
 import { makeSearchService } from "../services/search";
 import pkg from "../../package.json";
 import { makeSearchCmd } from "./cmd-search";
+import { makeViewCmd } from "./cmd-view";
 
 // Composition root
 
@@ -29,6 +29,9 @@ const searchService = makeSearchService();
 const addCmd = makeAddCmd(fetchService);
 const loginCmd = makeLoginCmd(npmrcAuthService, addUserService);
 const searchCmd = makeSearchCmd(searchService);
+const depsCmd = makeDepsCmd();
+const removeCmd = makeRemoveCmd();
+const viewCmd = makeViewCmd();
 
 // Validators
 
@@ -116,7 +119,7 @@ program
   .description("remove package from manifest json")
   .action(async function (pkg, otherPkgs, options) {
     const pkgs = [pkg].concat(otherPkgs);
-    const removeResult = await remove(pkgs, makeCmdOptions(options));
+    const removeResult = await removeCmd(pkgs, makeCmdOptions(options));
     if (removeResult.isErr()) process.exit(1);
   });
 
@@ -136,7 +139,7 @@ program
   .aliases(["v", "info", "show"])
   .description("view package information")
   .action(async function (pkg, options) {
-    const result = await view(pkg, makeCmdOptions(options));
+    const result = await viewCmd(pkg, makeCmdOptions(options));
     if (result.isErr()) process.exit(1);
   });
 
@@ -151,7 +154,7 @@ openupm deps <pkg>
 openupm deps <pkg>@<version>`
   )
   .action(async function (pkg, options) {
-    const depsResult = await deps(pkg, makeCmdOptions(options));
+    const depsResult = await depsCmd(pkg, makeCmdOptions(options));
     if (depsResult.isErr()) process.exit(1);
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,6 @@ import { createCommand } from "@commander-js/extra-typings";
 import pkginfo from "pkginfo";
 import updateNotifier from "update-notifier";
 import { remove } from "./cmd-remove";
-import { search } from "./cmd-search";
 import { view } from "./cmd-view";
 import { deps } from "./cmd-deps";
 import { makeLoginCmd } from "./cmd-login";
@@ -16,18 +15,20 @@ import { makePackumentFetchService } from "../services/fetch-packument";
 import { makeAddCmd } from "./cmd-add";
 import { makeNpmrcAuthService } from "../services/npmrc-auth";
 import { makeAddUserService } from "../services/add-user";
-
-// update-notifier
+import { makeSearchService } from "../services/search";
 import pkg from "../../package.json";
+import { makeSearchCmd } from "./cmd-search";
 
 // Composition root
 
 const fetchService = makePackumentFetchService();
 const npmrcAuthService = makeNpmrcAuthService();
 const addUserService = makeAddUserService();
+const searchService = makeSearchService();
 
 const addCmd = makeAddCmd(fetchService);
 const loginCmd = makeLoginCmd(npmrcAuthService, addUserService);
+const searchCmd = makeSearchCmd(searchService);
 
 // Validators
 
@@ -45,6 +46,8 @@ const mustBeRegistryUrl = mustBeParsable(
   coerceRegistryUrl,
   (input) => `"${input}" is not a valid registry-url`
 );
+
+// update-notifier
 
 pkginfo(module);
 const notifier = updateNotifier({ pkg });
@@ -123,7 +126,7 @@ program
   .aliases(["s", "se", "find"])
   .description("Search package by keyword")
   .action(async function (keyword, options) {
-    const searchResult = await search(keyword, makeCmdOptions(options));
+    const searchResult = await searchCmd(keyword, makeCmdOptions(options));
     if (searchResult.isErr()) process.exit(1);
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,7 +31,7 @@ const loginCmd = makeLoginCmd(npmrcAuthService, addUserService);
 const searchCmd = makeSearchCmd(searchService);
 const depsCmd = makeDepsCmd();
 const removeCmd = makeRemoveCmd();
-const viewCmd = makeViewCmd();
+const viewCmd = makeViewCmd(fetchService);
 
 // Validators
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,23 +5,29 @@ import { remove } from "./cmd-remove";
 import { search } from "./cmd-search";
 import { view } from "./cmd-view";
 import { deps } from "./cmd-deps";
-import { login } from "./cmd-login";
+import { makeLoginCmd } from "./cmd-login";
 import log from "./logger";
 import { eachValue, mustBeParsable, mustSatisfy } from "./cli-parsing";
 import { isPackageReference } from "../domain/package-reference";
 import { isDomainName } from "../domain/domain-name";
 import { coerceRegistryUrl } from "../domain/registry-url";
 import { CmdOptions } from "./options";
+import { makePackumentFetchService } from "../services/fetch-packument";
+import { makeAddCmd } from "./cmd-add";
+import { makeNpmrcAuthService } from "../services/npmrc-auth";
+import { makeAddUserService } from "../services/add-user";
 
 // update-notifier
 import pkg from "../../package.json";
-import { makePackumentFetchService } from "../services/fetch-packument";
-import { makeAddCmd } from "./cmd-add";
 
 // Composition root
 
 const fetchService = makePackumentFetchService();
+const npmrcAuthService = makeNpmrcAuthService();
+const addUserService = makeAddUserService();
+
 const addCmd = makeAddCmd(fetchService);
+const loginCmd = makeLoginCmd(npmrcAuthService, addUserService);
 
 // Validators
 
@@ -159,7 +165,7 @@ program
   )
   .description("authenticate with a scoped registry")
   .action(async function (options) {
-    const loginResult = await login(makeCmdOptions(options));
+    const loginResult = await loginCmd(makeCmdOptions(options));
     if (loginResult.isErr()) process.exit(1);
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,21 +1,29 @@
 import { createCommand } from "@commander-js/extra-typings";
 import pkginfo from "pkginfo";
 import updateNotifier from "update-notifier";
-import { add } from "./cmd-add";
 import { remove } from "./cmd-remove";
 import { search } from "./cmd-search";
 import { view } from "./cmd-view";
 import { deps } from "./cmd-deps";
 import { login } from "./cmd-login";
 import log from "./logger";
-
-// update-notifier
-import pkg from "../../package.json";
 import { eachValue, mustBeParsable, mustSatisfy } from "./cli-parsing";
 import { isPackageReference } from "../domain/package-reference";
 import { isDomainName } from "../domain/domain-name";
 import { coerceRegistryUrl } from "../domain/registry-url";
 import { CmdOptions } from "./options";
+
+// update-notifier
+import pkg from "../../package.json";
+import { makePackumentFetchService } from "../services/fetch-packument";
+import { makeAddCmd } from "./cmd-add";
+
+// Composition root
+
+const fetchService = makePackumentFetchService();
+const addCmd = makeAddCmd(fetchService);
+
+// Validators
 
 const mustBePackageReference = mustSatisfy(
   isPackageReference,
@@ -83,7 +91,7 @@ openupm add <pkg>@<version> [otherPkgs...]`
   )
   .action(async function (pkg, otherPkgs, options) {
     const pkgs = [pkg].concat(otherPkgs);
-    const addResult = await add(pkgs, makeCmdOptions(options));
+    const addResult = await addCmd(pkgs, makeCmdOptions(options));
     if (addResult.isErr()) process.exit(1);
   });
 

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -1,4 +1,4 @@
-import { deps, DepsOptions } from "../src/cli/cmd-deps";
+import { DepsOptions, makeDepsCmd } from "../src/cli/cmd-deps";
 import { buildPackument } from "./data-packument";
 import { makeDomainName } from "../src/domain/domain-name";
 import { makePackageReference } from "../src/domain/package-reference";
@@ -8,6 +8,11 @@ import { unityRegistryUrl } from "../src/domain/registry-url";
 import { mockUpmConfig } from "./upm-config-io.mock";
 import { mockProjectVersion } from "./project-version-io.mock";
 import { exampleRegistryUrl } from "./data-registry";
+
+function makeDependencies() {
+  const depsCmd = makeDepsCmd();
+  return [depsCmd] as const;
+}
 
 describe("cmd-deps", () => {
   const options: DepsOptions = {
@@ -46,17 +51,19 @@ describe("cmd-deps", () => {
     });
 
     it("should print direct dependencies", async () => {
+      const [depsCmd] = makeDependencies();
       const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await deps(remotePackumentA.name, options);
+      const depsResult = await depsCmd(remotePackumentA.name, options);
 
       expect(depsResult).toBeOk();
       expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
     });
     it("should print all dependencies when requested", async () => {
+      const [depsCmd] = makeDependencies();
       const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await deps(remotePackumentA.name, {
+      const depsResult = await depsCmd(remotePackumentA.name, {
         ...options,
         deep: true,
       });
@@ -66,9 +73,10 @@ describe("cmd-deps", () => {
       expect(noticeSpy).toHaveLogLike("dependency", remotePackumentUp.name);
     });
     it("should print correct dependencies for latest tag", async () => {
+      const [depsCmd] = makeDependencies();
       const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await deps(
+      const depsResult = await depsCmd(
         makePackageReference(remotePackumentA.name, "latest"),
         options
       );
@@ -77,9 +85,10 @@ describe("cmd-deps", () => {
       expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
     });
     it("should print correct dependencies for semantic version", async () => {
+      const [depsCmd] = makeDependencies();
       const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await deps(
+      const depsResult = await depsCmd(
         makePackageReference(remotePackumentA.name, "1.0.0"),
         options
       );
@@ -88,9 +97,10 @@ describe("cmd-deps", () => {
       expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
     });
     it("should print no dependencies for unknown version", async () => {
+      const [depsCmd] = makeDependencies();
       const warnLog = spyOnLog("warn");
 
-      const depsResult = await deps(
+      const depsResult = await depsCmd(
         makePackageReference(remotePackumentA.name, "2.0.0"),
         options
       );
@@ -99,15 +109,20 @@ describe("cmd-deps", () => {
       expect(warnLog).toHaveLogLike("404", "is not a valid choice");
     });
     it("should print no dependencies for unknown packument", async () => {
+      const [depsCmd] = makeDependencies();
       const warnSpy = spyOnLog("warn");
 
-      const depsResult = await deps(makeDomainName("pkg-not-exist"), options);
+      const depsResult = await depsCmd(
+        makeDomainName("pkg-not-exist"),
+        options
+      );
 
       expect(depsResult).toBeOk();
       expect(warnSpy).toHaveLogLike("404", "not found");
     });
     it("should print dependencies for upstream packuments", async () => {
-      const depsResult = await deps(remotePackumentUp.name, options);
+      const [depsCmd] = makeDependencies();
+      const depsResult = await depsCmd(remotePackumentUp.name, options);
 
       expect(depsResult).toBeOk();
     });

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -1,4 +1,3 @@
-import { remove } from "../src/cli/cmd-remove";
 import { buildProjectManifest } from "./data-project-manifest";
 import { makeDomainName } from "../src/domain/domain-name";
 import { makeSemanticVersion } from "../src/domain/semantic-version";
@@ -11,10 +10,16 @@ import {
 import { mockUpmConfig } from "./upm-config-io.mock";
 import { mockProjectVersion } from "./project-version-io.mock";
 import { exampleRegistryUrl } from "./data-registry";
+import { makeRemoveCmd } from "../src/cli/cmd-remove";
 
 const packageA = makeDomainName("com.example.package-a");
 const packageB = makeDomainName("com.example.package-b");
 const missingPackage = makeDomainName("pkg-not-exist");
+
+function makeDependencies() {
+  const removeCmd = makeRemoveCmd();
+  return [removeCmd] as const;
+}
 
 describe("cmd-remove", () => {
   describe("remove", () => {
@@ -31,6 +36,7 @@ describe("cmd-remove", () => {
     });
 
     it("should remove packument without version", async () => {
+      const [removeCmd] = makeDependencies();
       const noticeSpy = spyOnLog("notice");
       const manifestSavedSpy = spyOnSavedManifest();
       const options = {
@@ -39,7 +45,7 @@ describe("cmd-remove", () => {
         },
       };
 
-      const removeResult = await remove(packageA, options);
+      const removeResult = await removeCmd(packageA, options);
 
       expect(removeResult).toBeOk();
       expect(manifestSavedSpy).toHaveBeenCalledWith(
@@ -52,6 +58,7 @@ describe("cmd-remove", () => {
       expect(noticeSpy).toHaveLogLike("", "open Unity");
     });
     it("should fail to remove packument with semantic version", async () => {
+      const [removeCmd] = makeDependencies();
       const warnSpy = spyOnLog("warn");
       const manifestSavedSpy = spyOnSavedManifest();
       const options = {
@@ -60,7 +67,7 @@ describe("cmd-remove", () => {
         },
       };
 
-      const removeResult = await remove(
+      const removeResult = await removeCmd(
         makePackageReference(packageA, makeSemanticVersion("1.0.0")),
         options
       );
@@ -70,6 +77,7 @@ describe("cmd-remove", () => {
       expect(warnSpy).toHaveLogLike("", "do not specify a version");
     });
     it("should fail for uninstalled packument", async () => {
+      const [removeCmd] = makeDependencies();
       const errorSpy = spyOnLog("error");
       const manifestSavedSpy = spyOnSavedManifest();
       const options = {
@@ -78,13 +86,14 @@ describe("cmd-remove", () => {
         },
       };
 
-      const removeResult = await remove(missingPackage, options);
+      const removeResult = await removeCmd(missingPackage, options);
 
       expect(removeResult).toBeError();
       expect(manifestSavedSpy).not.toHaveBeenCalled();
       expect(errorSpy).toHaveLogLike("404", "package not found");
     });
     it("should remove multiple packuments", async () => {
+      const [removeCmd] = makeDependencies();
       const noticeSpy = spyOnLog("notice");
       const manifestSavedSpy = spyOnSavedManifest();
       const options = {
@@ -93,7 +102,7 @@ describe("cmd-remove", () => {
         },
       };
 
-      const removeResult = await remove([packageA, packageB], options);
+      const removeResult = await removeCmd([packageA, packageB], options);
 
       expect(removeResult).toBeOk();
       expect(manifestSavedSpy).toHaveBeenCalledWith(

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -6,19 +6,86 @@ import { makePackageReference } from "../src/domain/package-reference";
 import { spyOnLog } from "./log.mock";
 import { mockUpmConfig } from "./upm-config-io.mock";
 import { mockProjectVersion } from "./project-version-io.mock";
-import { unityRegistryUrl } from "../src/domain/registry-url";
-import { mockFetchPackumentService } from "./fetch-packument.mock";
-import { makePackumentFetchService } from "../src/services/fetch-packument";
+import { FetchPackumentService } from "../src/services/fetch-packument";
 import { exampleRegistryUrl } from "./data-registry";
-
-jest.mock("../src/services/fetch-packument");
+import { mockResolvedPackuments } from "./packument-resolving.mock";
+import { unityRegistryUrl } from "../src/domain/registry-url";
 
 const packageA = makeDomainName("com.example.package-a");
 const packageUp = makeDomainName("com.example.package-up");
 const packageMissing = makeDomainName("pkg-not-exist");
+const remotePackumentA = buildPackument(packageA, (packument) =>
+  packument
+    .set("time", {
+      modified: "2019-11-28T18:51:58.123Z",
+      created: "2019-11-28T18:51:58.123Z",
+      [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
+    })
+    .set("_rev", "3-418f950115c32bd0")
+    .set("readme", "A demo package")
+    .addVersion("1.0.0", (version) =>
+      version
+        .set("displayName", "Package A")
+        .set("author", { name: "batman" })
+        .set("unity", "2018.4")
+        .set("description", "A demo package")
+        .set("keywords", [""])
+        .set("category", "Unity")
+        .set("gitHead", "5c141ecfac59c389090a07540f44c8ac5d07a729")
+        .set("readmeFilename", "README.md")
+        .set("_nodeVersion", "12.13.1")
+        .set("_npmVersion", "6.12.1")
+        .set("dist", {
+          integrity:
+            "sha512-MAh44bur7HGyfbCXH9WKfaUNS67aRMfO0VAbLkr+jwseb1hJue/I1pKsC7PKksuBYh4oqoo9Jov1cBcvjVgjmA==",
+          shasum: "516957cac4249f95cafab0290335def7d9703db7",
+          tarball:
+            "https://cdn.example.com/com.example.package-a/com.example.package-a-1.0.0.tgz",
+        })
+        .addDependency(packageA, "1.0.0")
+    )
+);
+
+const remotePackumentUp = buildPackument(packageUp, (packument) =>
+  packument
+    .set("time", {
+      modified: "2019-11-28T18:51:58.123Z",
+      created: "2019-11-28T18:51:58.123Z",
+      [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
+    })
+    .set("_rev", "3-418f950115c32bd0")
+    .set("readme", "A demo package")
+    .addVersion("1.0.0", (version) =>
+      version
+        .set("displayName", "Package A")
+        .set("author", {
+          name: "batman",
+        })
+        .set("unity", "2018.4")
+        .set("description", "A demo package")
+        .set("keywords", [""])
+        .set("category", "Unity")
+        .addDependency(packageUp, "1.0.0")
+        .set("gitHead", "5c141ecfac59c389090a07540f44c8ac5d07a729")
+        .set("readmeFilename", "README.md")
+        .set("_nodeVersion", "12.13.1")
+        .set("_npmVersion", "6.12.1")
+        .set("dist", {
+          integrity:
+            "sha512-MAh44bur7HGyfbCXH9WKfaUNS67aRMfO0VAbLkr+jwseb1hJue/I1pKsC7PKksuBYh4oqoo9Jov1cBcvjVgjmA==",
+          shasum: "516957cac4249f95cafab0290335def7d9703db7",
+          tarball:
+            "https://cdn.example.com/com.example.package-up/com.example.package-up-1.0.0.tgz",
+        })
+    )
+);
 
 function makeDependencies() {
-  const viewCmd = makeViewCmd();
+  const fetchService: jest.Mocked<FetchPackumentService> = {
+    tryFetchByName: jest.fn(),
+  };
+
+  const viewCmd = makeViewCmd(fetchService);
   return [viewCmd] as const;
 }
 
@@ -37,84 +104,13 @@ describe("cmd-view", () => {
     },
   };
   describe("view", () => {
-    const remotePackumentA = buildPackument(packageA, (packument) =>
-      packument
-        .set("time", {
-          modified: "2019-11-28T18:51:58.123Z",
-          created: "2019-11-28T18:51:58.123Z",
-          [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
-        })
-        .set("_rev", "3-418f950115c32bd0")
-        .set("readme", "A demo package")
-        .addVersion("1.0.0", (version) =>
-          version
-            .set("displayName", "Package A")
-            .set("author", { name: "batman" })
-            .set("unity", "2018.4")
-            .set("description", "A demo package")
-            .set("keywords", [""])
-            .set("category", "Unity")
-            .set("gitHead", "5c141ecfac59c389090a07540f44c8ac5d07a729")
-            .set("readmeFilename", "README.md")
-            .set("_nodeVersion", "12.13.1")
-            .set("_npmVersion", "6.12.1")
-            .set("dist", {
-              integrity:
-                "sha512-MAh44bur7HGyfbCXH9WKfaUNS67aRMfO0VAbLkr+jwseb1hJue/I1pKsC7PKksuBYh4oqoo9Jov1cBcvjVgjmA==",
-              shasum: "516957cac4249f95cafab0290335def7d9703db7",
-              tarball:
-                "https://cdn.example.com/com.example.package-a/com.example.package-a-1.0.0.tgz",
-            })
-            .addDependency(packageA, "1.0.0")
-        )
-    );
-
-    const remotePackumentUp = buildPackument(packageUp, (packument) =>
-      packument
-        .set("time", {
-          modified: "2019-11-28T18:51:58.123Z",
-          created: "2019-11-28T18:51:58.123Z",
-          [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
-        })
-        .set("_rev", "3-418f950115c32bd0")
-        .set("readme", "A demo package")
-        .addVersion("1.0.0", (version) =>
-          version
-            .set("displayName", "Package A")
-            .set("author", {
-              name: "batman",
-            })
-            .set("unity", "2018.4")
-            .set("description", "A demo package")
-            .set("keywords", [""])
-            .set("category", "Unity")
-            .addDependency(packageUp, "1.0.0")
-            .set("gitHead", "5c141ecfac59c389090a07540f44c8ac5d07a729")
-            .set("readmeFilename", "README.md")
-            .set("_nodeVersion", "12.13.1")
-            .set("_npmVersion", "6.12.1")
-            .set("dist", {
-              integrity:
-                "sha512-MAh44bur7HGyfbCXH9WKfaUNS67aRMfO0VAbLkr+jwseb1hJue/I1pKsC7PKksuBYh4oqoo9Jov1cBcvjVgjmA==",
-              shasum: "516957cac4249f95cafab0290335def7d9703db7",
-              tarball:
-                "https://cdn.example.com/com.example.package-up/com.example.package-up-1.0.0.tgz",
-            })
-        )
-    );
-
     beforeEach(() => {
       mockUpmConfig(null);
-
       mockProjectVersion("2020.2.1f1");
-
-      const fetchPackumentService = mockFetchPackumentService(
+      mockResolvedPackuments(
         [exampleRegistryUrl, remotePackumentA],
         [unityRegistryUrl, remotePackumentUp]
       );
-      jest
-        .mocked(makePackumentFetchService)
-        .mockReturnValue(fetchPackumentService);
     });
 
     it("should print information for packument without version", async () => {


### PR DESCRIPTION
Currently cmd-functions create the services they use themselves. This makes it harder to test because service-creation logic needs to be mocked. Also it makes the dependencies for a cmd hard to find.

This PR refactores cmd functions so that services are injected into them. All services and cmd functions are now created inside `cli/index`.