### PR TITLE
refactor: inject project-manifest load

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -1,9 +1,9 @@
 import log from "./logger";
 import { isPackageUrl, PackageUrl } from "../domain/package-url";
 import {
+  LoadProjectManifest,
   ManifestLoadError,
   ManifestSaveError,
-  tryLoadProjectManifest,
   trySaveProjectManifest,
 } from "../io/project-manifest-io";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
@@ -98,7 +98,8 @@ type AddCmd = (
 export function makeAddCmd(
   parseEnv: ParseEnvService,
   resolveRemovePackument: ResolveRemotePackumentService,
-  resolveDependencies: ResolveDependenciesService
+  resolveDependencies: ResolveDependenciesService,
+  loadProjectManifest: LoadProjectManifest
 ): AddCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
@@ -300,7 +301,7 @@ export function makeAddCmd(
     };
 
     // load manifest
-    const loadResult = await tryLoadProjectManifest(env.cwd).promise;
+    const loadResult = await loadProjectManifest(env.cwd).promise;
     if (loadResult.isErr()) {
       logManifestLoadError(loadResult.error);
       return loadResult;

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -1,8 +1,8 @@
 import log from "./logger";
 import {
+  LoadProjectManifest,
   ManifestLoadError,
   ManifestSaveError,
-  tryLoadProjectManifest,
   trySaveProjectManifest,
 } from "../io/project-manifest-io";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
@@ -49,7 +49,10 @@ export type RemoveCmd = (
 /**
  * Makes a {@link RemoveCmd} function.
  */
-export function makeRemoveCmd(parseEnv: ParseEnvService): RemoveCmd {
+export function makeRemoveCmd(
+  parseEnv: ParseEnvService,
+  loadProjectManifest: LoadProjectManifest
+): RemoveCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
     // parse env
@@ -90,7 +93,7 @@ export function makeRemoveCmd(parseEnv: ParseEnvService): RemoveCmd {
     };
 
     // load manifest
-    const manifestResult = await tryLoadProjectManifest(env.cwd).promise;
+    const manifestResult = await loadProjectManifest(env.cwd).promise;
     if (manifestResult.isErr()) {
       logManifestLoadError(manifestResult.error);
       return manifestResult;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,10 +25,12 @@ import {
 import RegClient from "another-npm-registry-client";
 import { makeParseEnvService } from "../services/parse-env";
 import { makeResolveRemotePackumentService } from "../services/resolve-remote-packument";
+import { makeProjectManifestLoader } from "../io/project-manifest-io";
 
 // Composition root
 
 const regClient = new RegClient({ log });
+const loadProjectManifest = makeProjectManifestLoader();
 
 const parseEnv = makeParseEnvService();
 const fetchPackument = makeFetchPackumentService(regClient);
@@ -45,12 +47,13 @@ const getAllPackuments = makeGetAllPackumentsService();
 const addCmd = makeAddCmd(
   parseEnv,
   resolveRemotePackument,
-  resolveDependencies
+  resolveDependencies,
+  loadProjectManifest
 );
 const loginCmd = makeLoginCmd(parseEnv, authNpmrc, addUser);
 const searchCmd = makeSearchCmd(parseEnv, searchRegistry, getAllPackuments);
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies);
-const removeCmd = makeRemoveCmd(parseEnv);
+const removeCmd = makeRemoveCmd(parseEnv, loadProjectManifest);
 const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument);
 
 // update-notifier

--- a/test/project-manifest-io.mock.ts
+++ b/test/project-manifest-io.mock.ts
@@ -1,23 +1,28 @@
 import * as projectManifestIoModule from "../src/io/project-manifest-io";
-import { manifestPathFor } from "../src/io/project-manifest-io";
+import {
+  LoadProjectManifest,
+  manifestPathFor,
+} from "../src/io/project-manifest-io";
 import { UnityProjectManifest } from "../src/domain/project-manifest";
 import { Err, Ok } from "ts-results-es";
 import { NotFoundError } from "../src/io/file-io";
 
 /**
- * Mocks results for calls to {@link tryLoadProjectManifest}.
+ * Mocks results for a {@link LoadProjectManifest} function.
+ * @param loadProjectManifest The load function.
  * @param manifest The manifest that should be returned. Null if there should
  * be no manifest.
  */
-export function mockProjectManifest(manifest: UnityProjectManifest | null) {
-  return jest
-    .spyOn(projectManifestIoModule, "tryLoadProjectManifest")
-    .mockImplementation((projectPath) => {
-      const manifestPath = manifestPathFor(projectPath);
-      return manifest === null
-        ? Err(new NotFoundError(manifestPath)).toAsyncResult()
-        : Ok(manifest).toAsyncResult();
-    });
+export function mockProjectManifest(
+  loadProjectManifest: jest.MockedFunction<LoadProjectManifest>,
+  manifest: UnityProjectManifest | null
+) {
+  return loadProjectManifest.mockImplementation((projectPath) => {
+    const manifestPath = manifestPathFor(projectPath);
+    return manifest === null
+      ? Err(new NotFoundError(manifestPath)).toAsyncResult()
+      : Ok(manifest).toAsyncResult();
+  });
 }
 
 /**


### PR DESCRIPTION
The logic for loading project-manifests is currently directly called from within client functions. This makes it somewhat harder to mock.

This change makes it so that manifest-loading logic is a "service-style" function which needs to be injected into client services. This allows for easier mocking.