### PR TITLE
refactor: inject project manifest save

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -3,8 +3,8 @@ import { isPackageUrl, PackageUrl } from "../domain/package-url";
 import {
   LoadProjectManifest,
   ManifestLoadError,
-  ManifestSaveError,
-  trySaveProjectManifest,
+  ManifestWriteError,
+  WriteProjectManifest,
 } from "../io/project-manifest-io";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
 import {
@@ -80,7 +80,7 @@ export type AddError =
   | InvalidPackumentDataError
   | EditorIncompatibleError
   | UnresolvedDependencyError
-  | ManifestSaveError;
+  | ManifestWriteError;
 
 /**
  * Cmd-handler for adding packages.
@@ -99,7 +99,8 @@ export function makeAddCmd(
   parseEnv: ParseEnvService,
   resolveRemovePackument: ResolveRemotePackumentService,
   resolveDependencies: ResolveDependenciesService,
-  loadProjectManifest: LoadProjectManifest
+  loadProjectManifest: LoadProjectManifest,
+  writeProjectManifest: WriteProjectManifest
 ): AddCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
@@ -323,8 +324,7 @@ export function makeAddCmd(
 
     // Save manifest
     if (dirty) {
-      const saveResult = await trySaveProjectManifest(env.cwd, manifest)
-        .promise;
+      const saveResult = await writeProjectManifest(env.cwd, manifest).promise;
       if (saveResult.isErr()) {
         logManifestSaveError(saveResult.error);
         return saveResult;

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -2,8 +2,8 @@ import log from "./logger";
 import {
   LoadProjectManifest,
   ManifestLoadError,
-  ManifestSaveError,
-  trySaveProjectManifest,
+  ManifestWriteError,
+  WriteProjectManifest,
 } from "../io/project-manifest-io";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
 import {
@@ -32,7 +32,7 @@ export type RemoveError =
   | PackageWithVersionError
   | PackumentNotFoundError
   | ManifestLoadError
-  | ManifestSaveError;
+  | ManifestWriteError;
 
 export type RemoveOptions = CmdOptions;
 
@@ -51,7 +51,8 @@ export type RemoveCmd = (
  */
 export function makeRemoveCmd(
   parseEnv: ParseEnvService,
-  loadProjectManifest: LoadProjectManifest
+  loadProjectManifest: LoadProjectManifest,
+  writeProjectManifest: WriteProjectManifest
 ): RemoveCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
@@ -108,7 +109,7 @@ export function makeRemoveCmd(
     }
 
     // save manifest
-    const saveResult = await trySaveProjectManifest(env.cwd, manifest).promise;
+    const saveResult = await writeProjectManifest(env.cwd, manifest).promise;
     if (saveResult.isErr()) {
       logManifestSaveError(saveResult.error);
       return saveResult;

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -1,7 +1,7 @@
 import log from "./logger";
 import {
   ManifestLoadError,
-  ManifestSaveError,
+  ManifestWriteError,
 } from "../io/project-manifest-io";
 import { NotFoundError } from "../io/file-io";
 
@@ -20,10 +20,10 @@ export function logManifestLoadError(error: ManifestLoadError) {
 }
 
 /**
- * Logs a {@link ManifestSaveError} to the console.
+ * Logs a {@link ManifestWriteError} to the console.
  * @param error The error to log.
  */
-export function logManifestSaveError(error: ManifestSaveError) {
+export function logManifestSaveError(error: ManifestWriteError) {
   const prefix = "manifest";
   log.error(prefix, "can not write manifest json file");
   log.error(prefix, error.message);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,12 +25,16 @@ import {
 import RegClient from "another-npm-registry-client";
 import { makeParseEnvService } from "../services/parse-env";
 import { makeResolveRemotePackumentService } from "../services/resolve-remote-packument";
-import { makeProjectManifestLoader } from "../io/project-manifest-io";
+import {
+  makeProjectManifestLoader,
+  makeProjectManifestWriter,
+} from "../io/project-manifest-io";
 
 // Composition root
 
 const regClient = new RegClient({ log });
 const loadProjectManifest = makeProjectManifestLoader();
+const writeProjectManifest = makeProjectManifestWriter();
 
 const parseEnv = makeParseEnvService();
 const fetchPackument = makeFetchPackumentService(regClient);
@@ -48,12 +52,17 @@ const addCmd = makeAddCmd(
   parseEnv,
   resolveRemotePackument,
   resolveDependencies,
-  loadProjectManifest
+  loadProjectManifest,
+  writeProjectManifest
 );
 const loginCmd = makeLoginCmd(parseEnv, authNpmrc, addUser);
 const searchCmd = makeSearchCmd(parseEnv, searchRegistry, getAllPackuments);
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies);
-const removeCmd = makeRemoveCmd(parseEnv, loadProjectManifest);
+const removeCmd = makeRemoveCmd(
+  parseEnv,
+  loadProjectManifest,
+  writeProjectManifest
+);
 const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument);
 
 // update-notifier

--- a/src/domain/scoped-registry.ts
+++ b/src/domain/scoped-registry.ts
@@ -76,7 +76,9 @@ export function removeScope(
  * the registry's hostname.
  * @param registryUrl The registry-url.
  */
-export function makeEmptyScopedRegistryFor(registryUrl: RegistryUrl): ScopedRegistry {
+export function makeEmptyScopedRegistryFor(
+  registryUrl: RegistryUrl
+): ScopedRegistry {
   const name = new URL(registryUrl).hostname;
   return makeScopedRegistry(name, registryUrl);
 }

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -13,6 +13,9 @@ import {
 } from "./file-io";
 import { tryParseJson } from "../utils/data-parsing";
 
+/**
+ * Error which may occur when saving a project manifest.
+ */
 export type ManifestSaveError = IOError;
 
 /**
@@ -24,6 +27,9 @@ export function manifestPathFor(projectPath: string): string {
   return path.join(projectPath, "Packages/manifest.json");
 }
 
+/**
+ * Error which may occur when loading a project manifest.
+ */
 export type ManifestLoadError = NotFoundError | FileParseError;
 
 /**

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -14,11 +14,6 @@ import {
 import { tryParseJson } from "../utils/data-parsing";
 
 /**
- * Error which may occur when saving a project manifest.
- */
-export type ManifestSaveError = IOError;
-
-/**
  * Determines the path to the package manifest based on the project
  * directory.
  * @param projectPath The root path of the Unity project.
@@ -60,17 +55,29 @@ export function makeProjectManifestLoader(): LoadProjectManifest {
 }
 
 /**
- * Saves a Unity project manifest.
- * @param projectPath The path to the projects root directory.
- * @param manifest The manifest to save.
+ * Error which may occur when saving a project manifest.
  */
-export const trySaveProjectManifest = function (
+export type ManifestWriteError = IOError;
+
+/**
+ * Function for replacing the project manifest for a Unity project.
+ * @param projectPath The path to the project's directory.
+ * @param manifest The manifest to write to the project.
+ */
+export type WriteProjectManifest = (
   projectPath: string,
   manifest: UnityProjectManifest
-): AsyncResult<void, ManifestSaveError> {
-  const manifestPath = manifestPathFor(projectPath);
-  manifest = pruneManifest(manifest);
-  const json = JSON.stringify(manifest, null, 2);
+) => AsyncResult<void, ManifestWriteError>;
 
-  return tryWriteTextToFile(manifestPath, json);
-};
+/**
+ * Makes a {@link WriteProjectManifest} function.
+ */
+export function makeProjectManifestWriter(): WriteProjectManifest {
+  return (projectPath, manifest) => {
+    const manifestPath = manifestPathFor(projectPath);
+    manifest = pruneManifest(manifest);
+    const json = JSON.stringify(manifest, null, 2);
+
+    return tryWriteTextToFile(manifestPath, json);
+  };
+}

--- a/test/project-manifest-io.mock.ts
+++ b/test/project-manifest-io.mock.ts
@@ -1,7 +1,8 @@
-import * as projectManifestIoModule from "../src/io/project-manifest-io";
 import {
   LoadProjectManifest,
   manifestPathFor,
+  ManifestWriteError,
+  WriteProjectManifest,
 } from "../src/io/project-manifest-io";
 import { UnityProjectManifest } from "../src/domain/project-manifest";
 import { Err, Ok } from "ts-results-es";
@@ -26,10 +27,15 @@ export function mockProjectManifest(
 }
 
 /**
- * Creates a spy for saved project-manifests.
+ * Mocks the result of writing the project manifest.
+ * @param writeProjectManifest The write function.
+ * @param error The error that should be returned by the write operation. If
+ * omitted the operation will be mocked to succeed.
  */
-export function spyOnSavedManifest() {
-  return jest
-    .spyOn(projectManifestIoModule, "trySaveProjectManifest")
-    .mockReturnValue(Ok(undefined).toAsyncResult());
+export function mockProjectManifestWriteResult(
+  writeProjectManifest: jest.MockedFunction<WriteProjectManifest>,
+  error?: ManifestWriteError
+) {
+  const result = error !== undefined ? Err(error) : Ok(undefined);
+  return writeProjectManifest.mockReturnValue(result.toAsyncResult());
 }


### PR DESCRIPTION
Currently the logic to write the project manifest to disk is directly used in client code. This makes mocking a little difficult.

This change makes it so that the write function is created in composition root and then injected into client code.