### PR TITLE
refactor: resolve latest version service

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,6 +29,7 @@ import {
   makeProjectManifestWriter,
 } from "../io/project-manifest-io";
 import npmlog from "npmlog";
+import { makeResolveLatestVersionService } from "../services/resolve-latest-version";
 
 // Composition root
 
@@ -44,8 +45,10 @@ const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =
   makeResolveRemotePackumentService(fetchPackument);
+const resolveLatestVersion = makeResolveLatestVersionService(fetchPackument);
 const resolveDependencies = makeResolveDependenciesService(
-  resolveRemotePackument
+  resolveRemotePackument,
+  resolveLatestVersion
 );
 const getAllPackuments = makeGetAllPackumentsService();
 

--- a/src/domain/packument.ts
+++ b/src/domain/packument.ts
@@ -98,7 +98,10 @@ export const tryGetLatestVersion = function (
   packument: VersionedPackument
 ): SemanticVersion | undefined {
   if (hasLatestDistTag(packument)) return packument["dist-tags"].latest;
-  else if (packument.version) return packument.version;
+
+  if (packument.version !== undefined) return packument.version;
+
+  return undefined;
 };
 
 /**

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -1,0 +1,58 @@
+import { Registry } from "../domain/registry";
+import { DomainName } from "../domain/domain-name";
+import { AsyncResult, Err, Ok } from "ts-results-es";
+import { SemanticVersion } from "../domain/semantic-version";
+import { PackumentNotFoundError } from "../common-errors";
+import { FetchPackumentError, FetchPackumentService } from "./fetch-packument";
+import { tryGetLatestVersion } from "../domain/packument";
+import { recordKeys } from "../utils/record-utils";
+import { NoVersionsError } from "../packument-resolving";
+
+/**
+ * Error which may occur when resolving the latest version for a package.
+ */
+export type ResolveLatestVersionError =
+  | PackumentNotFoundError
+  | FetchPackumentError
+  | NoVersionsError;
+
+/**
+ * Service for resolving the latest published version of a package.
+ * @param sources All sources to check for the package.
+ * @param packageName The name of the package to search.
+ */
+export type ResolveLatestVersionService = (
+  sources: ReadonlyArray<Registry>,
+  packageName: DomainName
+) => AsyncResult<SemanticVersion, ResolveLatestVersionError>;
+
+export function makeResolveLatestVersionService(
+  fetchPackument: FetchPackumentService
+): ResolveLatestVersionService {
+  const resolveLatestVersion: ResolveLatestVersionService = (
+    sources,
+    packageName
+  ) => {
+    if (sources.length === 0)
+      return Err(new PackumentNotFoundError()).toAsyncResult();
+
+    const sourceToCheck = sources[0]!;
+    return fetchPackument(sourceToCheck, packageName).andThen(
+      (maybePackument) => {
+        if (maybePackument === null)
+          return resolveLatestVersion(sources.slice(1), packageName);
+
+        const latestVersion = tryGetLatestVersion(maybePackument);
+        if (latestVersion !== undefined) return Ok(latestVersion);
+
+        const availableVersions = recordKeys(maybePackument.versions);
+        if (availableVersions.length === 0)
+          return Err(new NoVersionsError()).toAsyncResult();
+
+        return Ok(availableVersions.at(-1)!);
+      }
+    );
+  };
+
+  return resolveLatestVersion;
+}

