### PR TITLE
refactor: fix incorrect error distinction

### DIFF
--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -26,7 +26,7 @@ export class NotFoundError extends CustomError {
  * Generic IO error for when interacting with the file-system failed.
  */
 export class IOError extends CustomError {
-  private readonly _class = "CustomError";
+  private readonly _class = "IOError";
 
   constructor(
     /**


### PR DESCRIPTION
Errors use a special property to distinguish themselves. The `IOError` type had an incorrect property value.