### PR TITLE
refactor: extract utility function

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -23,6 +23,7 @@ import {
 import {
   addDependency,
   addTestable,
+  hasDependency,
   mapScopedRegistry,
   UnityProjectManifest,
 } from "../domain/project-manifest";
@@ -231,9 +232,10 @@ export function makeAddCmd(
           let isAnyDependencyUnresolved = false;
           depsInvalid.forEach((depObj) => {
             logPackumentResolveError(log, depObj.name, depObj.reason);
-            const resolvedVersion = manifest.dependencies[depObj.name];
-            const wasResolved = Boolean(resolvedVersion);
-            if (!wasResolved) {
+
+            // If the manifest already has the dependency than it does not
+            // really matter that it was not resolved.
+            if (!hasDependency(manifest, depObj.name)) {
               isAnyDependencyUnresolved = true;
               if (depObj.reason instanceof VersionNotFoundError)
                 log.notice(

--- a/src/domain/project-manifest.ts
+++ b/src/domain/project-manifest.ts
@@ -171,3 +171,13 @@ export function pruneManifest(
     ),
   };
 }
+
+/**
+ * Checks if a manifest has a dependency on a specific package.
+ */
+export function hasDependency(
+  manifest: UnityProjectManifest,
+  packageName: DomainName
+): boolean {
+  return packageName in manifest.dependencies;
+}

--- a/test/domain/project-manifest.test.ts
+++ b/test/domain/project-manifest.test.ts
@@ -2,6 +2,7 @@ import {
   addDependency,
   addTestable,
   emptyProjectManifest,
+  hasDependency,
   mapScopedRegistry,
   removeDependency,
   setScopedRegistry,
@@ -14,6 +15,7 @@ import { makeRegistryUrl } from "../../src/domain/registry-url";
 import fc from "fast-check";
 import { arbDomainName } from "./domain-name.arb";
 import { exampleRegistryUrl } from "./data-registry";
+import { buildProjectManifest } from "./data-project-manifest";
 
 describe("project-manifest", () => {
   describe("dependency", () => {
@@ -181,6 +183,23 @@ describe("project-manifest", () => {
       manifest = addTestable(manifest, makeDomainName("a"));
 
       expect(manifest.testables).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("has dependency", () => {
+    it("should be true if manifest has dependency", () => {
+      const packageName = makeDomainName("com.some.package");
+      const manifest = buildProjectManifest((manifest) =>
+        manifest.addDependency(packageName, "1.0.0", true, true)
+      );
+
+      expect(hasDependency(manifest, packageName)).toBeTruthy();
+    });
+
+    it("should be false if manifest does not have dependency", () => {
+      const packageName = makeDomainName("com.some.package");
+
+      expect(hasDependency(emptyProjectManifest, packageName)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
This change extracts a utility function for checking if a manifest has a dependency.

Also adds test and a short explanatory comment where it is used.