### PR TITLE
refactor: remove unseen logs

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,13 +41,13 @@ const parseEnv = makeParseEnvService(log);
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService();
 const npmLogin = makeNpmLoginService(regClient);
-const searchRegistry = makeSearchRegistryService(log);
+const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =
   makeResolveRemotePackumentService(fetchPackument);
 const resolveDependencies = makeResolveDependenciesService(
   resolveRemotePackument
 );
-const getAllPackuments = makeGetAllPackumentsService(log);
+const getAllPackuments = makeGetAllPackumentsService();
 
 const addCmd = makeAddCmd(
   parseEnv,

--- a/src/services/get-all-packuments.ts
+++ b/src/services/get-all-packuments.ts
@@ -4,7 +4,6 @@ import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { getNpmFetchOptions, SearchedPackument } from "./search-registry";
 import { DomainName } from "../domain/domain-name";
-import { Logger } from "npmlog";
 
 /**
  * The result of querying the /-/all endpoint.
@@ -25,13 +24,11 @@ export type GetAllPackumentsService = (
 /**
  * Makes a {@link GetAllPackumentsService} service.
  */
-export function makeGetAllPackumentsService(
-  log: Logger
-): GetAllPackumentsService {
+export function makeGetAllPackumentsService(): GetAllPackumentsService {
   return (registry) => {
     return new AsyncResult(
       npmFetch
-        .json("/-/all", getNpmFetchOptions(log, registry))
+        .json("/-/all", getNpmFetchOptions(registry))
         .then((result) => Ok(result as AllPackumentsResult))
         .catch((error) => {
           assertIsHttpError(error);

--- a/src/services/search-registry.ts
+++ b/src/services/search-registry.ts
@@ -5,7 +5,6 @@ import { assertIsHttpError } from "../utils/error-type-guards";
 import { UnityPackument } from "../domain/packument";
 import { SemanticVersion } from "../domain/semantic-version";
 import { Registry } from "../domain/registry";
-import { Logger } from "npmlog";
 
 /**
  * A type representing a searched packument. Instead of having all versions
@@ -31,11 +30,9 @@ export type SearchRegistryService = (
  * Get npm fetch options.
  */
 export const getNpmFetchOptions = function (
-  log: Logger,
   registry: Registry
 ): npmFetch.Options {
   const opts: npmSearch.Options = {
-    log,
     registry: registry.url,
   };
   const auth = registry.auth;
@@ -46,10 +43,10 @@ export const getNpmFetchOptions = function (
 /**
  * Makes a {@link SearchRegistryService} function.
  */
-export function makeSearchRegistryService(log: Logger): SearchRegistryService {
+export function makeSearchRegistryService(): SearchRegistryService {
   return (registry, keyword) => {
     return new AsyncResult(
-      npmSearch(keyword, getNpmFetchOptions(log, registry))
+      npmSearch(keyword, getNpmFetchOptions(registry))
         // NOTE: The results of the search will be packument objects, so we can change the type
         .then((results) => Ok(results as SearchedPackument[]))
         .catch((error) => {

--- a/test/services/get-all-packuments.test.ts
+++ b/test/services/get-all-packuments.test.ts
@@ -2,7 +2,6 @@ import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
 import { makeGetAllPackumentsService } from "../../src/services/get-all-packuments";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { makeMockLogger } from "../cli/log.mock";
 
 jest.mock("npm-registry-fetch");
 
@@ -12,9 +11,7 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const log = makeMockLogger();
-
-  const getAllPackuments = makeGetAllPackumentsService(log);
+  const getAllPackuments = makeGetAllPackumentsService();
   return { getAllPackuments } as const;
 }
 

--- a/test/services/search-registry.test.ts
+++ b/test/services/search-registry.test.ts
@@ -4,7 +4,6 @@ import { HttpErrorBase } from "npm-registry-fetch";
 import { makeSearchRegistryService } from "../../src/services/search-registry";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { makeMockLogger } from "../cli/log.mock";
 
 jest.mock("libnpmsearch");
 
@@ -14,9 +13,7 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const log = makeMockLogger();
-
-  const searchRegistry = makeSearchRegistryService(log);
+  const searchRegistry = makeSearchRegistryService();
   return { searchRegistry } as const;
 }
 


### PR DESCRIPTION
The registry service takes a logger to log diagnostic information. These logs should not really be seen by the user and thus should not use the "front-end" logger.