### PR TITLE
fix: adjust incorrect typing

### DIFF
--- a/src/services/npm-login.ts
+++ b/src/services/npm-login.ts
@@ -57,7 +57,7 @@ export function makeNpmLoginService(
           registryUrl,
           { auth: { username, email, password } },
           (error, responseData, _, response) => {
-            if (error !== null || !responseData.ok)
+            if (response !== undefined && !responseData.ok)
               resolve(
                 Err(
                   new AuthenticationError(
@@ -66,7 +66,9 @@ export function makeNpmLoginService(
                   )
                 )
               );
-            else resolve(Ok(responseData.token));
+            else if (responseData.ok) resolve(Ok(responseData.token));
+
+            // TODO: Handle error
           }
         );
       })

--- a/src/types/another-npm-registry-client.d.ts
+++ b/src/types/another-npm-registry-client.d.ts
@@ -26,7 +26,7 @@ declare module "another-npm-registry-client" {
     error: Error | null,
     data: TData,
     raw: string,
-    res: Response
+    res: Response | undefined
   ) => void;
 
   type Instance = {

--- a/test/services/npm-login.test.ts
+++ b/test/services/npm-login.test.ts
@@ -70,10 +70,15 @@ describe("npm-login service", () => {
 
   it("should fail for error response", async () => {
     const { addUser, registryClient } = makeDependencies();
-    mockRegClientAddUserResult(registryClient, {} as HttpErrorBase, null, {
-      statusMessage: "bad user",
-      statusCode: 401,
-    });
+    mockRegClientAddUserResult(
+      registryClient,
+      {} as HttpErrorBase,
+      { ok: false },
+      {
+        statusMessage: "bad user",
+        statusCode: 401,
+      }
+    );
 
     const result = await addUser(
       exampleRegistryUrl,


### PR DESCRIPTION
npm-registry-client passes an `undefined` response when the request was not even sent or when we got no response. This caused uncaught errors when trying to access properties of `undefined`.

Adjusted usage.