### PR TITLE
refactor: dependency-resolve service

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -214,8 +214,7 @@ export function makeAddCmd(
             `fetch: ${makePackageReference(name, requestedVersion)}`
           );
           const resolveResult = await resolveDependencies(
-            env.registry,
-            env.upstreamRegistry,
+            [env.registry, env.upstreamRegistry],
             name,
             requestedVersion,
             true

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -68,8 +68,7 @@ export function makeDepsCmd(
       `fetch: ${makePackageReference(name, version)}, deep=${deep}`
     );
     const resolveResult = await resolveDependencies(
-      env.registry,
-      env.upstreamRegistry,
+      [env.registry, env.upstreamRegistry],
       name,
       version,
       deep


### PR DESCRIPTION
Currently the dependency resolve service expects the registries to check as two distinct parameters.

This change refactors it to allow it to use any number of sources instead.