### PR TITLE
refactor: rename service

### DIFF
--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,4 +1,4 @@
-import { AddUserService, AuthenticationError } from "../services/add-user";
+import { NpmLoginService, AuthenticationError } from "../services/npm-login";
 import log from "./logger";
 import {
   GetUpmConfigDirError,
@@ -58,7 +58,7 @@ export type LoginCmd = (
 export function makeLoginCmd(
   parseEnv: ParseEnvService,
   authNpmrc: AuthNpmrcService,
-  addUser: AddUserService
+  npmLogin: NpmLoginService
 ): LoginCmd {
   return async (options) => {
     // parse env
@@ -94,7 +94,7 @@ export function makeLoginCmd(
       if (result.isErr()) return result;
     } else {
       // npm login
-      const loginResult = await addUser(
+      const loginResult = await npmLogin(
         loginRegistry,
         username,
         password,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import { CmdOptions } from "./options";
 import { makeFetchPackumentService } from "../services/fetch-packument";
 import { makeAddCmd } from "./cmd-add";
 import { makeAuthNpmrcService } from "../services/npmrc-auth";
-import { makeAddUserService } from "../services/add-user";
+import { makeNpmLoginService } from "../services/npm-login";
 import { makeSearchRegistryService } from "../services/search-registry";
 import pkg from "../../package.json";
 import { makeSearchCmd } from "./cmd-search";
@@ -39,7 +39,7 @@ const writeProjectManifest = makeProjectManifestWriter();
 const parseEnv = makeParseEnvService();
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService();
-const addUser = makeAddUserService(regClient);
+const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =
   makeResolveRemotePackumentService(fetchPackument);
@@ -55,7 +55,7 @@ const addCmd = makeAddCmd(
   loadProjectManifest,
   writeProjectManifest
 );
-const loginCmd = makeLoginCmd(parseEnv, authNpmrc, addUser);
+const loginCmd = makeLoginCmd(parseEnv, authNpmrc, npmLogin);
 const searchCmd = makeSearchCmd(parseEnv, searchRegistry, getAllPackuments);
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies);
 const removeCmd = makeRemoveCmd(

--- a/src/services/npm-login.ts
+++ b/src/services/npm-login.ts
@@ -20,31 +20,36 @@ export class AuthenticationError extends CustomError {
 }
 
 /**
+ * Error which may occur when logging a user into a npm registry.
+ */
+export type NpmLoginError = AuthenticationError;
+
+/**
  * A token authenticating a user.
  */
 type AuthenticationToken = string;
 
 /**
- * Service function for adding authenticating new users.
+ * Service function for authenticating users with a npm registry.
  * @param registryUrl The url of the registry into which to login.
  * @param username The username with which to login.
  * @param email The email with which to login.
  * @param password The password with which to login.
  * @returns An authentication token or null if registration failed.
  */
-export type AddUserService = (
+export type NpmLoginService = (
   registryUrl: RegistryUrl,
   username: string,
   email: string,
   password: string
-) => AsyncResult<AuthenticationToken, AuthenticationError>;
+) => AsyncResult<AuthenticationToken, NpmLoginError>;
 
 /**
- * Makes a new {@link AddUserService} function.
+ * Makes a new {@link NpmLoginService} function.
  */
-export function makeAddUserService(
+export function makeNpmLoginService(
   registryClient: RegClient.Instance
-): AddUserService {
+): NpmLoginService {
   return (registryUrl, username, email, password) => {
     return new AsyncResult(
       new Promise((resolve) => {

--- a/test/services/npm-login.test.ts
+++ b/test/services/npm-login.test.ts
@@ -1,8 +1,8 @@
 import "assert";
 import {
   AuthenticationError,
-  makeAddUserService,
-} from "../../src/services/add-user";
+  makeNpmLoginService,
+} from "../../src/services/npm-login";
 import RegClient from "another-npm-registry-client";
 import { HttpErrorBase } from "npm-registry-fetch";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -14,11 +14,11 @@ function makeDependencies() {
     get: jest.fn(),
   };
 
-  const addUser = makeAddUserService(registryClient);
+  const addUser = makeNpmLoginService(registryClient);
   return { addUser, registryClient } as const;
 }
 
-describe("add-user-service", () => {
+describe("npm-login service", () => {
   it("should give token for valid user", async () => {
     const expected = "some token";
     const { addUser, registryClient } = makeDependencies();


### PR DESCRIPTION
The `AddUserService` is responsible for logging in users into a npm registry.

The service and associated symbols were renamed to `NpmLoginService`  to better reflect this.