### PR TITLE
refactor: inject registry-client

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,10 +22,13 @@ import {
   mustBePackageReference,
   mustBeRegistryUrl,
 } from "./validators";
+import RegClient from "another-npm-registry-client";
 
 // Composition root
 
-const fetchPackument = makeFetchPackumentService();
+const regClient = new RegClient({ log });
+
+const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService();
 const addUser = makeAddUserService();
 const searchRegistry = makeSearchRegistryService();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,7 +30,7 @@ const regClient = new RegClient({ log });
 
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService();
-const addUser = makeAddUserService();
+const addUser = makeAddUserService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveDependencies = makeResolveDependenciesService(fetchPackument);
 const getAllPackuments = makeGetAllPackumentsService();

--- a/src/services/add-user.ts
+++ b/src/services/add-user.ts
@@ -1,5 +1,4 @@
 import RegClient from "another-npm-registry-client";
-import log from "../cli/logger";
 import { RegistryUrl } from "../domain/registry-url";
 import { CustomError } from "ts-custom-error";
 import { AsyncResult, Err, Ok } from "ts-results-es";
@@ -43,9 +42,9 @@ export type AddUserService = (
 /**
  * Makes a new {@link AddUserService} function.
  */
-export function makeAddUserService(): AddUserService {
-  // TODO: Inject registry client
-  const registryClient = new RegClient({ log });
+export function makeAddUserService(
+  registryClient: RegClient.Instance
+): AddUserService {
   return (registryUrl, username, email, password) => {
     return new AsyncResult(
       new Promise((resolve) => {

--- a/src/services/fetch-packument.ts
+++ b/src/services/fetch-packument.ts
@@ -1,5 +1,4 @@
 import RegClient from "another-npm-registry-client";
-import log from "../cli/logger";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { UnityPackument } from "../domain/packument";
@@ -21,10 +20,9 @@ export type FetchPackumentService = (
 /**
  * Makes a {@link FetchPackumentService} function.
  */
-export function makeFetchPackumentService(): FetchPackumentService {
-  // TODO: Inject registry client
-  const registryClient = new RegClient({ log });
-
+export function makeFetchPackumentService(
+  registryClient: RegClient.Instance
+): FetchPackumentService {
   return (registry, name) => {
     const url = `${registry.url}/${name}`;
     return new AsyncResult(

--- a/test/add-user.test.ts
+++ b/test/add-user.test.ts
@@ -8,29 +8,33 @@ import { HttpErrorBase } from "npm-registry-fetch";
 import { Response } from "request";
 import { exampleRegistryUrl } from "./data-registry";
 
-jest.mock("another-npm-registry-client");
-
 function makeDependencies() {
-  const addUser = makeAddUserService();
-  return [addUser] as const;
+  const registryClient: jest.Mocked<RegClient.Instance> = {
+    adduser: jest.fn(),
+    get: jest.fn(),
+  };
+
+  const addUser = makeAddUserService(registryClient);
+  return [addUser, registryClient] as const;
 }
 
 function mockRegClientAddUserResult(
+  registryClient: jest.Mocked<RegClient.Instance>,
   error: HttpErrorBase | null,
   responseData: AddUserResponse | null,
   response: Pick<Response, "statusMessage" | "statusCode"> | null
 ) {
-  jest.mocked(RegClient).mockImplementation(() => ({
-    adduser: (_1, _2, cb) =>
-      cb(error, responseData!, null!, response! as Response),
-    get: () => undefined,
-  }));
+  registryClient.adduser.mockImplementation((_1, _2, cb) =>
+    cb(error, responseData!, null!, response! as Response)
+  );
 }
 
 describe("add-user-service", () => {
   it("should give token for valid user", async () => {
     const expected = "some token";
+    const [addUser, registryClient] = makeDependencies();
     mockRegClientAddUserResult(
+      registryClient,
       null,
       {
         ok: true,
@@ -38,7 +42,6 @@ describe("add-user-service", () => {
       },
       null
     );
-    const [addUser] = makeDependencies();
 
     const result = await addUser(
       exampleRegistryUrl,
@@ -51,7 +54,9 @@ describe("add-user-service", () => {
   });
 
   it("should fail for not-ok response", async () => {
+    const [addUser, registryClient] = makeDependencies();
     mockRegClientAddUserResult(
+      registryClient,
       null,
       {
         ok: false,
@@ -61,7 +66,6 @@ describe("add-user-service", () => {
         statusCode: 401,
       }
     );
-    const [addUser] = makeDependencies();
 
     const result = await addUser(
       exampleRegistryUrl,
@@ -76,11 +80,11 @@ describe("add-user-service", () => {
   });
 
   it("should fail for error response", async () => {
-    mockRegClientAddUserResult({} as HttpErrorBase, null, {
+    const [addUser, registryClient] = makeDependencies();
+    mockRegClientAddUserResult(registryClient, {} as HttpErrorBase, null, {
       statusMessage: "bad user",
       statusCode: 401,
     });
-    const [addUser] = makeDependencies();
 
     const result = await addUser(
       exampleRegistryUrl,


### PR DESCRIPTION
Refactors services which use the `another-nmm-registry-client` registry-client to get it injected instead of creating it themselves.

This improves mocking/testing.