### PR TITLE
refactor: extract helper  function

### DIFF
--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -25,6 +25,7 @@ import { buildProjectManifest } from "./data-project-manifest";
 import { ResolveDependenciesService } from "../src/services/dependency-resolving";
 import { makeSemanticVersion } from "../src/domain/semantic-version";
 import { VersionNotFoundError } from "../src/packument-resolving";
+import { mockService } from "./service.mock";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -56,13 +57,12 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv: jest.MockedFunction<ParseEnvService> = jest.fn();
+  const parseEnv = mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
-  const fetchService: jest.MockedFunction<FetchPackumentService> = jest.fn();
+  const fetchService = mockService<FetchPackumentService>();
 
-  const resolveDependencies: jest.MockedFunction<ResolveDependenciesService> =
-    jest.fn();
+  const resolveDependencies = mockService<ResolveDependenciesService>();
   resolveDependencies.mockResolvedValue([
     [
       {

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -11,6 +11,7 @@ import { makeSemanticVersion } from "../src/domain/semantic-version";
 import { PackumentNotFoundError } from "../src/common-errors";
 import { VersionNotFoundError } from "../src/packument-resolving";
 import { ResolveDependenciesService } from "../src/services/dependency-resolving";
+import { mockService } from "./service.mock";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -21,11 +22,10 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv: jest.MockedFunction<ParseEnvService> = jest.fn();
+  const parseEnv = mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
-  const resolveDependencies: jest.MockedFunction<ResolveDependenciesService> =
-    jest.fn();
+  const resolveDependencies = mockService<ResolveDependenciesService>();
   resolveDependencies.mockResolvedValue([
     [
       {

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -16,6 +16,7 @@ import {
   PackumentNotFoundError,
 } from "../src/common-errors";
 import { spyOnLog } from "./log.mock";
+import {mockService} from "./service.mock";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -28,7 +29,7 @@ const defaultManifest = buildProjectManifest((manifest) =>
 );
 
 function makeDependencies() {
-  const parseEnv: jest.MockedFunction<ParseEnvService> = jest.fn();
+  const parseEnv= mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
   const removeCmd = makeRemoveCmd(parseEnv);

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -16,6 +16,7 @@ import {
   GetAllPackumentsService,
 } from "../src/services/get-all-packuments";
 import { Env, ParseEnvService } from "../src/services/parse-env";
+import { mockService } from "./service.mock";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -26,16 +27,15 @@ const exampleSearchResult: SearchedPackument = {
 };
 
 function makeDependencies() {
-  const parseEnv: jest.MockedFunction<ParseEnvService> = jest.fn();
+  const parseEnv = mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(
     Ok({ registry: { url: exampleRegistryUrl, auth: null } } as Env)
   );
 
-  const searchRegistry: jest.MockedFunction<SearchRegistryService> = jest.fn();
+  const searchRegistry = mockService<SearchRegistryService>();
   searchRegistry.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
 
-  const getAllPackuments: jest.MockedFunction<GetAllPackumentsService> =
-    jest.fn();
+  const getAllPackuments = mockService<GetAllPackumentsService>();
   getAllPackuments.mockReturnValue(
     Ok({
       _updated: 9999,

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -16,6 +16,7 @@ import { spyOnLog } from "./log.mock";
 import * as packumentResolveModule from "../src/packument-resolving";
 import { ResolvedPackument } from "../src/packument-resolving";
 import { buildPackument } from "./data-packument";
+import {mockService} from "./service.mock";
 
 const somePackage = makeDomainName("com.some.package");
 const somePackument = buildPackument(somePackage, (packument) =>
@@ -55,10 +56,10 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv: jest.MockedFunction<ParseEnvService> = jest.fn();
+  const parseEnv= mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
-  const fetchService: jest.MockedFunction<FetchPackumentService> = jest.fn();
+  const fetchService= mockService<FetchPackumentService>();
 
   const viewCmd = makeViewCmd(parseEnv, fetchService);
   return [viewCmd, parseEnv] as const;

--- a/test/service.mock.ts
+++ b/test/service.mock.ts
@@ -1,0 +1,13 @@
+/**
+ * Creates a mock for a service function.
+ * This is just a typing-utility function. Under the hood this just calls
+ * {@link jest.fn}.
+ */
+export function mockService<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends (...args: any[]) => any
+>(): jest.MockedFunction<T> {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return jest.fn();
+}


### PR DESCRIPTION
Extract helper function for mocking service functions. It makes it a little bit shorter.