### PR TITLE
refactor: remove unused code

### DIFF
--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import fse from "fs-extra";
 import { AsyncResult, Err, Ok, Result } from "ts-results-es";
 import yaml from "yaml";
 import { FileParseError } from "../common-errors";
@@ -10,29 +9,6 @@ export type ProjectVersionLoadError = FileReadError | FileParseError;
 
 function projectVersionTxtPathFor(projectDirPath: string) {
   return path.join(projectDirPath, "ProjectSettings", "ProjectVersion.txt");
-}
-
-/**
- * Creates a ProjectVersion.txt file for a Unity project.
- * Nothing besides m_EditorVersion is specified.
- * @param projectDirPath The projects root folder.
- * @param version The editor-version to use.
- */
-export function tryCreateProjectVersionTxt(
-  projectDirPath: string,
-  version: string
-): AsyncResult<void, Error> {
-  return new AsyncResult(
-    Result.wrapAsync(async () => {
-      const projectSettingsDir = path.join(projectDirPath, "ProjectSettings");
-      await fse.mkdirp(projectSettingsDir);
-      const data = `m_EditorVersion: ${version}`;
-      await fse.writeFile(
-        path.join(projectSettingsDir, "ProjectVersion.txt"),
-        data
-      );
-    })
-  );
 }
 
 /**


### PR DESCRIPTION
Logic for creating ProjectVersion.txt used to be used in tests. Now this is all mocked, so we can remove this code.