### PR TITLE
refactor: add string-format error

### DIFF
--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -13,7 +13,7 @@ import {
 } from "./file-io";
 import { tryGetEnv } from "../utils/env-util";
 import { tryGetHomePath } from "./special-paths";
-import { TomlParseError, tryParseToml } from "../utils/data-parsing";
+import { StringFormatError, tryParseToml } from "../utils/data-parsing";
 import { tryGetWslPath, WslPathError } from "./wls";
 import { ChildProcessError } from "../utils/process";
 
@@ -35,7 +35,7 @@ export type GetUpmConfigDirError =
   | RequiredEnvMissingError
   | ChildProcessError;
 
-export type UpmConfigLoadError = TomlParseError;
+export type UpmConfigLoadError = IOError | StringFormatError;
 
 /**
  * Gets the path to directory in which the upm config is stored.

--- a/src/utils/data-parsing.ts
+++ b/src/utils/data-parsing.ts
@@ -1,20 +1,35 @@
 import TOML, { AnyJson, JsonMap } from "@iarna/toml";
 import { Result } from "ts-results-es";
+import { CustomError } from "ts-custom-error";
 
-export type TomlParseError = Error;
+/**
+ * Error for when a string could not be parsed to a specific format.
+ */
+export class StringFormatError extends CustomError {
+  // noinspection JSUnusedLocalSymbols
+  private readonly _class = "StringFormatError";
+
+  public constructor(public readonly formatName: string) {
+    super();
+  }
+}
 
 /**
  * Attempts to parse a json-string.
  * @param json The string to be parsed.
  */
-export function tryParseJson(json: string): Result<AnyJson, SyntaxError> {
-  return Result.wrap(() => JSON.parse(json));
+export function tryParseJson(json: string): Result<AnyJson, StringFormatError> {
+  return Result.wrap(() => JSON.parse(json)).mapErr(
+    () => new StringFormatError("Json")
+  );
 }
 
 /**
  * Attempts to parse a toml-string.
  * @param toml The string to be parsed.
  */
-export function tryParseToml(toml: string): Result<JsonMap, TomlParseError> {
-  return Result.wrap(() => TOML.parse(toml));
+export function tryParseToml(toml: string): Result<JsonMap, StringFormatError> {
+  return Result.wrap(() => TOML.parse(toml)).mapErr(
+    () => new StringFormatError("Toml")
+  );
 }

--- a/test/data-parsing.test.ts
+++ b/test/data-parsing.test.ts
@@ -1,4 +1,4 @@
-import { tryParseJson } from "../src/utils/data-parsing";
+import { StringFormatError, tryParseJson } from "../src/utils/data-parsing";
 
 describe("data-parsing", () => {
   describe("json", () => {
@@ -17,7 +17,7 @@ describe("data-parsing", () => {
       const result = tryParseJson(json);
 
       expect(result).toBeError((error) =>
-        expect(error).toBeInstanceOf(SyntaxError)
+        expect(error).toBeInstanceOf(StringFormatError)
       );
     });
   });

--- a/test/upm-config-io.test.ts
+++ b/test/upm-config-io.test.ts
@@ -6,7 +6,7 @@ import {
 import { tryGetHomePath } from "../src/io/special-paths";
 import { Err, Ok } from "ts-results-es";
 import { IOError, NotFoundError, tryReadTextFromFile } from "../src/io/file-io";
-import { tryParseToml } from "../src/utils/data-parsing";
+import { StringFormatError, tryParseToml } from "../src/utils/data-parsing";
 
 jest.mock("../src/io/file-io");
 jest.mock("../src/io/special-paths");
@@ -74,7 +74,7 @@ describe("upm-config-io", () => {
 
     it("should fail if file has bad toml content", async () => {
       const path = "/home/user";
-      const expected = new Error("Bad toml");
+      const expected = new StringFormatError("Toml");
       jest.mocked(tryParseToml).mockReturnValue(Err(expected));
 
       const result = await tryLoadUpmConfig(path).promise;


### PR DESCRIPTION
Currently, errors for when json or toml can not be parsed are just a plain `Error`. This is problematic, because it messes with TS' ability to differentiate errors.

To fix this, this change introduces the `StringFormatError` which can be used if a string does not match a specific format.