### PR TITLE
feat: better manifest-load error logs

### DIFF
--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -3,7 +3,7 @@ import {
   ManifestLoadError,
   ManifestWriteError,
 } from "../io/project-manifest-io";
-import { NotFoundError } from "../io/file-io";
+import { IOError, NotFoundError } from "../io/file-io";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.
@@ -11,12 +11,30 @@ import { NotFoundError } from "../io/file-io";
  */
 export function logManifestLoadError(error: ManifestLoadError) {
   const prefix = "manifest";
-  if (error instanceof NotFoundError)
-    log.error(prefix, `manifest at ${error.path} does not exist`);
-  else {
-    log.error(prefix, `failed to parse manifest at ${error.path}`);
-    if (error.cause !== undefined) log.error(prefix, error.cause.message);
-  }
+
+  if (error.cause instanceof NotFoundError)
+    log.error(
+      prefix,
+      `there is no project manifest at ${error.path}. Are you in the correct working directory?`
+    );
+  else if (error.cause instanceof IOError)
+    log.error(
+      prefix,
+      `failed to load project manifest at ${
+        error.path
+      } due to a file-system error.
+    The exact error is ${
+      error.cause.cause !== undefined
+        ? `"${error.cause.cause.message}"`
+        : "unknown"
+    }`
+    );
+  else
+    log.error(
+      prefix,
+      `your project manifests content does not seem to be valid json.
+      The exact error is "${error.cause.cause.message}".`
+    );
 }
 
 /**

--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -32,7 +32,7 @@ export class IOError extends CustomError {
     /**
      * The actual error that caused the failure.
      */
-    cause?: NodeJS.ErrnoException
+    public readonly cause?: NodeJS.ErrnoException
   ) {
     super("An interaction with the file-system caused an error.", { cause });
   }

--- a/test/cmd-add.test.ts
+++ b/test/cmd-add.test.ts
@@ -10,7 +10,7 @@ import { exampleRegistryUrl } from "./data-registry";
 import { unityRegistryUrl } from "../src/domain/registry-url";
 import { makeEditorVersion } from "../src/domain/editor-version";
 import { Err, Ok } from "ts-results-es";
-import { IOError, NotFoundError } from "../src/io/file-io";
+import { IOError } from "../src/io/file-io";
 import {
   mockProjectManifest,
   mockProjectManifestWriteResult,
@@ -28,6 +28,7 @@ import { mockService } from "./service.mock";
 import { ResolveRemotePackumentService } from "../src/services/resolve-remote-packument";
 import {
   LoadProjectManifest,
+  ManifestLoadError,
   WriteProjectManifest,
 } from "../src/io/project-manifest-io";
 
@@ -133,7 +134,7 @@ describe("cmd-add", () => {
     const result = await addCmd(somePackage, { _global: {} });
 
     expect(result).toBeError((actual) =>
-      expect(actual).toBeInstanceOf(NotFoundError)
+      expect(actual).toBeInstanceOf(ManifestLoadError)
     );
   });
 

--- a/test/cmd-remove.test.ts
+++ b/test/cmd-remove.test.ts
@@ -2,7 +2,7 @@ import { exampleRegistryUrl } from "./data-registry";
 import { Env, ParseEnvService } from "../src/services/parse-env";
 import { makeRemoveCmd } from "../src/cli/cmd-remove";
 import { Err, Ok } from "ts-results-es";
-import { IOError, NotFoundError } from "../src/io/file-io";
+import { IOError } from "../src/io/file-io";
 import { makeDomainName } from "../src/domain/domain-name";
 import {
   mockProjectManifest,
@@ -19,6 +19,7 @@ import { spyOnLog } from "./log.mock";
 import { mockService } from "./service.mock";
 import {
   LoadProjectManifest,
+  ManifestLoadError,
   WriteProjectManifest,
 } from "../src/io/project-manifest-io";
 
@@ -73,7 +74,7 @@ describe("cmd-remove", () => {
     const result = await removeCmd(somePackage, { _global: {} });
 
     expect(result).toBeError((actual) =>
-      expect(actual).toBeInstanceOf(NotFoundError)
+      expect(actual).toBeInstanceOf(ManifestLoadError)
     );
   });
 

--- a/test/project-manifest-io.mock.ts
+++ b/test/project-manifest-io.mock.ts
@@ -1,5 +1,6 @@
 import {
   LoadProjectManifest,
+  ManifestLoadError,
   manifestPathFor,
   ManifestWriteError,
   WriteProjectManifest,
@@ -20,9 +21,13 @@ export function mockProjectManifest(
 ) {
   return loadProjectManifest.mockImplementation((projectPath) => {
     const manifestPath = manifestPathFor(projectPath);
-    return manifest === null
-      ? Err(new NotFoundError(manifestPath)).toAsyncResult()
-      : Ok(manifest).toAsyncResult();
+    const result =
+      manifest === null
+        ? Err(
+            new ManifestLoadError(manifestPath, new NotFoundError(manifestPath))
+          )
+        : Ok(manifest);
+    return result.toAsyncResult();
   });
 }
 


### PR DESCRIPTION
The error logs for when the project manifest can not be loaded currently don't handle all cases.

Added missing logs and also make them more detailed and include suggestions for fixing.