### PR TITLE
refactor: pull up log

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -47,6 +47,7 @@ import { tryGetTargetEditorVersionFor } from "../domain/packument";
 import { ResolveDependenciesService } from "../services/dependency-resolving";
 import { ResolveRemotePackumentService } from "../services/resolve-remote-packument";
 import { Logger } from "npmlog";
+import { logValidDependency } from "./dependency-logging";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";
@@ -215,6 +216,9 @@ export function makeAddCmd(
             true
           );
           // add depsValid to pkgsInScope.
+          depsValid.forEach((dependency) =>
+            logValidDependency(log, dependency)
+          );
           depsValid
             .filter((x) => !x.upstream && !x.internal)
             .map((x) => x.name)

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -14,6 +14,7 @@ import { PackumentNotFoundError } from "../common-errors";
 import { Ok, Result } from "ts-results-es";
 import { ResolveDependenciesService } from "../services/dependency-resolving";
 import { Logger } from "npmlog";
+import { logValidDependency } from "./dependency-logging";
 
 export type DepsError = EnvParseError;
 
@@ -70,6 +71,7 @@ export function makeDepsCmd(
       version,
       deep
     );
+    depsValid.forEach((dependency) => logValidDependency(log, dependency));
     depsValid
       .filter((x) => !x.self)
       .forEach((x) =>

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -1,0 +1,14 @@
+import { ValidDependency } from "../services/dependency-resolving";
+import { makePackageReference } from "../domain/package-reference";
+import { Logger } from "npmlog";
+
+/**
+ * Logs information about a valid dependency to a logger.
+ */
+export function logValidDependency(log: Logger, dependency: ValidDependency) {
+  const packageRef = makePackageReference(dependency.name, dependency.version);
+  const internalTag = dependency.internal ? "[internal] " : "";
+  const upstreamTag = dependency.upstream ? "[upstream]" : "";
+  const message = `${packageRef} ${internalTag}${upstreamTag}`;
+  log.verbose("dependency", message);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,8 +45,7 @@ const searchRegistry = makeSearchRegistryService(log);
 const resolveRemotePackument =
   makeResolveRemotePackumentService(fetchPackument);
 const resolveDependencies = makeResolveDependenciesService(
-  resolveRemotePackument,
-  log
+  resolveRemotePackument
 );
 const getAllPackuments = makeGetAllPackumentsService(log);
 

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -1,6 +1,5 @@
 import { DomainName, isInternalPackage } from "../domain/domain-name";
 import { isSemanticVersion, SemanticVersion } from "../domain/semantic-version";
-import { makePackageReference } from "../domain/package-reference";
 import { addToCache, emptyPackumentCache } from "../packument-cache";
 import {
   PackumentResolveError,
@@ -14,6 +13,7 @@ import assert from "assert";
 import { Registry } from "../domain/registry";
 import { ResolveRemotePackumentService } from "./resolve-remote-packument";
 import { Logger } from "npmlog";
+import { logValidDependency } from "../cli/dependency-logging";
 
 export type DependencyBase = {
   /**
@@ -181,19 +181,15 @@ export function makeResolveDependenciesService(
         assert(resolvedVersion !== undefined);
         assert(isSemanticVersion(resolvedVersion));
 
-        depsValid.push({
+        const dependency: ValidDependency = {
           name: entry.name,
           version: resolvedVersion,
           internal: isInternal,
           upstream: isUpstream,
           self: isSelf,
-        });
-        log.verbose(
-          "dependency",
-          `${makePackageReference(entry.name, resolvedVersion)} ${
-            isInternal ? "[internal] " : ""
-          }${isUpstream ? "[upstream]" : ""}`
-        );
+        };
+        logValidDependency(log, dependency);
+        depsValid.push(dependency);
       }
     }
     return [depsValid, depsInvalid];

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -13,7 +13,6 @@ import assert from "assert";
 import { Registry } from "../domain/registry";
 import { ResolveRemotePackumentService } from "./resolve-remote-packument";
 import { Logger } from "npmlog";
-import { logValidDependency } from "../cli/dependency-logging";
 
 export type DependencyBase = {
   /**
@@ -188,7 +187,6 @@ export function makeResolveDependenciesService(
           upstream: isUpstream,
           self: isSelf,
         };
-        logValidDependency(log, dependency);
         depsValid.push(dependency);
       }
     }

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -12,7 +12,6 @@ import { recordEntries } from "../utils/record-utils";
 import assert from "assert";
 import { Registry } from "../domain/registry";
 import { ResolveRemotePackumentService } from "./resolve-remote-packument";
-import { Logger } from "npmlog";
 
 export type DependencyBase = {
   /**
@@ -76,8 +75,7 @@ export type ResolveDependenciesService = (
  * Makes a {@link ResolveDependenciesService} function.
  */
 export function makeResolveDependenciesService(
-  resolveRemotePackument: ResolveRemotePackumentService,
-  log: Logger
+  resolveRemotePackument: ResolveRemotePackumentService
 ): ResolveDependenciesService {
   return async (registry, upstreamRegistry, name, version, deep) => {
     // a list of pending dependency {name, version}

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -444,6 +444,23 @@ describe("cmd-add", () => {
     );
   });
 
+  it("should print verbose information about valid dependencies", async () => {
+    const { addCmd, log } = makeDependencies();
+
+    await addCmd(somePackage, {
+      _global: {},
+    });
+
+    expect(log.verbose).toHaveLogLike(
+      "dependency",
+      expect.stringContaining(somePackage)
+    );
+    expect(log.verbose).toHaveLogLike(
+      "dependency",
+      expect.stringContaining(otherPackage)
+    );
+  });
+
   it("should fail if dependency could not be resolved and not running with force", async () => {
     const { addCmd, resolveDependencies } = makeDependencies();
     resolveDependencies.mockResolvedValue([

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -105,6 +105,23 @@ describe("cmd-deps", () => {
     );
   });
 
+  it("should print verbose information about valid dependencies", async () => {
+    const { depsCmd, log } = makeDependencies();
+
+    await depsCmd(somePackage, {
+      _global: {},
+    });
+
+    expect(log.verbose).toHaveLogLike(
+      "dependency",
+      expect.stringContaining(somePackage)
+    );
+    expect(log.verbose).toHaveLogLike(
+      "dependency",
+      expect.stringContaining(otherPackage)
+    );
+  });
+
   it("should log valid dependencies", async () => {
     const { depsCmd, log } = makeDependencies();
 


### PR DESCRIPTION
Currently the dependency-resolve function logs all dependencies to the verbose level while resolving.

This log was now pulled up to the corresponding cmd functions. Also add establishing tests.