### PR TITLE
refactor: inject logger

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -1,4 +1,3 @@
-import log from "./logger";
 import { isPackageUrl, PackageUrl } from "../domain/package-url";
 import {
   LoadProjectManifest,
@@ -43,6 +42,7 @@ import { logManifestLoadError, logManifestSaveError } from "./error-logging";
 import { tryGetTargetEditorVersionFor } from "../domain/packument";
 import { ResolveDependenciesService } from "../services/dependency-resolving";
 import { ResolveRemotePackumentService } from "../services/resolve-remote-packument";
+import { Logger } from "npmlog";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";
@@ -100,7 +100,8 @@ export function makeAddCmd(
   resolveRemovePackument: ResolveRemotePackumentService,
   resolveDependencies: ResolveDependenciesService,
   loadProjectManifest: LoadProjectManifest,
-  writeProjectManifest: WriteProjectManifest
+  writeProjectManifest: WriteProjectManifest,
+  log: Logger
 ): AddCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
@@ -310,7 +311,7 @@ export function makeAddCmd(
     // load manifest
     const loadResult = await loadProjectManifest(env.cwd).promise;
     if (loadResult.isErr()) {
-      logManifestLoadError(loadResult.error);
+      logManifestLoadError(log, loadResult.error);
       return loadResult;
     }
     let manifest = loadResult.value;
@@ -332,7 +333,7 @@ export function makeAddCmd(
     if (dirty) {
       const saveResult = await writeProjectManifest(env.cwd, manifest).promise;
       if (saveResult.isErr()) {
-        logManifestSaveError(saveResult.error);
+        logManifestSaveError(log, saveResult.error);
         return saveResult;
       }
 

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -1,4 +1,3 @@
-import log from "./logger";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
 import { isPackageUrl } from "../domain/package-url";
 import {
@@ -14,6 +13,7 @@ import {
 import { PackumentNotFoundError } from "../common-errors";
 import { Ok, Result } from "ts-results-es";
 import { ResolveDependenciesService } from "../services/dependency-resolving";
+import { Logger } from "npmlog";
 
 export type DepsError = EnvParseError;
 
@@ -43,7 +43,8 @@ function errorPrefixForError(error: PackumentResolveError): string {
  */
 export function makeDepsCmd(
   parseEnv: ParseEnvService,
-  resolveDependencies: ResolveDependenciesService
+  resolveDependencies: ResolveDependenciesService,
+  log: Logger
 ): DepsCmd {
   return async (pkg, options) => {
     // parse env

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,5 +1,4 @@
-import { NpmLoginService, AuthenticationError } from "../services/npm-login";
-import log from "./logger";
+import { AuthenticationError, NpmLoginService } from "../services/npm-login";
 import {
   GetUpmConfigDirError,
   tryGetUpmConfigDir,
@@ -19,6 +18,7 @@ import { CmdOptions } from "./options";
 import { Ok, Result } from "ts-results-es";
 import { NpmrcLoadError, NpmrcSaveError } from "../io/npmrc-io";
 import { AuthNpmrcService } from "../services/npmrc-auth";
+import { Logger } from "npmlog";
 
 /**
  * Errors which may occur when logging in.
@@ -58,7 +58,8 @@ export type LoginCmd = (
 export function makeLoginCmd(
   parseEnv: ParseEnvService,
   authNpmrc: AuthNpmrcService,
-  npmLogin: NpmLoginService
+  npmLogin: NpmLoginService,
+  log: Logger
 ): LoginCmd {
   return async (options) => {
     // parse env
@@ -86,7 +87,7 @@ export function makeLoginCmd(
     if (options.basicAuth) {
       // basic auth
       const _auth = encodeBasicAuth(username, password);
-      const result = await tryStoreUpmAuth(configDir, loginRegistry, {
+      const result = await tryStoreUpmAuth(log, configDir, loginRegistry, {
         email,
         alwaysAuth,
         _auth,
@@ -120,7 +121,7 @@ export function makeLoginCmd(
         log.notice("config", `saved to npm config: ${configPath}`)
       );
 
-      const storeResult = await tryStoreUpmAuth(configDir, loginRegistry, {
+      const storeResult = await tryStoreUpmAuth(log, configDir, loginRegistry, {
         email,
         alwaysAuth,
         token,

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -1,4 +1,3 @@
-import log from "./logger";
 import {
   LoadProjectManifest,
   ManifestLoadError,
@@ -26,6 +25,7 @@ import {
   PackumentNotFoundError,
 } from "../common-errors";
 import { logManifestLoadError, logManifestSaveError } from "./error-logging";
+import { Logger } from "npmlog";
 
 export type RemoveError =
   | EnvParseError
@@ -52,7 +52,8 @@ export type RemoveCmd = (
 export function makeRemoveCmd(
   parseEnv: ParseEnvService,
   loadProjectManifest: LoadProjectManifest,
-  writeProjectManifest: WriteProjectManifest
+  writeProjectManifest: WriteProjectManifest,
+  log: Logger
 ): RemoveCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
@@ -96,7 +97,7 @@ export function makeRemoveCmd(
     // load manifest
     const manifestResult = await loadProjectManifest(env.cwd).promise;
     if (manifestResult.isErr()) {
-      logManifestLoadError(manifestResult.error);
+      logManifestLoadError(log, manifestResult.error);
       return manifestResult;
     }
     let manifest = manifestResult.value;
@@ -111,7 +112,7 @@ export function makeRemoveCmd(
     // save manifest
     const saveResult = await writeProjectManifest(env.cwd, manifest).promise;
     if (saveResult.isErr()) {
-      logManifestSaveError(saveResult.error);
+      logManifestSaveError(log, saveResult.error);
       return saveResult;
     }
 

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -1,5 +1,4 @@
 import chalk from "chalk";
-import log from "./logger";
 import assert from "assert";
 import { tryGetLatestVersion, UnityPackument } from "../domain/packument";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
@@ -13,6 +12,7 @@ import { recordKeys } from "../utils/record-utils";
 import { Err, Ok, Result } from "ts-results-es";
 import { PackageWithVersionError } from "../common-errors";
 import { ResolveRemotePackumentService } from "../services/resolve-remote-packument";
+import { Logger } from "npmlog";
 
 export type ViewOptions = CmdOptions;
 
@@ -102,7 +102,8 @@ const printInfo = function (packument: UnityPackument) {
  */
 export function makeViewCmd(
   parseEnv: ParseEnvService,
-  resolveRemotePackument: ResolveRemotePackumentService
+  resolveRemotePackument: ResolveRemotePackumentService,
+  log: Logger
 ): ViewCmd {
   return async (pkg, options) => {
     // parse env

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -1,15 +1,14 @@
-import log from "./logger";
 import {
   ManifestLoadError,
   ManifestWriteError,
 } from "../io/project-manifest-io";
 import { NotFoundError } from "../io/file-io";
+import { Logger } from "npmlog";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.
- * @param error The error to log.
  */
-export function logManifestLoadError(error: ManifestLoadError) {
+export function logManifestLoadError(log: Logger, error: ManifestLoadError) {
   const prefix = "manifest";
   if (error instanceof NotFoundError)
     log.error(prefix, `manifest at ${error.path} does not exist`);
@@ -21,9 +20,8 @@ export function logManifestLoadError(error: ManifestLoadError) {
 
 /**
  * Logs a {@link ManifestWriteError} to the console.
- * @param error The error to log.
  */
-export function logManifestSaveError(error: ManifestWriteError) {
+export function logManifestSaveError(log: Logger, error: ManifestWriteError) {
   const prefix = "manifest";
   log.error(prefix, "can not write manifest json file");
   log.error(prefix, error.message);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,6 @@ import updateNotifier from "update-notifier";
 import { makeRemoveCmd } from "./cmd-remove";
 import { makeDepsCmd } from "./cmd-deps";
 import { makeLoginCmd } from "./cmd-login";
-import log from "./logger";
 import { eachValue } from "./cli-parsing";
 import { CmdOptions } from "./options";
 import { makeFetchPackumentService } from "../services/fetch-packument";
@@ -29,41 +28,51 @@ import {
   makeProjectManifestLoader,
   makeProjectManifestWriter,
 } from "../io/project-manifest-io";
+import npmlog from "npmlog";
 
 // Composition root
 
+const log = npmlog;
 const regClient = new RegClient({ log });
 const loadProjectManifest = makeProjectManifestLoader();
 const writeProjectManifest = makeProjectManifestWriter();
 
-const parseEnv = makeParseEnvService();
+const parseEnv = makeParseEnvService(log);
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService();
 const npmLogin = makeNpmLoginService(regClient);
-const searchRegistry = makeSearchRegistryService();
+const searchRegistry = makeSearchRegistryService(log);
 const resolveRemotePackument =
   makeResolveRemotePackumentService(fetchPackument);
 const resolveDependencies = makeResolveDependenciesService(
-  resolveRemotePackument
+  resolveRemotePackument,
+  log
 );
-const getAllPackuments = makeGetAllPackumentsService();
+const getAllPackuments = makeGetAllPackumentsService(log);
 
 const addCmd = makeAddCmd(
   parseEnv,
   resolveRemotePackument,
   resolveDependencies,
   loadProjectManifest,
-  writeProjectManifest
+  writeProjectManifest,
+  log
 );
-const loginCmd = makeLoginCmd(parseEnv, authNpmrc, npmLogin);
-const searchCmd = makeSearchCmd(parseEnv, searchRegistry, getAllPackuments);
-const depsCmd = makeDepsCmd(parseEnv, resolveDependencies);
+const loginCmd = makeLoginCmd(parseEnv, authNpmrc, npmLogin, log);
+const searchCmd = makeSearchCmd(
+  parseEnv,
+  searchRegistry,
+  getAllPackuments,
+  log
+);
+const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log);
 const removeCmd = makeRemoveCmd(
   parseEnv,
   loadProjectManifest,
-  writeProjectManifest
+  writeProjectManifest,
+  log
 );
-const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument);
+const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument, log);
 
 // update-notifier
 

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -1,9 +1,0 @@
-import npmlog from "npmlog";
-import { tryGetEnv } from "../utils/env-util";
-
-if (tryGetEnv("NODE_ENV") === "test") {
-  npmlog.stream = process.stdout;
-  npmlog.disableColor();
-}
-
-export default npmlog;

--- a/src/domain/upm-config.ts
+++ b/src/domain/upm-config.ts
@@ -1,7 +1,6 @@
 import { trySplitAtFirstOccurrenceOf } from "../utils/string-utils";
 import { Base64, decodeBase64, encodeBase64 } from "./base64";
 import { RegistryUrl } from "./registry-url";
-import log from "../cli/logger";
 import { NpmAuth } from "another-npm-registry-client";
 
 /**

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import TOML from "@iarna/toml";
-import log from "../cli/logger";
 import { addAuth, UpmAuth, UPMConfig } from "../domain/upm-config";
 import { RegistryUrl } from "../domain/registry-url";
 import { CustomError } from "ts-custom-error";
@@ -16,6 +15,7 @@ import { tryGetHomePath } from "./special-paths";
 import { StringFormatError, tryParseToml } from "../utils/string-parsing";
 import { tryGetWslPath, WslPathError } from "./wsl";
 import { ChildProcessError } from "../utils/process";
+import { Logger } from "npmlog";
 
 const configFileName = ".upmconfig.toml";
 
@@ -118,6 +118,7 @@ export type UpmAuthStoreError = UpmConfigLoadError | IOError;
  * Stores authentication information in the projects upm config.
  */
 export const tryStoreUpmAuth = function (
+  log: Logger,
   configDir: string,
   registry: RegistryUrl,
   auth: UpmAuth

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -1,6 +1,5 @@
 import { DomainName, isInternalPackage } from "../domain/domain-name";
 import { isSemanticVersion, SemanticVersion } from "../domain/semantic-version";
-import log from "../cli/logger";
 import { makePackageReference } from "../domain/package-reference";
 import { addToCache, emptyPackumentCache } from "../packument-cache";
 import {
@@ -16,6 +15,7 @@ import assert from "assert";
 import { PackumentNotFoundError } from "../common-errors";
 import { Registry } from "../domain/registry";
 import { ResolveRemotePackumentService } from "./resolve-remote-packument";
+import { Logger } from "npmlog";
 
 export type DependencyBase = {
   /**
@@ -79,7 +79,8 @@ export type ResolveDependenciesService = (
  * Makes a {@link ResolveDependenciesService} function.
  */
 export function makeResolveDependenciesService(
-  resolveRemotePackument: ResolveRemotePackumentService
+  resolveRemotePackument: ResolveRemotePackumentService,
+  log: Logger
 ): ResolveDependenciesService {
   return async (registry, upstreamRegistry, name, version, deep) => {
     // a list of pending dependency {name, version}

--- a/src/services/get-all-packuments.ts
+++ b/src/services/get-all-packuments.ts
@@ -4,6 +4,7 @@ import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { getNpmFetchOptions, SearchedPackument } from "./search-registry";
 import { DomainName } from "../domain/domain-name";
+import { Logger } from "npmlog";
 
 /**
  * The result of querying the /-/all endpoint.
@@ -24,11 +25,13 @@ export type GetAllPackumentsService = (
 /**
  * Makes a {@link GetAllPackumentsService} service.
  */
-export function makeGetAllPackumentsService(): GetAllPackumentsService {
+export function makeGetAllPackumentsService(
+  log: Logger
+): GetAllPackumentsService {
   return (registry) => {
     return new AsyncResult(
       npmFetch
-        .json("/-/all", getNpmFetchOptions(registry))
+        .json("/-/all", getNpmFetchOptions(log, registry))
         .then((result) => Ok(result as AllPackumentsResult))
         .catch((error) => {
           assertIsHttpError(error);

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -1,4 +1,3 @@
-import log from "../cli/logger";
 import chalk from "chalk";
 import {
   GetUpmConfigDirError,
@@ -24,6 +23,7 @@ import {
   tryParseEditorVersion,
 } from "../domain/editor-version";
 import { Registry } from "../domain/registry";
+import { Logger } from "npmlog";
 
 export type Env = Readonly<{
   cwd: string;
@@ -55,6 +55,7 @@ function determineWsl(options: CmdOptions): boolean {
 }
 
 function determinePrimaryRegistry(
+  log: Logger,
   options: CmdOptions,
   upmConfig: UPMConfig | null
 ): Registry {
@@ -115,7 +116,7 @@ export type ParseEnvService = (
 /**
  * Creates a {@link ParseEnvService} function.
  */
-export function makeParseEnvService(): ParseEnvService {
+export function makeParseEnvService(log: Logger): ParseEnvService {
   return async (options) => {
     // log level
     log.level = determineLogLevel(options);
@@ -144,7 +145,7 @@ export function makeParseEnvService(): ParseEnvService {
     if (upmConfigResult.isErr()) return upmConfigResult;
     const upmConfig = upmConfigResult.value;
 
-    const registry = determinePrimaryRegistry(options, upmConfig);
+    const registry = determinePrimaryRegistry(log, options, upmConfig);
     const upstreamRegistry = determineUpstreamRegistry(options);
 
     // cwd

--- a/src/services/search-registry.ts
+++ b/src/services/search-registry.ts
@@ -2,10 +2,10 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
 import npmSearch from "libnpmsearch";
 import { assertIsHttpError } from "../utils/error-type-guards";
-import log from "../cli/logger";
 import { UnityPackument } from "../domain/packument";
 import { SemanticVersion } from "../domain/semantic-version";
 import { Registry } from "../domain/registry";
+import { Logger } from "npmlog";
 
 /**
  * A type representing a searched packument. Instead of having all versions
@@ -29,9 +29,9 @@ export type SearchRegistryService = (
 
 /**
  * Get npm fetch options.
- * @param registry The registry for which to get the options.
  */
 export const getNpmFetchOptions = function (
+  log: Logger,
   registry: Registry
 ): npmFetch.Options {
   const opts: npmSearch.Options = {
@@ -46,10 +46,10 @@ export const getNpmFetchOptions = function (
 /**
  * Makes a {@link SearchRegistryService} function.
  */
-export function makeSearchRegistryService(): SearchRegistryService {
+export function makeSearchRegistryService(log: Logger): SearchRegistryService {
   return (registry, keyword) => {
     return new AsyncResult(
-      npmSearch(keyword, getNpmFetchOptions(registry))
+      npmSearch(keyword, getNpmFetchOptions(log, registry))
         // NOTE: The results of the search will be packument objects, so we can change the type
         .then((results) => Ok(results as SearchedPackument[]))
         .catch((error) => {

--- a/test/cli/log.mock.ts
+++ b/test/cli/log.mock.ts
@@ -1,8 +1,7 @@
-import log from "../../src/cli/logger";
 import { Logger, LogLevels } from "npmlog";
 import AsymmetricMatcher = jest.AsymmetricMatcher;
 
-type LogSpy = jest.SpyInstance<void, Parameters<Logger[LogLevels]>>;
+type LogSpy = jest.MockedFunctionDeep<Logger[LogLevels]>;
 
 expect.extend({
   toHaveLogLike(
@@ -43,9 +42,8 @@ expect.extend({
 });
 
 /**
- * Creates a spy for mocking logs to a specific logging-level.
- * @param level The level to spy on.
+ * Creates mock logger.
  */
-export function spyOnLog(level: LogLevels): LogSpy {
-  return jest.spyOn(log, level);
+export function makeMockLogger() {
+  return jest.mocked(jest.createMockFromModule<Logger>("npmlog"));
 }

--- a/test/services/get-all-packuments.test.ts
+++ b/test/services/get-all-packuments.test.ts
@@ -2,6 +2,7 @@ import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
 import { makeGetAllPackumentsService } from "../../src/services/get-all-packuments";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
+import { makeMockLogger } from "../cli/log.mock";
 
 jest.mock("npm-registry-fetch");
 
@@ -11,7 +12,9 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const getAllPackuments = makeGetAllPackumentsService();
+  const log = makeMockLogger();
+
+  const getAllPackuments = makeGetAllPackumentsService(log);
   return { getAllPackuments } as const;
 }
 

--- a/test/services/search-registry.test.ts
+++ b/test/services/search-registry.test.ts
@@ -4,6 +4,7 @@ import { HttpErrorBase } from "npm-registry-fetch";
 import { makeSearchRegistryService } from "../../src/services/search-registry";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
+import { makeMockLogger } from "../cli/log.mock";
 
 jest.mock("libnpmsearch");
 
@@ -13,7 +14,9 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const searchRegistry = makeSearchRegistryService();
+  const log = makeMockLogger();
+
+  const searchRegistry = makeSearchRegistryService(log);
   return { searchRegistry } as const;
 }
 


### PR DESCRIPTION
Currently all places in the app that log use a global logger.

This change makes it so that the logger is injected into all relevant code as a function parameter. This has two advantages:

- Improves testability
- Makes it more obvious where logging is done deep in the app where it should not happen.