### PR TITLE
refactor: cmd view

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,7 +71,7 @@ const removeCmd = makeRemoveCmd(
   writeProjectManifest,
   log
 );
-const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument, log);
+const viewCmd = makeViewCmd(parseEnv, fetchPackument, log);
 
 // update-notifier
 


### PR DESCRIPTION
Cmd-view does not really need access to the resolve-packument service since that one is used for resolving specific versions, but cmd-view only needs the packument itself.