### PR TITLE
refactor: dependency source logic

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -48,6 +48,7 @@ import { ResolveDependenciesService } from "../services/dependency-resolving";
 import { ResolveRemotePackumentService } from "../services/resolve-remote-packument";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
+import { unityRegistryUrl } from "../domain/registry-url";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";
@@ -220,7 +221,11 @@ export function makeAddCmd(
             logValidDependency(log, dependency)
           );
           depsValid
-            .filter((x) => !x.upstream && !x.internal)
+            .filter((x) => {
+              if (x.internal) return false;
+              const isUnityPackage = x.source === unityRegistryUrl;
+              return !isUnityPackage;
+            })
             .map((x) => x.name)
             .forEach((name) => pkgsInScope.push(name));
           // print suggestion for depsInvalid

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -1,6 +1,7 @@
 import { ValidDependency } from "../services/dependency-resolving";
 import { makePackageReference } from "../domain/package-reference";
 import { Logger } from "npmlog";
+import { unityRegistryUrl } from "../domain/registry-url";
 
 /**
  * Logs information about a valid dependency to a logger.
@@ -8,7 +9,8 @@ import { Logger } from "npmlog";
 export function logValidDependency(log: Logger, dependency: ValidDependency) {
   const packageRef = makePackageReference(dependency.name, dependency.version);
   const internalTag = dependency.internal ? "[internal] " : "";
-  const upstreamTag = dependency.upstream ? "[upstream]" : "";
+  const upstreamTag =
+    dependency.source === unityRegistryUrl ? "[upstream]" : "";
   const message = `${packageRef} ${internalTag}${upstreamTag}`;
   log.verbose("dependency", message);
 }

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -7,7 +7,7 @@ import {
   ResolvableVersion,
   tryResolveFromCache,
 } from "../packument-resolving";
-import { unityRegistryUrl } from "../domain/registry-url";
+import { RegistryUrl } from "../domain/registry-url";
 import { recordEntries } from "../utils/record-utils";
 import assert from "assert";
 import { Registry } from "../domain/registry";
@@ -30,9 +30,9 @@ export type DependencyBase = {
  */
 export interface ValidDependency extends DependencyBase {
   /**
-   * Whether this dependency was found on the upstream registry.
+   * The source from which this dependency was resolved.
    */
-  readonly upstream: boolean;
+  readonly source: RegistryUrl;
   /**
    * Whether this dependency is an internal package.
    */
@@ -119,7 +119,7 @@ export function makeResolveDependenciesService(
         processedList.push(entry);
         const isInternal = isInternalPackage(entry.name);
         const isSelf = entry.name === name;
-        let isUpstream = false;
+        let source = upstreamRegistry.url;
         let resolvedVersion = entry.version;
 
         if (!isInternal) {
@@ -150,7 +150,7 @@ export function makeResolveDependenciesService(
           }
 
           // Packument was resolved successfully
-          isUpstream = resolveResult.value.source === unityRegistryUrl;
+          source = resolveResult.value.source;
           resolvedVersion = resolveResult.value.packumentVersion.version;
           packumentCache = addToCache(
             packumentCache,
@@ -182,7 +182,7 @@ export function makeResolveDependenciesService(
           name: entry.name,
           version: resolvedVersion,
           internal: isInternal,
-          upstream: isUpstream,
+          source,
           self: isSelf,
         };
         depsValid.push(dependency);

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -78,14 +78,14 @@ function makeDependencies() {
       {
         name: somePackage,
         version: makeSemanticVersion("1.0.0"),
-        upstream: false,
+        source: exampleRegistryUrl,
         internal: false,
         self: true,
       },
       {
         name: otherPackage,
         version: makeSemanticVersion("1.0.0"),
-        upstream: false,
+        source: exampleRegistryUrl,
         internal: false,
         self: false,
       },

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -29,14 +29,14 @@ function makeDependencies() {
   resolveDependencies.mockResolvedValue([
     [
       {
-        upstream: false,
+        source: exampleRegistryUrl,
         internal: false,
         self: true,
         name: somePackage,
         version: makeSemanticVersion("1.2.3"),
       },
       {
-        upstream: false,
+        source: exampleRegistryUrl,
         internal: false,
         self: false,
         name: otherPackage,


### PR DESCRIPTION
Currently the resolved dependencies have a flag indicating whether they are resolved from the primary or upstream registry.

To prepare for the case where the app might use n registries (#49) refactor to instead specify the package source.