--- a/test/domain/packument.test.ts
+++ b/test/domain/packument.test.ts
@@ -6,12 +6,33 @@ import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { buildPackument } from "./data-packument";
 
 describe("packument", () => {
-  describe("tryGetLatestVersion", () => {
-    it("should get version from dist-tags", async () => {
-      const version = tryGetLatestVersion({
+  describe("get latest version", () => {
+    it("should first get version from dist-tags", async () => {
+      const packument = {
         "dist-tags": { latest: makeSemanticVersion("1.0.0") },
-      });
+      };
+
+      const version = tryGetLatestVersion(packument);
+
       expect(version).toEqual("1.0.0");
+    });
+
+    it("should then get version from version property", async () => {
+      const packument = {
+        version: makeSemanticVersion("1.0.0"),
+      };
+
+      const version = tryGetLatestVersion(packument);
+
+      expect(version).toEqual("1.0.0");
+    });
+
+    it("should be undefined if version can not be found", () => {
+      const packument = {};
+
+      const version = tryGetLatestVersion(packument);
+
+      expect(version).toBeUndefined();
     });
   });
 

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -1,0 +1,87 @@
+import { mockService } from "./service.mock";
+import { FetchPackumentService } from "../../src/services/fetch-packument";
+import { makeResolveLatestVersionService } from "../../src/services/resolve-latest-version";
+import { makeDomainName } from "../../src/domain/domain-name";
+import { PackumentNotFoundError } from "../../src/common-errors";
+import { Ok } from "ts-results-es";
+import { UnityPackument } from "../../src/domain/packument";
+import { Registry } from "../../src/domain/registry";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { NoVersionsError } from "../../src/packument-resolving";
+import { unityRegistryUrl } from "../../src/domain/registry-url";
+
+describe("resolve latest version service", () => {
+  const somePackage = makeDomainName("com.some.package");
+
+  const exampleRegistry: Registry = { url: exampleRegistryUrl, auth: null };
+  const upstreamRegistry: Registry = { url: unityRegistryUrl, auth: null };
+
+  function makeDependencies() {
+    const fetchPackument = mockService<FetchPackumentService>();
+
+    const resolveLatestVersion =
+      makeResolveLatestVersionService(fetchPackument);
+    return { resolveLatestVersion, fetchPackument } as const;
+  }
+
+  it("should fail if not given any sources", async () => {
+    const { resolveLatestVersion } = makeDependencies();
+
+    const result = await resolveLatestVersion([], somePackage).promise;
+
+    expect(result).toBeError((error) =>
+      expect(error).toBeInstanceOf(PackumentNotFoundError)
+    );
+  });
+
+  it("should get specified latest version from first packument", async () => {
+    const { resolveLatestVersion, fetchPackument } = makeDependencies();
+    const packument = { "dist-tags": { latest: "1.0.0" } } as UnityPackument;
+    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+
+    const result = await resolveLatestVersion([exampleRegistry], somePackage)
+      .promise;
+
+    expect(result).toBeOk((value) => expect(value).toEqual("1.0.0"));
+  });
+
+  it("should get latest listed version from first packument if no latest was specified", async () => {
+    const { resolveLatestVersion, fetchPackument } = makeDependencies();
+    const packument = {
+      versions: { ["1.0.0"]: {} },
+    } as unknown as UnityPackument;
+    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+
+    const result = await resolveLatestVersion([exampleRegistry], somePackage)
+      .promise;
+
+    expect(result).toBeOk((value) => expect(value).toEqual("1.0.0"));
+  });
+
+  it("should fail if packument had no versions", async () => {
+    const { resolveLatestVersion, fetchPackument } = makeDependencies();
+    const packument = { versions: {} } as UnityPackument;
+    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+
+    const result = await resolveLatestVersion([exampleRegistry], somePackage)
+      .promise;
+
+    expect(result).toBeError((error) =>
+      expect(error).toBeInstanceOf(NoVersionsError)
+    );
+  });
+
+  it("should check all registries", async () => {
+    const { resolveLatestVersion, fetchPackument } = makeDependencies();
+    const packument = { "dist-tags": { latest: "1.0.0" } } as UnityPackument;
+    fetchPackument.mockReturnValueOnce(Ok(null).toAsyncResult());
+    fetchPackument.mockReturnValueOnce(Ok(packument).toAsyncResult());
+
+    const result = await resolveLatestVersion(
+      [exampleRegistry, upstreamRegistry],
+      somePackage
+    ).promise;
+
+    expect(result).toBeOk((value) => expect(value).toEqual("1.0.0"));
+  });
+});


### PR DESCRIPTION
Add and use a new service that can resolve the latest version for a remote package, given only its name.