### PR TITLE
refactor. pull up log

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -222,6 +222,8 @@ export function makeAddCmd(
           // print suggestion for depsInvalid
           let isAnyDependencyUnresolved = false;
           depsInvalid.forEach((depObj) => {
+            logPackumentResolveError(log, depObj.name, depObj.reason);
+
             if (
               depObj.reason instanceof PackumentNotFoundError ||
               depObj.reason instanceof VersionNotFoundError

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -14,7 +14,6 @@ import assert from "assert";
 import { Registry } from "../domain/registry";
 import { ResolveRemotePackumentService } from "./resolve-remote-packument";
 import { Logger } from "npmlog";
-import { logPackumentResolveError } from "../cli/error-logging";
 
 export type DependencyBase = {
   /**
@@ -145,7 +144,6 @@ export function makeResolveDependenciesService(
           }
 
           if (resolveResult.isErr()) {
-            logPackumentResolveError(log, entry.name, resolveResult.error);
             depsInvalid.push({
               name: entry.name,
               self: isSelf,

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -358,6 +358,29 @@ describe("cmd-add", () => {
     );
   });
 
+  it("should notify of unresolved dependencies", async () => {
+    const { addCmd, resolveDependencies, log } = makeDependencies();
+    resolveDependencies.mockResolvedValue([
+      [],
+      [
+        {
+          name: otherPackage,
+          self: false,
+          reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
+        },
+      ],
+    ]);
+
+    await addCmd(somePackage, {
+      _global: {},
+    });
+
+    expect(log.warn).toHaveLogLike(
+      "404",
+      expect.stringContaining("is not a valid choice")
+    );
+  });
+
   it("should not fetch dependencies for upstream packages", async () => {
     const { addCmd, resolveRemotePackument, log } = makeDependencies();
     mockResolvedPackuments(resolveRemotePackument, [


### PR DESCRIPTION
Currently we log unresolved packuments in the dependency-resolving process. This is undesirable from two perspectives:
- We have logging in a service. We only want logging in the cli layer.
- The dependency-service is used by the deps-cmd which will log missing dependencies independently. So we have these logs twice.

Pulled up log to only call in cmd-add. Also add establishing test.