### PR TITLE
test: simplify deps test

### DIFF
--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -52,8 +52,9 @@ export function makeDepsCmd(): DepsCmd {
     const fetchService = makePackumentFetchService();
 
     const [name, version] = splitPackageReference(pkg);
-
+    
     if (version !== undefined && isPackageUrl(version))
+      // TODO: Convert to result
       throw new Error("Cannot get dependencies for url-version");
 
     const deep = options.deep || false;

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -1,13 +1,31 @@
-import { DepsOptions, makeDepsCmd } from "../src/cli/cmd-deps";
-import { buildPackument } from "./data-packument";
+import { makeDepsCmd } from "../src/cli/cmd-deps";
+import * as envModule from "../src/utils/env";
+import { Env } from "../src/utils/env";
+import * as resolveDependencyModule from "../src/dependency-resolving";
+import { Err, Ok } from "ts-results-es";
+import { exampleRegistryUrl } from "./data-registry";
+import { unityRegistryUrl } from "../src/domain/registry-url";
+import { makeEditorVersion } from "../src/domain/editor-version";
+import { IOError } from "../src/io/file-io";
 import { makeDomainName } from "../src/domain/domain-name";
 import { makePackageReference } from "../src/domain/package-reference";
 import { spyOnLog } from "./log.mock";
-import { mockResolvedPackuments } from "./packument-resolving.mock";
-import { unityRegistryUrl } from "../src/domain/registry-url";
-import { mockUpmConfig } from "./upm-config-io.mock";
-import { mockProjectVersion } from "./project-version-io.mock";
-import { exampleRegistryUrl } from "./data-registry";
+import { makeSemanticVersion } from "../src/domain/semantic-version";
+import { PackumentNotFoundError } from "../src/common-errors";
+import { VersionNotFoundError } from "../src/packument-resolving";
+
+const somePackage = makeDomainName("com.some.package");
+const otherPackage = makeDomainName("com.other.package");
+
+const defaultEnv: Env = {
+  cwd: "/users/some-user/projects/SomeProject",
+  systemUser: false,
+  wsl: false,
+  upstream: false,
+  registry: { url: exampleRegistryUrl, auth: null },
+  upstreamRegistry: { url: unityRegistryUrl, auth: null },
+  editorVersion: makeEditorVersion(2022, 2, 1, "f", 2),
+};
 
 function makeDependencies() {
   const depsCmd = makeDepsCmd();
@@ -15,116 +33,133 @@ function makeDependencies() {
 }
 
 describe("cmd-deps", () => {
-  const options: DepsOptions = {
-    _global: {
-      registry: exampleRegistryUrl,
-    },
-  };
-  describe("deps", () => {
-    const remotePackumentA = buildPackument(
-      "com.example.package-a",
-      (packument) =>
-        packument.addVersion("1.0.0", (version) =>
-          version.addDependency("com.example.package-b", "1.0.0")
-        )
+  beforeEach(() => {
+    jest.spyOn(envModule, "parseEnv").mockResolvedValue(Ok(defaultEnv));
+    jest
+      .spyOn(resolveDependencyModule, "fetchPackageDependencies")
+      .mockResolvedValue([
+        [
+          {
+            upstream: false,
+            internal: false,
+            self: true,
+            name: somePackage,
+            version: makeSemanticVersion("1.2.3"),
+          },
+          {
+            upstream: false,
+            internal: false,
+            self: false,
+            name: otherPackage,
+            version: makeSemanticVersion("1.2.3"),
+          },
+        ],
+        [],
+      ]);
+  });
+
+  it("should fail if env could not be parsed", async () => {
+    const expected = new IOError();
+    jest.spyOn(envModule, "parseEnv").mockResolvedValue(Err(expected));
+    const [depsCmd] = makeDependencies();
+
+    const result = await depsCmd(somePackage, { _global: {} });
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+
+  it("should fail if package-reference has url-version", async () => {
+    const [depsCmd] = makeDependencies();
+
+    const operation = depsCmd(
+      makePackageReference(somePackage, "https://some.registry.com"),
+      {
+        _global: {},
+      }
     );
-    const remotePackumentB = buildPackument(
-      "com.example.package-b",
-      (packument) =>
-        packument.addVersion("1.0.0", (version) =>
-          version.addDependency("com.example.package-up", "1.0.0")
-        )
-    );
-    const remotePackumentUp = buildPackument(
-      "com.example.package-up",
-      (packument) => packument.addVersion("1.0.0")
-    );
 
-    beforeEach(() => {
-      mockResolvedPackuments(
-        [exampleRegistryUrl, remotePackumentA],
-        [exampleRegistryUrl, remotePackumentB],
-        [unityRegistryUrl, remotePackumentUp]
-      );
-      mockProjectVersion("2020.2.1f1");
-      mockUpmConfig(null);
+    await expect(operation).rejects.toMatchObject({
+      message: "Cannot get dependencies for url-version",
+    });
+  });
+
+  it("should notify of shallow operation start", async () => {
+    const verboseSpy = spyOnLog("verbose");
+    const [depsCmd] = makeDependencies();
+
+    await depsCmd(somePackage, {
+      _global: {},
     });
 
-    it("should print direct dependencies", async () => {
-      const [depsCmd] = makeDependencies();
-      const noticeSpy = spyOnLog("notice");
+    expect(verboseSpy).toHaveLogLike("dependency", "deep=false");
+  });
 
-      const depsResult = await depsCmd(remotePackumentA.name, options);
+  it("should notify of deep operation start", async () => {
+    const verboseSpy = spyOnLog("verbose");
+    const [depsCmd] = makeDependencies();
 
-      expect(depsResult).toBeOk();
-      expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
+    await depsCmd(somePackage, {
+      _global: {},
+      deep: true,
     });
-    it("should print all dependencies when requested", async () => {
-      const [depsCmd] = makeDependencies();
-      const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await depsCmd(remotePackumentA.name, {
-        ...options,
-        deep: true,
-      });
+    expect(verboseSpy).toHaveLogLike("dependency", "deep=true");
+  });
 
-      expect(depsResult).toBeOk();
-      expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
-      expect(noticeSpy).toHaveLogLike("dependency", remotePackumentUp.name);
+  it("should log valid dependencies", async () => {
+    const noticeSpy = spyOnLog("notice");
+    const [depsCmd] = makeDependencies();
+
+    await depsCmd(somePackage, {
+      _global: {},
     });
-    it("should print correct dependencies for latest tag", async () => {
-      const [depsCmd] = makeDependencies();
-      const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await depsCmd(
-        makePackageReference(remotePackumentA.name, "latest"),
-        options
-      );
+    expect(noticeSpy).toHaveLogLike("dependency", otherPackage);
+  });
 
-      expect(depsResult).toBeOk();
-      expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
+  it("should log missing dependency", async () => {
+    const warnSpy = spyOnLog("warn");
+    jest
+      .spyOn(resolveDependencyModule, "fetchPackageDependencies")
+      .mockResolvedValue([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new PackumentNotFoundError(),
+          },
+        ],
+      ]);
+    const [depsCmd] = makeDependencies();
+
+    await depsCmd(somePackage, {
+      _global: {},
     });
-    it("should print correct dependencies for semantic version", async () => {
-      const [depsCmd] = makeDependencies();
-      const noticeSpy = spyOnLog("notice");
 
-      const depsResult = await depsCmd(
-        makePackageReference(remotePackumentA.name, "1.0.0"),
-        options
-      );
+    expect(warnSpy).toHaveLogLike("missing dependency", otherPackage);
+  });
 
-      expect(depsResult).toBeOk();
-      expect(noticeSpy).toHaveLogLike("dependency", remotePackumentB.name);
+  it("should log missing dependency version", async () => {
+    const warnSpy = spyOnLog("warn");
+    jest
+      .spyOn(resolveDependencyModule, "fetchPackageDependencies")
+      .mockResolvedValue([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.2.3"), []),
+          },
+        ],
+      ]);
+    const [depsCmd] = makeDependencies();
+
+    await depsCmd(somePackage, {
+      _global: {},
     });
-    it("should print no dependencies for unknown version", async () => {
-      const [depsCmd] = makeDependencies();
-      const warnLog = spyOnLog("warn");
 
-      const depsResult = await depsCmd(
-        makePackageReference(remotePackumentA.name, "2.0.0"),
-        options
-      );
-
-      expect(depsResult).toBeOk();
-      expect(warnLog).toHaveLogLike("404", "is not a valid choice");
-    });
-    it("should print no dependencies for unknown packument", async () => {
-      const [depsCmd] = makeDependencies();
-      const warnSpy = spyOnLog("warn");
-
-      const depsResult = await depsCmd(
-        makeDomainName("pkg-not-exist"),
-        options
-      );
-
-      expect(depsResult).toBeOk();
-      expect(warnSpy).toHaveLogLike("404", "not found");
-    });
-    it("should print dependencies for upstream packuments", async () => {
-      const [depsCmd] = makeDependencies();
-      const depsResult = await depsCmd(remotePackumentUp.name, options);
-
-      expect(depsResult).toBeOk();
-    });
+    expect(warnSpy).toHaveLogLike("missing dependency version", otherPackage);
   });
 });


### PR DESCRIPTION
Clean up tests for cmd-deps. Mock direct dependencies in order to simplify necessary setup logic.