### PR TITLE
fix: bad log

### DIFF
--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -10,6 +10,7 @@ import {
   hasVersion,
   makePackageReference,
   PackageReference,
+  splitPackageReference,
 } from "../domain/package-reference";
 import { removeScope } from "../domain/scoped-registry";
 import {
@@ -62,7 +63,8 @@ export function makeRemoveCmd(): RemoveCmd {
     ): Promise<Result<UnityProjectManifest, RemoveError>> {
       // parse name
       if (hasVersion(pkg)) {
-        log.warn("", `please do not specify a version (Write only '${pkg}').`);
+        const [name] = splitPackageReference(pkg);
+        log.warn("", `please do not specify a version (Write only '${name}').`);
         return Err(new PackageWithVersionError());
       }
 

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -3,7 +3,11 @@ import log from "./logger";
 import assert from "assert";
 import { tryGetLatestVersion, UnityPackument } from "../domain/packument";
 import { EnvParseError, parseEnv } from "../utils/env";
-import { hasVersion, PackageReference } from "../domain/package-reference";
+import {
+  hasVersion,
+  PackageReference,
+  splitPackageReference,
+} from "../domain/package-reference";
 import { CmdOptions } from "./options";
 import { recordKeys } from "../utils/record-utils";
 import { Err, Ok, Result } from "ts-results-es";
@@ -106,7 +110,8 @@ export function makeViewCmd(fetchService: FetchPackumentService): ViewCmd {
 
     // parse name
     if (hasVersion(pkg)) {
-      log.warn("", `please do not specify a version (Write only '${pkg}').`);
+      const [name] = splitPackageReference(pkg);
+      log.warn("", `please do not specify a version (Write only '${name}').`);
       return Err(new PackageWithVersionError());
     }
 


### PR DESCRIPTION
For the remove and view command users should not specify package versions. I.e. they should not use these commands like `openupm remove com.some.package@1.0.0`. If they do specify a version, then a message warning the user should be printed.

This message is currently incorrect. If a user would use the command as above it would print `please do not specify a version (Write only 'com.some.package@1.0.0').`. This log also includes a version, despite that that is the exact issue.

Fixed. Now the log will say `please do not specify a version (Write only 'com.some.package').`