### PR TITLE
refactor: yaml parse utility

### DIFF
--- a/src/utils/data-parsing.ts
+++ b/src/utils/data-parsing.ts
@@ -1,6 +1,7 @@
 import TOML, { AnyJson, JsonMap } from "@iarna/toml";
 import { Result } from "ts-results-es";
 import { CustomError } from "ts-custom-error";
+import yaml from "yaml";
 
 /**
  * Error for when a string could not be parsed to a specific format.
@@ -31,5 +32,17 @@ export function tryParseJson(json: string): Result<AnyJson, StringFormatError> {
 export function tryParseToml(toml: string): Result<JsonMap, StringFormatError> {
   return Result.wrap(() => TOML.parse(toml)).mapErr(
     () => new StringFormatError("Toml")
+  );
+}
+
+/**
+ * Attempts to parse a yaml-string.
+ * @param input The string to be parsed.
+ */
+export function tryParseYaml(
+  input: string
+): Result<AnyJson, StringFormatError> {
+  return Result.wrap(() => yaml.parse(input)).mapErr(
+    () => new StringFormatError("Yaml")
   );
 }

--- a/test/data-parsing.test.ts
+++ b/test/data-parsing.test.ts
@@ -21,4 +21,7 @@ describe("data-parsing", () => {
       );
     });
   });
+  
+  // TODO: Add toml tests
+  
 });

--- a/test/data-parsing.test.ts
+++ b/test/data-parsing.test.ts
@@ -1,4 +1,9 @@
-import { StringFormatError, tryParseJson } from "../src/utils/data-parsing";
+import {
+  StringFormatError,
+  tryParseJson,
+  tryParseYaml,
+} from "../src/utils/data-parsing";
+import yaml from "yaml";
 
 describe("data-parsing", () => {
   describe("json", () => {
@@ -21,7 +26,27 @@ describe("data-parsing", () => {
       );
     });
   });
-  
+
   // TODO: Add toml tests
-  
+
+  describe("yaml", () => {
+    it("should round-trip valid yaml", () => {
+      const expected = { test: 123 };
+      const text = yaml.stringify(expected);
+
+      const result = tryParseYaml(text);
+
+      expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should fail for bad yaml", () => {
+      const yaml = "{ invalid yaml ";
+
+      const result = tryParseYaml(yaml);
+
+      expect(result).toBeError((error) =>
+        expect(error).toBeInstanceOf(StringFormatError)
+      );
+    });
+  });
 });

--- a/test/project-version-io.test.ts
+++ b/test/project-version-io.test.ts
@@ -3,6 +3,7 @@ import { NotFoundError } from "../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import { FileParseError } from "../src/common-errors";
 import { tryLoadProjectVersion } from "../src/io/project-version-io";
+import { StringFormatError } from "../src/utils/data-parsing";
 
 describe("project-version-io", () => {
   describe("load", () => {
@@ -20,12 +21,12 @@ describe("project-version-io", () => {
     it("should fail if file does not contain valid yaml", async () => {
       jest
         .spyOn(fileIoModule, "tryReadTextFromFile")
-        .mockReturnValue(Ok("this is not valid yaml").toAsyncResult());
+        .mockReturnValue(Ok("{ this is not valid yaml").toAsyncResult());
 
       const result = await tryLoadProjectVersion("/some/path").promise;
 
       expect(result).toBeError((actual) =>
-        expect(actual).toBeInstanceOf(FileParseError)
+        expect(actual).toBeInstanceOf(StringFormatError)
       );
     });
 


### PR DESCRIPTION
This PR extracts the logic for parsing yaml and wrapping in a result to it's own utility function. This allows for shorter client code.