### PR TITLE
refactor: use result return

### DIFF
--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -73,23 +73,25 @@ function makeDependencies() {
   );
 
   const resolveDependencies = mockService<ResolveDependenciesService>();
-  resolveDependencies.mockResolvedValue([
-    [
-      {
-        name: somePackage,
-        version: makeSemanticVersion("1.0.0"),
-        source: exampleRegistryUrl,
-        self: true,
-      },
-      {
-        name: otherPackage,
-        version: makeSemanticVersion("1.0.0"),
-        source: exampleRegistryUrl,
-        self: false,
-      },
-    ],
-    [],
-  ]);
+  resolveDependencies.mockResolvedValue(
+    Ok([
+      [
+        {
+          name: somePackage,
+          version: makeSemanticVersion("1.0.0"),
+          source: exampleRegistryUrl,
+          self: true,
+        },
+        {
+          name: otherPackage,
+          version: makeSemanticVersion("1.0.0"),
+          source: exampleRegistryUrl,
+          self: false,
+        },
+      ],
+      [],
+    ])
+  );
 
   const loadProjectManifest = mockService<LoadProjectManifest>();
   mockProjectManifest(loadProjectManifest, emptyProjectManifest);
@@ -358,16 +360,18 @@ describe("cmd-add", () => {
 
   it("should notify of unresolved dependencies", async () => {
     const { addCmd, resolveDependencies, log } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
+          },
+        ],
+      ])
+    );
 
     await addCmd(somePackage, {
       _global: {},
@@ -398,16 +402,18 @@ describe("cmd-add", () => {
 
   it("should suggest to install missing dependency version manually", async () => {
     const { addCmd, resolveDependencies, log } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
+          },
+        ],
+      ])
+    );
 
     await addCmd(somePackage, {
       _global: {},
@@ -421,16 +427,18 @@ describe("cmd-add", () => {
 
   it("should suggest to run with force if dependency could not be resolved", async () => {
     const { addCmd, resolveDependencies, log } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
+          },
+        ],
+      ])
+    );
 
     await addCmd(somePackage, {
       _global: {},
@@ -461,16 +469,18 @@ describe("cmd-add", () => {
 
   it("should fail if dependency could not be resolved and not running with force", async () => {
     const { addCmd, resolveDependencies } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
+          },
+        ],
+      ])
+    );
 
     const result = await addCmd(somePackage, {
       _global: {},
@@ -483,16 +493,18 @@ describe("cmd-add", () => {
 
   it("should add package with unresolved dependency when running with force", async () => {
     const { addCmd, resolveDependencies } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.0.0"), []),
+          },
+        ],
+      ])
+    );
 
     const result = await addCmd(somePackage, {
       _global: {},

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -26,23 +26,25 @@ function makeDependencies() {
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
   const resolveDependencies = mockService<ResolveDependenciesService>();
-  resolveDependencies.mockResolvedValue([
-    [
-      {
-        source: exampleRegistryUrl,
-        self: true,
-        name: somePackage,
-        version: makeSemanticVersion("1.2.3"),
-      },
-      {
-        source: exampleRegistryUrl,
-        self: false,
-        name: otherPackage,
-        version: makeSemanticVersion("1.2.3"),
-      },
-    ],
-    [],
-  ]);
+  resolveDependencies.mockResolvedValue(
+    Ok([
+      [
+        {
+          source: exampleRegistryUrl,
+          self: true,
+          name: somePackage,
+          version: makeSemanticVersion("1.2.3"),
+        },
+        {
+          source: exampleRegistryUrl,
+          self: false,
+          name: otherPackage,
+          version: makeSemanticVersion("1.2.3"),
+        },
+      ],
+      [],
+    ])
+  );
 
   const log = makeMockLogger();
 
@@ -135,16 +137,18 @@ describe("cmd-deps", () => {
 
   it("should log missing dependency", async () => {
     const { depsCmd, resolveDependencies, log } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new PackumentNotFoundError(),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new PackumentNotFoundError(),
+          },
+        ],
+      ])
+    );
 
     await depsCmd(somePackage, {
       _global: {},
@@ -158,16 +162,18 @@ describe("cmd-deps", () => {
 
   it("should log missing dependency version", async () => {
     const { depsCmd, resolveDependencies, log } = makeDependencies();
-    resolveDependencies.mockResolvedValue([
-      [],
-      [
-        {
-          name: otherPackage,
-          self: false,
-          reason: new VersionNotFoundError(makeSemanticVersion("1.2.3"), []),
-        },
-      ],
-    ]);
+    resolveDependencies.mockResolvedValue(
+      Ok([
+        [],
+        [
+          {
+            name: otherPackage,
+            self: false,
+            reason: new VersionNotFoundError(makeSemanticVersion("1.2.3"), []),
+          },
+        ],
+      ])
+    );
 
     await depsCmd(somePackage, {
       _global: {},


### PR DESCRIPTION
Refactor dependency-resolve service to use result-based return. This way it integrates more nicely into the service eco-system.