### PR TITLE
refactor: dependency logic in tests

### DIFF
--- a/test/add-user.test.ts
+++ b/test/add-user.test.ts
@@ -15,13 +15,13 @@ function makeDependencies() {
   };
 
   const addUser = makeAddUserService(registryClient);
-  return [addUser, registryClient] as const;
+  return { addUser, registryClient } as const;
 }
 
 describe("add-user-service", () => {
   it("should give token for valid user", async () => {
     const expected = "some token";
-    const [addUser, registryClient] = makeDependencies();
+    const { addUser, registryClient } = makeDependencies();
     mockRegClientAddUserResult(
       registryClient,
       null,
@@ -43,7 +43,7 @@ describe("add-user-service", () => {
   });
 
   it("should fail for not-ok response", async () => {
-    const [addUser, registryClient] = makeDependencies();
+    const { addUser, registryClient } = makeDependencies();
     mockRegClientAddUserResult(
       registryClient,
       null,
@@ -69,7 +69,7 @@ describe("add-user-service", () => {
   });
 
   it("should fail for error response", async () => {
-    const [addUser, registryClient] = makeDependencies();
+    const { addUser, registryClient } = makeDependencies();
     mockRegClientAddUserResult(registryClient, {} as HttpErrorBase, null, {
       statusMessage: "bad user",
       statusCode: 401,

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -98,13 +98,13 @@ function makeDependencies() {
     resolveDependencies,
     loadProjectManifest
   );
-  return [
+  return {
     addCmd,
     parseEnv,
     resolveRemotePackument,
     resolveDependencies,
     loadProjectManifest,
-  ] as const;
+  } as const;
 }
 
 describe("cmd-add", () => {
@@ -114,7 +114,7 @@ describe("cmd-add", () => {
 
   it("should fail if env could not be parsed", async () => {
     const expected = new IOError();
-    const [addCmd, parseEnv] = makeDependencies();
+    const { addCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
     const result = await addCmd(somePackage, { _global: {} });
@@ -123,10 +123,10 @@ describe("cmd-add", () => {
   });
 
   it("should fail if manifest could not be loaded", async () => {
-    const [viewCmd, , , , loadProjectManifest] = makeDependencies();
+    const { addCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(loadProjectManifest, null);
 
-    const result = await viewCmd(somePackage, { _global: {} });
+    const result = await addCmd(somePackage, { _global: {} });
 
     expect(result).toBeError((actual) =>
       expect(actual).toBeInstanceOf(NotFoundError)
@@ -135,19 +135,19 @@ describe("cmd-add", () => {
 
   it("should notify if manifest could not be loaded", async () => {
     const errorSpy = spyOnLog("error");
-    const [viewCmd, , , , loadProjectManifest] = makeDependencies();
+    const { addCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(loadProjectManifest, null);
 
-    await viewCmd(somePackage, { _global: {} });
+    await addCmd(somePackage, { _global: {} });
 
     expect(errorSpy).toHaveLogLike("manifest", "");
   });
 
   it("should fail if package could not be resolved", async () => {
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument);
 
-    const result = await viewCmd(somePackage, { _global: {} });
+    const result = await addCmd(somePackage, { _global: {} });
 
     expect(result).toBeError((error) =>
       expect(error).toBeInstanceOf(PackumentNotFoundError)
@@ -156,10 +156,10 @@ describe("cmd-add", () => {
 
   it("should notify if package could not be resolved", async () => {
     const errorSpy = spyOnLog("error");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument);
 
-    await viewCmd(somePackage, { _global: {} });
+    await addCmd(somePackage, { _global: {} });
 
     expect(errorSpy).toHaveLogLike("404", "not found");
   });
@@ -178,9 +178,9 @@ describe("cmd-add", () => {
   ---
       
   it("should fail if package version could not be resolved", async () => {
-    const [viewCmd] = makeDependencies();
+    const {addCmd} = makeDependencies();
 
-    const result = await viewCmd(makePackageReference(somePackage, "2.0.0"), {
+    const result = await addCmd(makePackageReference(somePackage, "2.0.0"), {
       _global: {},
     });
 
@@ -191,9 +191,9 @@ describe("cmd-add", () => {
 
   it("should notify if package version could not be resolved", async () => {
     const warnSpy = spyOnLog("warn");
-    const [viewCmd] = makeDependencies();
+    const {addCmd} = makeDependencies();
 
-    await viewCmd(makePackageReference(somePackage, "2.0.0"), {
+    await addCmd(makePackageReference(somePackage, "2.0.0"), {
       _global: {},
     });
 
@@ -203,12 +203,12 @@ describe("cmd-add", () => {
 
   it("should notify if editor-version is unknown", async () => {
     const warnSpy = spyOnLog("warn");
-    const [viewCmd, parseEnv] = makeDependencies();
+    const { addCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(
       Ok({ ...defaultEnv, editorVersion: "bad version" })
     );
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -217,13 +217,13 @@ describe("cmd-add", () => {
 
   it("should notify if package editor version is not valid", async () => {
     const warnSpy = spyOnLog("warn");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -232,13 +232,13 @@ describe("cmd-add", () => {
 
   it("should suggest running with force if package editor version is not valid", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -246,13 +246,13 @@ describe("cmd-add", () => {
   });
 
   it("should fail if package editor version is not valid and not running with force", async () => {
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
 
-    const result = await viewCmd(somePackage, {
+    const result = await addCmd(somePackage, {
       _global: {},
     });
 
@@ -262,13 +262,13 @@ describe("cmd-add", () => {
   });
 
   it("should add package with invalid editor version when running with force", async () => {
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
 
-    const result = await viewCmd(somePackage, {
+    const result = await addCmd(somePackage, {
       _global: {},
       force: true,
     });
@@ -278,13 +278,13 @@ describe("cmd-add", () => {
 
   it("should notify if package is incompatible with editor", async () => {
     const warnSpy = spyOnLog("warn");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -293,13 +293,13 @@ describe("cmd-add", () => {
 
   it("should suggest to run with force if package is incompatible with editor", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -307,13 +307,13 @@ describe("cmd-add", () => {
   });
 
   it("should fail if package is incompatible with editor and not running with force", async () => {
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
 
-    const result = await viewCmd(somePackage, {
+    const result = await addCmd(somePackage, {
       _global: {},
     });
 
@@ -323,13 +323,13 @@ describe("cmd-add", () => {
   });
 
   it("should add package with incompatible with editor when running with force", async () => {
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
 
-    const result = await viewCmd(somePackage, {
+    const result = await addCmd(somePackage, {
       _global: {},
       force: true,
     });
@@ -339,9 +339,9 @@ describe("cmd-add", () => {
 
   it("should notify of fetching dependencies", async () => {
     const verboseSpy = spyOnLog("verbose");
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -350,13 +350,13 @@ describe("cmd-add", () => {
 
   it("should not fetch dependencies for upstream packages", async () => {
     const verboseSpy = spyOnLog("verbose");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { addCmd, resolveRemotePackument } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [
       unityRegistryUrl,
       somePackument,
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -365,7 +365,7 @@ describe("cmd-add", () => {
 
   it("should suggest to install missing dependency version manually", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd, , , resolveDependencies] = makeDependencies();
+    const { addCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([
       [],
       [
@@ -377,7 +377,7 @@ describe("cmd-add", () => {
       ],
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -386,7 +386,7 @@ describe("cmd-add", () => {
 
   it("should suggest to run with force if dependency could not be resolved", async () => {
     const errorSpy = spyOnLog("error");
-    const [viewCmd, , , resolveDependencies] = makeDependencies();
+    const { addCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([
       [],
       [
@@ -398,7 +398,7 @@ describe("cmd-add", () => {
       ],
     ]);
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -409,7 +409,7 @@ describe("cmd-add", () => {
   });
 
   it("should fail if dependency could not be resolved and not running with force", async () => {
-    const [viewCmd, , , resolveDependencies] = makeDependencies();
+    const { addCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([
       [],
       [
@@ -421,7 +421,7 @@ describe("cmd-add", () => {
       ],
     ]);
 
-    const result = await viewCmd(somePackage, {
+    const result = await addCmd(somePackage, {
       _global: {},
     });
 
@@ -431,7 +431,7 @@ describe("cmd-add", () => {
   });
 
   it("should add package with unresolved dependency when running with force", async () => {
-    const [viewCmd, , , resolveDependencies] = makeDependencies();
+    const { addCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([
       [],
       [
@@ -443,7 +443,7 @@ describe("cmd-add", () => {
       ],
     ]);
 
-    const result = await viewCmd(somePackage, {
+    const result = await addCmd(somePackage, {
       _global: {},
       force: true,
     });
@@ -453,9 +453,9 @@ describe("cmd-add", () => {
 
   it("should add package", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -469,9 +469,9 @@ describe("cmd-add", () => {
 
   it("should notify if package was added", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -480,7 +480,7 @@ describe("cmd-add", () => {
 
   it("should replace package", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [viewCmd, , , , loadProjectManifest] = makeDependencies();
+    const { addCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(
       loadProjectManifest,
       buildProjectManifest((manifest) =>
@@ -488,7 +488,7 @@ describe("cmd-add", () => {
       )
     );
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -502,7 +502,7 @@ describe("cmd-add", () => {
 
   it("should notify if package was replaced", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd, , , , loadProjectManifest] = makeDependencies();
+    const { addCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(
       loadProjectManifest,
       buildProjectManifest((manifest) =>
@@ -510,7 +510,7 @@ describe("cmd-add", () => {
       )
     );
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -519,7 +519,7 @@ describe("cmd-add", () => {
 
   it("should notify if package is already in manifest", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd, , , , loadProjectManifest] = makeDependencies();
+    const { addCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(
       loadProjectManifest,
       buildProjectManifest((manifest) =>
@@ -527,7 +527,7 @@ describe("cmd-add", () => {
       )
     );
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -536,9 +536,9 @@ describe("cmd-add", () => {
 
   it("should add scope for package", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -558,9 +558,9 @@ describe("cmd-add", () => {
 
   it("should add package to testables when running with test option", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
       test: true,
     });
@@ -575,7 +575,7 @@ describe("cmd-add", () => {
 
   it("should not save if nothing changed", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [viewCmd, , , , loadProjectManifest] = makeDependencies();
+    const { addCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(
       loadProjectManifest,
       buildProjectManifest((manifest) =>
@@ -585,7 +585,7 @@ describe("cmd-add", () => {
       )
     );
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -594,10 +594,10 @@ describe("cmd-add", () => {
 
   it("should be atomic", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
     // The second package can not be added
-    await viewCmd([somePackage, makeDomainName("com.unknown.package")], {
+    await addCmd([somePackage, makeDomainName("com.unknown.package")], {
       _global: {},
     });
 
@@ -608,9 +608,9 @@ describe("cmd-add", () => {
 
   it("should suggest to open Unity after save", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, {
+    await addCmd(somePackage, {
       _global: {},
     });
 
@@ -620,9 +620,9 @@ describe("cmd-add", () => {
   it("should fail if manifest could not be saved", async () => {
     const expected = new IOError();
     spyOnSavedManifest().mockReturnValue(Err(expected).toAsyncResult());
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    const result = await viewCmd(somePackage, { _global: {} });
+    const result = await addCmd(somePackage, { _global: {} });
 
     expect(result).toBeError((actual) => expect(actual).toEqual(expected));
   });
@@ -630,9 +630,9 @@ describe("cmd-add", () => {
   it("should notify if manifest could not be saved", async () => {
     const errorSpy = spyOnLog("error");
     spyOnSavedManifest().mockReturnValue(Err(new IOError()).toAsyncResult());
-    const [viewCmd] = makeDependencies();
+    const { addCmd } = makeDependencies();
 
-    await viewCmd(somePackage, { _global: {} });
+    await addCmd(somePackage, { _global: {} });
 
     expect(errorSpy).toHaveLogLike("manifest", "");
   });

--- a/test/cmd-deps.test.ts
+++ b/test/cmd-deps.test.ts
@@ -47,13 +47,13 @@ function makeDependencies() {
   ]);
 
   const depsCmd = makeDepsCmd(parseEnv, resolveDependencies);
-  return [depsCmd, parseEnv, resolveDependencies] as const;
+  return { depsCmd, parseEnv, resolveDependencies } as const;
 }
 
 describe("cmd-deps", () => {
   it("should fail if env could not be parsed", async () => {
     const expected = new IOError();
-    const [depsCmd, parseEnv] = makeDependencies();
+    const { depsCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
     const result = await depsCmd(somePackage, { _global: {} });
@@ -62,7 +62,7 @@ describe("cmd-deps", () => {
   });
 
   it("should fail if package-reference has url-version", async () => {
-    const [depsCmd] = makeDependencies();
+    const { depsCmd } = makeDependencies();
 
     const operation = depsCmd(
       makePackageReference(somePackage, "https://some.registry.com"),
@@ -78,7 +78,7 @@ describe("cmd-deps", () => {
 
   it("should notify of shallow operation start", async () => {
     const verboseSpy = spyOnLog("verbose");
-    const [depsCmd] = makeDependencies();
+    const { depsCmd } = makeDependencies();
 
     await depsCmd(somePackage, {
       _global: {},
@@ -89,7 +89,7 @@ describe("cmd-deps", () => {
 
   it("should notify of deep operation start", async () => {
     const verboseSpy = spyOnLog("verbose");
-    const [depsCmd] = makeDependencies();
+    const { depsCmd } = makeDependencies();
 
     await depsCmd(somePackage, {
       _global: {},
@@ -101,7 +101,7 @@ describe("cmd-deps", () => {
 
   it("should log valid dependencies", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [depsCmd] = makeDependencies();
+    const { depsCmd } = makeDependencies();
 
     await depsCmd(somePackage, {
       _global: {},
@@ -112,7 +112,7 @@ describe("cmd-deps", () => {
 
   it("should log missing dependency", async () => {
     const warnSpy = spyOnLog("warn");
-    const [depsCmd, , resolveDependencies] = makeDependencies();
+    const { depsCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([
       [],
       [
@@ -133,7 +133,7 @@ describe("cmd-deps", () => {
 
   it("should log missing dependency version", async () => {
     const warnSpy = spyOnLog("warn");
-    const [depsCmd, , resolveDependencies] = makeDependencies();
+    const { depsCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([
       [],
       [

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -37,7 +37,7 @@ function makeDependencies() {
   mockProjectManifest(loadProjectManifest, defaultManifest);
 
   const removeCmd = makeRemoveCmd(parseEnv, loadProjectManifest);
-  return [removeCmd, parseEnv, loadProjectManifest] as const;
+  return { removeCmd, parseEnv, loadProjectManifest } as const;
 }
 
 describe("cmd-remove", () => {
@@ -47,7 +47,7 @@ describe("cmd-remove", () => {
 
   it("should fail if env could not be parsed", async () => {
     const expected = new IOError();
-    const [removeCmd, parseEnv] = makeDependencies();
+    const { removeCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
     const result = await removeCmd(somePackage, { _global: {} });
@@ -56,7 +56,7 @@ describe("cmd-remove", () => {
   });
 
   it("should fail if manifest could not be loaded", async () => {
-    const [removeCmd, , loadProjectManifest] = makeDependencies();
+    const { removeCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(loadProjectManifest, null);
 
     const result = await removeCmd(somePackage, { _global: {} });
@@ -68,7 +68,7 @@ describe("cmd-remove", () => {
 
   it("should notify if manifest could not be loaded", async () => {
     const errorSpy = spyOnLog("error");
-    const [removeCmd, , loadProjectManifest] = makeDependencies();
+    const { removeCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(loadProjectManifest, null);
 
     await removeCmd(somePackage, { _global: {} });
@@ -77,7 +77,7 @@ describe("cmd-remove", () => {
   });
 
   it("should fail if package version was specified", async () => {
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     const result = await removeCmd(
       makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
@@ -91,7 +91,7 @@ describe("cmd-remove", () => {
 
   it("should notify if package version was specified", async () => {
     const warnSpy = spyOnLog("warn");
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(
       makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
@@ -102,7 +102,7 @@ describe("cmd-remove", () => {
   });
 
   it("should fail if package is not in manifest", async () => {
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     const result = await removeCmd(otherPackage, { _global: {} });
 
@@ -113,7 +113,7 @@ describe("cmd-remove", () => {
 
   it("should notify if package is not in manifest", async () => {
     const errorSpy = spyOnLog("error");
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(otherPackage, { _global: {} });
 
@@ -122,7 +122,7 @@ describe("cmd-remove", () => {
 
   it("should notify of removed package", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(somePackage, { _global: {} });
 
@@ -131,7 +131,7 @@ describe("cmd-remove", () => {
 
   it("should be atomic for multiple packages", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     // One of these packages can not be removed, so none should be removed.
     await removeCmd([somePackage, otherPackage], { _global: {} });
@@ -141,7 +141,7 @@ describe("cmd-remove", () => {
 
   it("should remove package from manifest", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(somePackage, { _global: {} });
 
@@ -157,7 +157,7 @@ describe("cmd-remove", () => {
 
   it("should remove scope from manifest", async () => {
     const saveSpy = spyOnSavedManifest();
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(somePackage, { _global: {} });
 
@@ -172,7 +172,7 @@ describe("cmd-remove", () => {
   it("should fail if manifest could not be saved", async () => {
     const expected = new IOError();
     spyOnSavedManifest().mockReturnValue(Err(expected).toAsyncResult());
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     const result = await removeCmd(somePackage, { _global: {} });
 
@@ -182,7 +182,7 @@ describe("cmd-remove", () => {
   it("should notify if manifest could not be saved", async () => {
     const errorSpy = spyOnLog("error");
     spyOnSavedManifest().mockReturnValue(Err(new IOError()).toAsyncResult());
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(somePackage, { _global: {} });
 
@@ -191,7 +191,7 @@ describe("cmd-remove", () => {
 
   it("should suggest to open Unity after save", async () => {
     const noticeSpy = spyOnLog("notice");
-    const [removeCmd] = makeDependencies();
+    const { removeCmd } = makeDependencies();
 
     await removeCmd(somePackage, { _global: {} });
 

--- a/test/cmd-search.test.ts
+++ b/test/cmd-search.test.ts
@@ -44,7 +44,7 @@ function makeDependencies() {
   );
 
   const searchCmd = makeSearchCmd(parseEnv, searchRegistry, getAllPackuments);
-  return [searchCmd, parseEnv, searchRegistry, getAllPackuments] as const;
+  return { searchCmd, parseEnv, searchRegistry, getAllPackuments } as const;
 }
 
 describe("cmd-search", () => {
@@ -63,7 +63,7 @@ describe("cmd-search", () => {
   describe("search endpoint", () => {
     it("should print packument information", async () => {
       const consoleSpy = jest.spyOn(console, "log");
-      const [searchCmd] = makeDependencies();
+      const { searchCmd } = makeDependencies();
 
       const searchResult = await searchCmd("package-a", options);
 
@@ -79,7 +79,7 @@ describe("cmd-search", () => {
 
     it("should notify of unknown packument", async () => {
       const noticeSpy = spyOnLog("notice");
-      const [searchCmd, , searchRegistry] = makeDependencies();
+      const { searchCmd, searchRegistry } = makeDependencies();
       searchRegistry.mockReturnValue(Ok([]).toAsyncResult());
 
       const searchResult = await searchCmd("pkg-not-exist", options);
@@ -93,7 +93,7 @@ describe("cmd-search", () => {
     it("should print packument information", async () => {
       const warnSpy = spyOnLog("warn");
       const consoleSpy = jest.spyOn(console, "log");
-      const [searchCmd, , searchRegistry] = makeDependencies();
+      const { searchCmd, searchRegistry } = makeDependencies();
       searchRegistry.mockReturnValue(Err({} as HttpErrorBase).toAsyncResult());
 
       const searchResult = await searchCmd("package-a", options);
@@ -114,7 +114,7 @@ describe("cmd-search", () => {
 
     it("should notify of unknown packument", async () => {
       const noticeSpy = spyOnLog("notice");
-      const [searchCmd, , searchRegistry, getAllPackuments] =
+      const { searchCmd, searchRegistry, getAllPackuments } =
         makeDependencies();
       searchRegistry.mockReturnValue(Err({} as HttpErrorBase).toAsyncResult());
       getAllPackuments.mockReturnValue(Ok({ _updated: 9999 }).toAsyncResult());

--- a/test/cmd-view.test.ts
+++ b/test/cmd-view.test.ts
@@ -66,13 +66,13 @@ function makeDependencies() {
   );
 
   const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument);
-  return [viewCmd, parseEnv, resolveRemotePackument] as const;
+  return { viewCmd, parseEnv, resolveRemotePackument } as const;
 }
 
 describe("cmd-view", () => {
   it("should fail if env could not be parsed", async () => {
     const expected = new IOError();
-    const [viewCmd, parseEnv] = makeDependencies();
+    const { viewCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
     const result = await viewCmd(somePackage, { _global: {} });
@@ -81,7 +81,7 @@ describe("cmd-view", () => {
   });
 
   it("should fail if package version was specified", async () => {
-    const [viewCmd] = makeDependencies();
+    const { viewCmd } = makeDependencies();
 
     const result = await viewCmd(
       makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
@@ -95,7 +95,7 @@ describe("cmd-view", () => {
 
   it("should notify if package version was specified", async () => {
     const warnSpy = spyOnLog("warn");
-    const [viewCmd] = makeDependencies();
+    const { viewCmd } = makeDependencies();
 
     await viewCmd(
       makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
@@ -107,7 +107,7 @@ describe("cmd-view", () => {
 
   it("should fail if package could not be resolved", async () => {
     const expected = new PackumentNotFoundError();
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { viewCmd, resolveRemotePackument } = makeDependencies();
     resolveRemotePackument.mockReturnValue(Err(expected).toAsyncResult());
 
     const result = await viewCmd(somePackage, { _global: {} });
@@ -117,7 +117,7 @@ describe("cmd-view", () => {
 
   it("should notify if package could not be resolved", async () => {
     const errorSpy = spyOnLog("error");
-    const [viewCmd, , resolveRemotePackument] = makeDependencies();
+    const { viewCmd, resolveRemotePackument } = makeDependencies();
     resolveRemotePackument.mockReturnValue(
       Err(new PackumentNotFoundError()).toAsyncResult()
     );
@@ -129,7 +129,7 @@ describe("cmd-view", () => {
 
   it("should print package information", async () => {
     const consoleSpy = jest.spyOn(console, "log");
-    const [viewCmd] = makeDependencies();
+    const { viewCmd } = makeDependencies();
 
     await viewCmd(somePackage, { _global: {} });
 

--- a/test/fetch-packument.test.ts
+++ b/test/fetch-packument.test.ts
@@ -22,14 +22,14 @@ function makeDependencies() {
   };
 
   const fetchPackument = makeFetchPackumentService(regClient);
-  return [fetchPackument, regClient] as const;
+  return { fetchPackument, regClient } as const;
 }
 
 describe("fetch packument service", () => {
   it("should get existing packument", async () => {
     // TODO: Use prop test
     const packument = buildPackument(packageA);
-    const [fetchPackument, regClient] = makeDependencies();
+    const { fetchPackument, regClient } = makeDependencies();
     mockRegClientGetResult(regClient, null, packument);
 
     const result = await fetchPackument(exampleRegistry, packageA).promise;
@@ -38,7 +38,7 @@ describe("fetch packument service", () => {
   });
 
   it("should not find unknown packument", async () => {
-    const [fetchPackument, regClient] = makeDependencies();
+    const { fetchPackument, regClient } = makeDependencies();
     mockRegClientGetResult(
       regClient,
       {
@@ -55,7 +55,7 @@ describe("fetch packument service", () => {
   });
 
   it("should fail for errors", async () => {
-    const [fetchPackument, regClient] = makeDependencies();
+    const { fetchPackument, regClient } = makeDependencies();
     mockRegClientGetResult(
       regClient,
       {

--- a/test/get-all-packuments.test.ts
+++ b/test/get-all-packuments.test.ts
@@ -12,7 +12,7 @@ const exampleRegistry: Registry = {
 
 function makeDependencies() {
   const getAllPackuments = makeGetAllPackumentsService();
-  return [getAllPackuments] as const;
+  return { getAllPackuments } as const;
 }
 
 describe("get all packuments service", () => {
@@ -23,7 +23,7 @@ describe("get all packuments service", () => {
       statusCode: 500,
     } as HttpErrorBase;
     jest.mocked(npmFetch.json).mockRejectedValue(expected);
-    const [getAllPackuments] = makeDependencies();
+    const { getAllPackuments } = makeDependencies();
 
     const result = await getAllPackuments(exampleRegistry).promise;
 
@@ -35,7 +35,7 @@ describe("get all packuments service", () => {
       _update: 123,
     };
     jest.mocked(npmFetch.json).mockResolvedValue(expected);
-    const [getAllPackuments] = makeDependencies();
+    const { getAllPackuments } = makeDependencies();
 
     const result = await getAllPackuments(exampleRegistry).promise;
 

--- a/test/get-builtin-packages.test.ts
+++ b/test/get-builtin-packages.test.ts
@@ -11,7 +11,7 @@ import { makeEditorVersion } from "../src/domain/editor-version";
 
 function makeDependencies() {
   const getBuiltInPackages = makeGetBuiltInPackagesService();
-  return [getBuiltInPackages] as const;
+  return { getBuiltInPackages } as const;
 }
 
 describe("builtin-packages", () => {
@@ -21,7 +21,7 @@ describe("builtin-packages", () => {
       .spyOn(specialPaths, "tryGetEditorInstallPath")
       .mockReturnValue(Err(expected));
     const version = makeEditorVersion(2022, 1, 2, "f", 1);
-    const [getBuiltInPackages] = makeDependencies();
+    const { getBuiltInPackages } = makeDependencies();
 
     const result = await getBuiltInPackages(version).promise;
 
@@ -31,7 +31,7 @@ describe("builtin-packages", () => {
   it("should fail if editor is not installed", async () => {
     const version = makeEditorVersion(2022, 1, 2, "f", 1);
     const expected = new EditorNotInstalledError(version);
-    const [getBuiltInPackages] = makeDependencies();
+    const { getBuiltInPackages } = makeDependencies();
     jest
       .spyOn(fileIo, "tryGetDirectoriesIn")
       .mockReturnValue(Err(new NotFoundError("")).toAsyncResult());
@@ -44,7 +44,7 @@ describe("builtin-packages", () => {
   it("should find package names", async () => {
     const version = makeEditorVersion(2022, 1, 2, "f", 1);
     const expected = ["com.unity.ugui", "com.unity.modules.uielements"];
-    const [getBuiltInPackages] = makeDependencies();
+    const { getBuiltInPackages } = makeDependencies();
     jest
       .spyOn(specialPaths, "tryGetEditorInstallPath")
       .mockReturnValue(Ok("/some/path"));

--- a/test/npmrc-auth.ts
+++ b/test/npmrc-auth.ts
@@ -16,7 +16,7 @@ jest.mock("../src/io/npmrc-io");
 
 function makeDependencies() {
   const authNpmrc = makeAuthNpmrcService();
-  return [authNpmrc] as const;
+  return { authNpmrc } as const;
 }
 
 describe("npmrc-auth", () => {
@@ -30,50 +30,38 @@ describe("npmrc-auth", () => {
 
     it("should fail if path could not be determined", async () => {
       const expected = new RequiredEnvMissingError();
-      const [authNpmrc] = makeDependencies();
+      const { authNpmrc } = makeDependencies();
       jest.mocked(tryGetNpmrcPath).mockReturnValue(Err(expected));
 
-      const result = await authNpmrc(
-        exampleRegistryUrl,
-        "some token"
-      ).promise;
+      const result = await authNpmrc(exampleRegistryUrl, "some token").promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
     });
 
     it("should fail if npmrc load failed", async () => {
       const expected = new IOError();
-      const [authNpmrc] = makeDependencies();
+      const { authNpmrc } = makeDependencies();
       jest.mocked(tryLoadNpmrc).mockReturnValue(new AsyncResult(Err(expected)));
 
-      const result = await authNpmrc(
-        exampleRegistryUrl,
-        "some token"
-      ).promise;
+      const result = await authNpmrc(exampleRegistryUrl, "some token").promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
     });
 
     it("should fail if npmrc save failed", async () => {
       const expected = new IOError();
-      const [authNpmrc] = makeDependencies();
+      const { authNpmrc } = makeDependencies();
       jest.mocked(trySaveNpmrc).mockReturnValue(new AsyncResult(Err(expected)));
 
-      const result = await authNpmrc(
-        exampleRegistryUrl,
-        "some token"
-      ).promise;
+      const result = await authNpmrc(exampleRegistryUrl, "some token").promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
     });
 
     it("should return npmrc path", async () => {
-      const [authNpmrc] = makeDependencies();
+      const { authNpmrc } = makeDependencies();
 
-      const result = await authNpmrc(
-        exampleRegistryUrl,
-        "some token"
-      ).promise;
+      const result = await authNpmrc(exampleRegistryUrl, "some token").promise;
 
       expect(result).toBeOk((actual) =>
         expect(actual).toEqual(exampleNpmrcPath)
@@ -83,7 +71,7 @@ describe("npmrc-auth", () => {
     it("should create npmrc if missing", async () => {
       const expected = setToken(emptyNpmrc, exampleRegistryUrl, "some token");
       const saveSpy = jest.mocked(trySaveNpmrc);
-      const [authNpmrc] = makeDependencies();
+      const { authNpmrc } = makeDependencies();
 
       await authNpmrc(exampleRegistryUrl, "some token").promise;
 
@@ -99,7 +87,7 @@ describe("npmrc-auth", () => {
       const expected = setToken(initial, exampleRegistryUrl, "some token");
       jest.mocked(tryLoadNpmrc).mockReturnValue(new AsyncResult(Ok(initial)));
       const saveSpy = jest.mocked(trySaveNpmrc);
-      const [authNpmrc] = makeDependencies();
+      const { authNpmrc } = makeDependencies();
 
       await authNpmrc(exampleRegistryUrl, "some token").promise;
 

--- a/test/parse-env.test.ts
+++ b/test/parse-env.test.ts
@@ -40,7 +40,7 @@ const testProjectVersion = "2021.3.1f1";
 function makeDependencies() {
   const parseEnv = makeParseEnvService();
 
-  return [parseEnv] as const;
+  return { parseEnv } as const;
 }
 
 describe("env", () => {
@@ -65,7 +65,7 @@ describe("env", () => {
 
   describe("log-level", () => {
     it("should be verbose if verbose option is true", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       await parseEnv({
         _global: {
@@ -77,7 +77,7 @@ describe("env", () => {
     });
 
     it("should be notice if verbose option is false", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       await parseEnv({
         _global: {
@@ -89,7 +89,7 @@ describe("env", () => {
     });
 
     it("should be notice if verbose option is missing", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       await parseEnv({
         _global: {
@@ -107,7 +107,7 @@ describe("env", () => {
     });
 
     it("should use color if color option is true", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const colorDisableSpy = jest.spyOn(log, "disableColor");
 
       await parseEnv({
@@ -120,7 +120,7 @@ describe("env", () => {
     });
 
     it("should use color if color option is missing", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const colorDisableSpy = jest.spyOn(log, "disableColor");
 
       await parseEnv({
@@ -131,7 +131,7 @@ describe("env", () => {
     });
 
     it("should not use color if color option is false", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const colorDisableSpy = jest.spyOn(log, "disableColor");
 
       await parseEnv({
@@ -146,7 +146,7 @@ describe("env", () => {
 
   describe("use upstream", () => {
     it("should use upstream if upstream option is true", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -158,7 +158,7 @@ describe("env", () => {
     });
 
     it("should use upstream if upstream option is missing", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {},
@@ -168,7 +168,7 @@ describe("env", () => {
     });
 
     it("should not use upstream if upstream option is false", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -182,7 +182,7 @@ describe("env", () => {
 
   describe("region log", () => {
     it("should notify of china region if cn option is true", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const logSpy = jest.spyOn(log, "notice");
 
       await parseEnv({
@@ -195,7 +195,7 @@ describe("env", () => {
     });
 
     it("should not notify of china region if cn option is missing", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const logSpy = jest.spyOn(log, "notice");
 
       await parseEnv({
@@ -206,7 +206,7 @@ describe("env", () => {
     });
 
     it("should not notify of china region if cn option is false", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const logSpy = jest.spyOn(log, "notice");
 
       await parseEnv({
@@ -219,7 +219,7 @@ describe("env", () => {
 
   describe("system-user", () => {
     it("should be system-user if option is true", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -231,7 +231,7 @@ describe("env", () => {
     });
 
     it("should not be system-user if option is missing", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {},
@@ -241,7 +241,7 @@ describe("env", () => {
     });
 
     it("should not be system-user if option is false", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -255,7 +255,7 @@ describe("env", () => {
 
   describe("wsl", () => {
     it("should use wsl if option is true", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -267,7 +267,7 @@ describe("env", () => {
     });
 
     it("should not use wsl if option is missing", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {},
@@ -277,7 +277,7 @@ describe("env", () => {
     });
 
     it("should not use wsl if option is false", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -291,7 +291,7 @@ describe("env", () => {
 
   describe("upm-config", () => {
     it("should fail if upm-config dir cannot be determined", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const expected = new NoWslError();
       jest
         .mocked(tryGetUpmConfigDir)
@@ -305,7 +305,7 @@ describe("env", () => {
 
   describe("registry", () => {
     it("should be global openupm by default", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({ _global: {} });
 
@@ -315,7 +315,7 @@ describe("env", () => {
     });
 
     it("should be chinese openupm for chinese locale", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -329,7 +329,7 @@ describe("env", () => {
     });
 
     it("should be custom registry if overridden", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -343,7 +343,7 @@ describe("env", () => {
     });
 
     it("should have no auth if no upm-config was found", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -357,7 +357,7 @@ describe("env", () => {
     });
 
     it("should have no auth if upm-config had no entry for the url", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       mockUpmConfig({
         npmAuth: {},
       });
@@ -374,7 +374,7 @@ describe("env", () => {
     });
 
     it("should have auth if upm-config had entry for the url", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       mockUpmConfig(testUpmConfig);
 
       const result = await parseEnv({
@@ -391,7 +391,7 @@ describe("env", () => {
 
   describe("upstream registry", () => {
     it("should be global unity by default", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({ _global: {} });
 
@@ -401,7 +401,7 @@ describe("env", () => {
     });
 
     it("should be chinese unity for chinese locale", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {
@@ -415,7 +415,7 @@ describe("env", () => {
     });
 
     it("should have no auth", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {},
@@ -429,7 +429,7 @@ describe("env", () => {
 
   describe("cwd", () => {
     it("should be process directory by default", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {},
@@ -441,7 +441,7 @@ describe("env", () => {
     });
 
     it("should be specified path if overridden", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const expected = "/some/other/path";
 
@@ -455,7 +455,7 @@ describe("env", () => {
     });
 
     it("should fail if specified path is not found", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const notExistentPath = "/some/other/path";
       jest
         .mocked(fs.existsSync)
@@ -473,7 +473,7 @@ describe("env", () => {
     });
 
     it("should notify if specified path is not found", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const notExistentPath = "/some/other/path";
       jest
@@ -496,7 +496,7 @@ describe("env", () => {
 
   describe("editor-version", () => {
     it("should be parsed object for valid release versions", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
 
       const result = await parseEnv({
         _global: {},
@@ -508,7 +508,7 @@ describe("env", () => {
     });
 
     it("should be original string for non-release versions", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const expected = "2022.3";
       mockProjectVersion(expected);
 
@@ -522,7 +522,7 @@ describe("env", () => {
     });
 
     it("should be original string for non-version string", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const expected = "Bad version";
       mockProjectVersion(expected);
 
@@ -536,7 +536,7 @@ describe("env", () => {
     });
 
     it("should fail if ProjectVersion.txt could not be loaded", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       const expected = new IOError();
       jest
         .mocked(tryLoadProjectVersion)
@@ -550,7 +550,7 @@ describe("env", () => {
     });
 
     it("should notify of missing ProjectVersion.txt", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       jest
         .mocked(tryLoadProjectVersion)
         .mockReturnValue(
@@ -571,7 +571,7 @@ describe("env", () => {
     });
 
     it("should notify of parsing issue", async () => {
-      const [parseEnv] = makeDependencies();
+      const { parseEnv } = makeDependencies();
       jest
         .mocked(tryLoadProjectVersion)
         .mockReturnValue(

--- a/test/project-manifest-io.test.ts
+++ b/test/project-manifest-io.test.ts
@@ -33,11 +33,11 @@ describe("project-manifest io", () => {
   describe("load", () => {
     function makeDependencies() {
       const loadProjectManifest = makeProjectManifestLoader();
-      return [loadProjectManifest] as const;
+      return { loadProjectManifest } as const;
     }
 
     it("should fail if file could not be read", async () => {
-      const [loadProjectManifest] = makeDependencies();
+      const { loadProjectManifest } = makeDependencies();
       jest
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(Err(new IOError()).toAsyncResult());
@@ -50,7 +50,7 @@ describe("project-manifest io", () => {
     });
 
     it("should fail if file is not found", async () => {
-      const [loadProjectManifest] = makeDependencies();
+      const { loadProjectManifest } = makeDependencies();
       jest
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(Err(new NotFoundError("/some/path")).toAsyncResult());
@@ -63,7 +63,7 @@ describe("project-manifest io", () => {
     });
 
     it("should fail if file does not contain json", async () => {
-      const [loadProjectManifest] = makeDependencies();
+      const { loadProjectManifest } = makeDependencies();
       jest
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(Ok("{} dang, this is not json []").toAsyncResult());
@@ -76,7 +76,7 @@ describe("project-manifest io", () => {
     });
 
     it("should load valid manifest", async () => {
-      const [loadProjectManifest] = makeDependencies();
+      const { loadProjectManifest } = makeDependencies();
       jest
         .spyOn(fileIoModule, "tryReadTextFromFile")
         .mockReturnValue(

--- a/test/search-registry.test.ts
+++ b/test/search-registry.test.ts
@@ -14,7 +14,7 @@ const exampleRegistry: Registry = {
 
 function makeDependencies() {
   const searchRegistry = makeSearchRegistryService();
-  return [searchRegistry] as const;
+  return { searchRegistry } as const;
 }
 
 describe("search service", () => {
@@ -25,7 +25,7 @@ describe("search service", () => {
       statusCode: 500,
     } as HttpErrorBase;
     jest.mocked(npmSearch).mockRejectedValue(expected);
-    const [searchRegistry] = makeDependencies();
+    const { searchRegistry } = makeDependencies();
 
     const result = await searchRegistry(exampleRegistry, "wow").promise;
 
@@ -35,7 +35,7 @@ describe("search service", () => {
   it("should succeed for ok response", async () => {
     const expected = [{ name: "wow" } as search.Result];
     jest.mocked(npmSearch).mockResolvedValue(expected);
-    const [searchRegistry] = makeDependencies();
+    const { searchRegistry } = makeDependencies();
 
     const result = await searchRegistry(exampleRegistry, "wow").promise;
 


### PR DESCRIPTION
Currently test dependencies are exposed as a const array.

I realized it is more convenient to expose them as an object instead. That way you

- get intellisense for the property names
- can more easily only import required dependencies