### PR TITLE
refactor: remove cwd pre-check

### DIFF
--- a/test/parse-env.test.ts
+++ b/test/parse-env.test.ts
@@ -453,45 +453,6 @@ describe("env", () => {
 
       expect(result).toBeOk((env: Env) => expect(env.cwd).toEqual(expected));
     });
-
-    it("should fail if specified path is not found", async () => {
-      const { parseEnv } = makeDependencies();
-      const notExistentPath = "/some/other/path";
-      jest
-        .mocked(fs.existsSync)
-        .mockImplementation((path) => path !== notExistentPath);
-
-      const result = await parseEnv({
-        _global: {
-          chdir: notExistentPath,
-        },
-      });
-
-      expect(result).toBeError((error) =>
-        expect(error).toBeInstanceOf(NotFoundError)
-      );
-    });
-
-    it("should notify if specified path is not found", async () => {
-      const { parseEnv } = makeDependencies();
-
-      const notExistentPath = "/some/other/path";
-      jest
-        .mocked(fs.existsSync)
-        .mockImplementation((path) => path !== notExistentPath);
-      const logSpy = jest.spyOn(log, "error");
-
-      await parseEnv({
-        _global: {
-          chdir: notExistentPath,
-        },
-      });
-
-      expect(logSpy).toHaveBeenCalledWith(
-        "env",
-        expect.stringContaining("can not resolve")
-      );
-    });
   });
 
   describe("editor-version", () => {


### PR DESCRIPTION
Currently, we check if cwd exists during `parseEnv`. This is not really necessary, because all operations which use cwd will also check if the path exist or handle missing files accordingly.

We can thus safely remove this check. This comes with two slight changes in behavior:

- The app fails later if cwd is not found. Instead of the app failing immediately during start-up, will will only fail once cwd is actually required/used.
- There was a error-log in `parseEnv` which notified of the missing path. This log is now removed.