### PR TITLE
refactor: make function generic

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -43,12 +43,12 @@ import {
   logManifestSaveError,
   logPackumentResolveError,
 } from "./error-logging";
-import { tryGetTargetEditorVersionFor } from "../domain/packument";
 import { ResolveDependenciesService } from "../services/dependency-resolving";
 import { ResolveRemotePackumentService } from "../services/resolve-remote-packument";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
 import { unityRegistryUrl } from "../domain/registry-url";
+import { tryGetTargetEditorVersionFor } from "../domain/package-manifest";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";

--- a/src/domain/package-manifest.ts
+++ b/src/domain/package-manifest.ts
@@ -129,7 +129,7 @@ export function dependenciesOf(
  * with all Unity version.
  */
 export function tryGetTargetEditorVersionFor(
-  packageManifest: UnityPackageManifest
+  packageManifest: Pick<UnityPackageManifest, "unity" | "unityRelease">
 ): Result<EditorVersion | null, InvalidTargetEditorError> {
   if (packageManifest.unity === undefined) return Ok(null);
 

--- a/src/domain/package-manifest.ts
+++ b/src/domain/package-manifest.ts
@@ -2,6 +2,9 @@ import { DomainName } from "./domain-name";
 import { SemanticVersion } from "./semantic-version";
 import { Maintainer } from "@npm/types";
 import { recordEntries } from "../utils/record-utils";
+import { Err, Ok, Result } from "ts-results-es";
+import { EditorVersion, tryParseEditorVersion } from "./editor-version";
+import { InvalidTargetEditorError } from "./packument";
 
 type MajorMinor = `${number}.${number}`;
 
@@ -117,4 +120,27 @@ export function dependenciesOf(
   [dependencyName: DomainName, dependencyVersion: SemanticVersion]
 > {
   return recordEntries(packageManifest["dependencies"] || {});
+}
+
+/**
+ * Extracts the target editor-version from a package-manifest.
+ * @param packageManifest The manifest for which to get the editor.
+ * @returns The editor-version or null if the package is compatible
+ * with all Unity version.
+ */
+export function tryGetTargetEditorVersionFor(
+  packageManifest: UnityPackageManifest
+): Result<EditorVersion | null, InvalidTargetEditorError> {
+  if (packageManifest.unity === undefined) return Ok(null);
+
+  const majorMinor = packageManifest.unity;
+  const release =
+    packageManifest.unityRelease !== undefined
+      ? `.${packageManifest.unityRelease}`
+      : "";
+  const versionString = `${majorMinor}${release}`;
+  const parsed = tryParseEditorVersion(versionString);
+  return parsed !== null
+    ? Ok(parsed)
+    : Err(new InvalidTargetEditorError(versionString));
 }

--- a/src/domain/packument.ts
+++ b/src/domain/packument.ts
@@ -3,8 +3,6 @@ import { DomainName } from "./domain-name";
 import { UnityPackageManifest } from "./package-manifest";
 import { PackageId } from "./package-id";
 import { Dist, Maintainer } from "@npm/types";
-import { Err, Ok, Result } from "ts-results-es";
-import { EditorVersion, tryParseEditorVersion } from "./editor-version";
 import { CustomError } from "ts-custom-error";
 
 /**
@@ -119,29 +117,6 @@ export class InvalidTargetEditorError extends CustomError {
   ) {
     super();
   }
-}
-
-/**
- * Extracts the target editor-version from a package-manifest.
- * @param packageManifest The manifest for which to get the editor.
- * @returns The editor-version or null if the package is compatible
- * with all Unity version.
- */
-export function tryGetTargetEditorVersionFor(
-  packageManifest: UnityPackageManifest
-): Result<EditorVersion | null, InvalidTargetEditorError> {
-  if (packageManifest.unity === undefined) return Ok(null);
-
-  const majorMinor = packageManifest.unity;
-  const release =
-    packageManifest.unityRelease !== undefined
-      ? `.${packageManifest.unityRelease}`
-      : "";
-  const versionString = `${majorMinor}${release}`;
-  const parsed = tryParseEditorVersion(versionString);
-  return parsed !== null
-    ? Ok(parsed)
-    : Err(new InvalidTargetEditorError(versionString));
 }
 
 /**

--- a/src/domain/packument.ts
+++ b/src/domain/packument.ts
@@ -122,20 +122,20 @@ export class InvalidTargetEditorError extends CustomError {
 }
 
 /**
- * Extracts the target editor-version from a packument-version.
- * @param packumentVersion The packument-version for which to get the editor.
- * @returns The editor-version or null if the packument is compatible
+ * Extracts the target editor-version from a package-manifest.
+ * @param packageManifest The manifest for which to get the editor.
+ * @returns The editor-version or null if the package is compatible
  * with all Unity version.
  */
 export function tryGetTargetEditorVersionFor(
-  packumentVersion: UnityPackumentVersion
+  packageManifest: UnityPackageManifest
 ): Result<EditorVersion | null, InvalidTargetEditorError> {
-  if (packumentVersion.unity === undefined) return Ok(null);
+  if (packageManifest.unity === undefined) return Ok(null);
 
-  const majorMinor = packumentVersion.unity;
+  const majorMinor = packageManifest.unity;
   const release =
-    packumentVersion.unityRelease !== undefined
-      ? `.${packumentVersion.unityRelease}`
+    packageManifest.unityRelease !== undefined
+      ? `.${packageManifest.unityRelease}`
       : "";
   const versionString = `${majorMinor}${release}`;
   const parsed = tryParseEditorVersion(versionString);

--- a/test/domain/data-project-manifest.ts
+++ b/test/domain/data-project-manifest.ts
@@ -3,10 +3,10 @@ import { isDomainName } from "../../src/domain/domain-name";
 import { isSemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
 import {
-  setDependency,
   addTestable,
   emptyProjectManifest,
   mapScopedRegistry,
+  setDependency,
   UnityProjectManifest,
 } from "../../src/domain/project-manifest";
 import { exampleRegistryUrl } from "./data-registry";

--- a/test/domain/package-manifest.test.ts
+++ b/test/domain/package-manifest.test.ts
@@ -1,14 +1,12 @@
 import {
   dependenciesOf,
   tryGetTargetEditorVersionFor,
+  UnityPackageManifest,
 } from "../../src/domain/package-manifest";
 import fc from "fast-check";
 import { arbDomainName } from "./domain-name.arb";
 import { makeEditorVersion } from "../../src/domain/editor-version";
-import {
-  InvalidTargetEditorError,
-  UnityPackumentVersion,
-} from "../../src/domain/packument";
+import { InvalidTargetEditorError } from "../../src/domain/packument";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 
 describe("package manifest", () => {
@@ -45,13 +43,13 @@ describe("package manifest", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const expected = makeEditorVersion(2020, 3);
-          const packumentVersion: UnityPackumentVersion = {
+          const packageManifest: UnityPackageManifest = {
             name: packumentName,
             version: makeSemanticVersion("1.0.0"),
             unity: "2020.3",
           };
 
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
+          const result = tryGetTargetEditorVersionFor(packageManifest);
 
           expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
         })
@@ -62,14 +60,14 @@ describe("package manifest", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const expected = makeEditorVersion(2020, 3, 1);
-          const packumentVersion: UnityPackumentVersion = {
+          const packageManifest: UnityPackageManifest = {
             name: packumentName,
             version: makeSemanticVersion("1.0.0"),
             unity: "2020.3",
             unityRelease: "1",
           };
 
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
+          const result = tryGetTargetEditorVersionFor(packageManifest);
 
           expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
         })
@@ -79,12 +77,12 @@ describe("package manifest", () => {
     it("should be null for missing major.minor", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
-          const packumentVersion: UnityPackumentVersion = {
+          const packageManifest: UnityPackageManifest = {
             name: packumentName,
             version: makeSemanticVersion("1.0.0"),
           };
 
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
+          const result = tryGetTargetEditorVersionFor(packageManifest);
 
           expect(result).toBeOk((actual) => expect(actual).toBeNull());
         })
@@ -94,7 +92,7 @@ describe("package manifest", () => {
     it("should fail for bad version", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
-          const packumentVersion: UnityPackumentVersion = {
+          const packageManifest: UnityPackageManifest = {
             name: packumentName,
             version: makeSemanticVersion("1.0.0"),
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -102,7 +100,7 @@ describe("package manifest", () => {
             unity: "bad version",
           };
 
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
+          const result = tryGetTargetEditorVersionFor(packageManifest);
 
           expect(result).toBeError((actual) =>
             expect(actual).toBeInstanceOf(InvalidTargetEditorError)

--- a/test/domain/package-manifest.test.ts
+++ b/test/domain/package-manifest.test.ts
@@ -1,13 +1,9 @@
 import {
   dependenciesOf,
   tryGetTargetEditorVersionFor,
-  UnityPackageManifest,
 } from "../../src/domain/package-manifest";
-import fc from "fast-check";
-import { arbDomainName } from "./domain-name.arb";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { InvalidTargetEditorError } from "../../src/domain/packument";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
 
 describe("package manifest", () => {
   describe("get dependency list", () => {
@@ -40,72 +36,50 @@ describe("package manifest", () => {
 
   describe("determine editor-version", () => {
     it("should get version without release", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const expected = makeEditorVersion(2020, 3);
-          const packageManifest: UnityPackageManifest = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-            unity: "2020.3",
-          };
+      const expected = makeEditorVersion(2020, 3);
+      const packageManifest = {
+        unity: "2020.3",
+      } as const;
 
-          const result = tryGetTargetEditorVersionFor(packageManifest);
+      const result = tryGetTargetEditorVersionFor(packageManifest);
 
-          expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
-        })
-      );
+      expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
     });
 
     it("should get version with release", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const expected = makeEditorVersion(2020, 3, 1);
-          const packageManifest: UnityPackageManifest = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-            unity: "2020.3",
-            unityRelease: "1",
-          };
+      const expected = makeEditorVersion(2020, 3, 1);
+      const packageManifest = {
+        unity: "2020.3",
+        unityRelease: "1",
+      } as const;
 
-          const result = tryGetTargetEditorVersionFor(packageManifest);
+      const result = tryGetTargetEditorVersionFor(packageManifest);
 
-          expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
-        })
-      );
+      expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
     });
 
     it("should be null for missing major.minor", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const packageManifest: UnityPackageManifest = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-          };
+      const packageManifest = {};
 
-          const result = tryGetTargetEditorVersionFor(packageManifest);
+      const result = tryGetTargetEditorVersionFor(packageManifest);
 
-          expect(result).toBeOk((actual) => expect(actual).toBeNull());
-        })
-      );
+      expect(result).toBeOk((actual) => expect(actual).toBeNull());
     });
 
     it("should fail for bad version", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const packageManifest: UnityPackageManifest = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            unity: "bad version",
-          };
+      const packageManifest = {
+        unity: "bad version",
+      } as const;
 
-          const result = tryGetTargetEditorVersionFor(packageManifest);
+      const result = tryGetTargetEditorVersionFor(
+        // We pass a package with a bad value on purpose here
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        packageManifest
+      );
 
-          expect(result).toBeError((actual) =>
-            expect(actual).toBeInstanceOf(InvalidTargetEditorError)
-          );
-        })
+      expect(result).toBeError((actual) =>
+        expect(actual).toBeInstanceOf(InvalidTargetEditorError)
       );
     });
   });

--- a/test/domain/packument.test.ts
+++ b/test/domain/packument.test.ts
@@ -1,14 +1,8 @@
 import {
-  InvalidTargetEditorError,
   tryGetLatestVersion,
   tryGetPackumentVersion,
-  tryGetTargetEditorVersionFor,
-  UnityPackumentVersion,
 } from "../../src/domain/packument";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
-import fc from "fast-check";
-import { arbDomainName } from "./domain-name.arb";
-import { makeEditorVersion } from "../../src/domain/editor-version";
 import { buildPackument } from "./data-packument";
 
 describe("packument", () => {
@@ -18,78 +12,6 @@ describe("packument", () => {
         "dist-tags": { latest: makeSemanticVersion("1.0.0") },
       });
       expect(version).toEqual("1.0.0");
-    });
-  });
-
-  describe("determine editor-version", () => {
-    it("should get version without release", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const expected = makeEditorVersion(2020, 3);
-          const packumentVersion: UnityPackumentVersion = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-            unity: "2020.3",
-          };
-
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
-
-          expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
-        })
-      );
-    });
-
-    it("should get version with release", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const expected = makeEditorVersion(2020, 3, 1);
-          const packumentVersion: UnityPackumentVersion = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-            unity: "2020.3",
-            unityRelease: "1",
-          };
-
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
-
-          expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
-        })
-      );
-    });
-
-    it("should be null for missing major.minor", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const packumentVersion: UnityPackumentVersion = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-          };
-
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
-
-          expect(result).toBeOk((actual) => expect(actual).toBeNull());
-        })
-      );
-    });
-
-    it("should fail for bad version", () => {
-      fc.assert(
-        fc.property(arbDomainName, (packumentName) => {
-          const packumentVersion: UnityPackumentVersion = {
-            name: packumentName,
-            version: makeSemanticVersion("1.0.0"),
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            unity: "bad version",
-          };
-
-          const result = tryGetTargetEditorVersionFor(packumentVersion);
-
-          expect(result).toBeError((actual) =>
-            expect(actual).toBeInstanceOf(InvalidTargetEditorError)
-          );
-        })
-      );
     });
   });
 


### PR DESCRIPTION
Makes the `tryGetTargetEditorVersionFor` function more generic. Please see commit messages for more details.