### PR TITLE
refactor: make function more focused

### DIFF
--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -38,6 +38,12 @@ export function makeResolveRemotePackumentService(
         return Ok(maybePackument);
       })
       .andThen((packument) =>
-        tryResolveFromPackument(packument, requestedVersion, source.url)
+        tryResolveFromPackument(packument, requestedVersion).map(
+          (packumentVersion) => ({
+            packument,
+            packumentVersion,
+            source: source.url,
+          })
+        )
       );
 }

--- a/test/services/packument-resolving.mock.ts
+++ b/test/services/packument-resolving.mock.ts
@@ -26,12 +26,11 @@ export function mockResolvedPackuments(
       if (matchingEntry === undefined)
         return Err(new PackumentNotFoundError()).toAsyncResult();
 
-      const resolvedVersionResult = tryResolveFromPackument(
-        matchingEntry[1],
-        requestedVersion,
-        matchingEntry[0]
-      );
-      return resolvedVersionResult.toAsyncResult();
+      const source = matchingEntry[0];
+      const packument = matchingEntry[1];
+      return tryResolveFromPackument(packument, requestedVersion)
+        .map((packumentVersion) => ({ packument, packumentVersion, source }))
+        .toAsyncResult();
     }
   );
 }

--- a/test/utils/packument-resolving.test.ts
+++ b/test/utils/packument-resolving.test.ts
@@ -4,7 +4,6 @@ import {
   tryResolveFromPackument,
   VersionNotFoundError,
 } from "../../src/packument-resolving";
-import { exampleRegistryUrl } from "../domain/data-registry";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 
@@ -12,7 +11,6 @@ const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
 const someHighVersion = makeSemanticVersion("2.0.0");
 const someLowVersion = makeSemanticVersion("1.0.0");
-const someSource = exampleRegistryUrl;
 const somePackument = buildPackument(somePackage, (packument) =>
   packument
     .addVersion(someLowVersion, (version) =>
@@ -28,11 +26,7 @@ describe("packument resolving", () => {
     it("should fail it packument has no versions", () => {
       const emptyPackument = buildPackument(somePackage);
 
-      const result = tryResolveFromPackument(
-        emptyPackument,
-        "latest",
-        someSource
-      );
+      const result = tryResolveFromPackument(emptyPackument, "latest");
 
       expect(result).toBeError((error) =>
         expect(error).toBeInstanceOf(NoVersionsError)
@@ -40,50 +34,26 @@ describe("packument resolving", () => {
     });
 
     it("should find latest version when requested", () => {
-      const result = tryResolveFromPackument(
-        somePackument,
-        "latest",
-        someSource
-      );
+      const result = tryResolveFromPackument(somePackument, "latest");
 
       expect(result).toBeOk((value) =>
-        expect(value).toMatchObject({
-          packument: somePackument,
-          packumentVersion: somePackument.versions[someHighVersion]!,
-          source: someSource,
-        })
+        expect(value).toEqual(somePackument.versions[someHighVersion]!)
       );
     });
 
     it("should find latest version when requesting no particular version", () => {
-      const result = tryResolveFromPackument(
-        somePackument,
-        undefined,
-        someSource
-      );
+      const result = tryResolveFromPackument(somePackument, undefined);
 
       expect(result).toBeOk((value) =>
-        expect(value).toMatchObject({
-          packument: somePackument,
-          packumentVersion: somePackument.versions[someHighVersion]!,
-          source: someSource,
-        })
+        expect(value).toEqual(somePackument.versions[someHighVersion]!)
       );
     });
 
     it("should find specific version", () => {
-      const result = tryResolveFromPackument(
-        somePackument,
-        someLowVersion,
-        someSource
-      );
+      const result = tryResolveFromPackument(somePackument, someLowVersion);
 
       expect(result).toBeOk((value) =>
-        expect(value).toMatchObject({
-          packument: somePackument,
-          packumentVersion: somePackument.versions[someLowVersion]!,
-          source: someSource,
-        })
+        expect(value).toEqual(somePackument.versions[someLowVersion]!)
       );
     });
 
@@ -92,8 +62,7 @@ describe("packument resolving", () => {
 
       const result = tryResolveFromPackument(
         somePackument,
-        someNonExistentVersion,
-        someSource
+        someNonExistentVersion
       );
 
       expect(result).toBeError((error) =>


### PR DESCRIPTION
The `tryResolveFromPackument` function should be responsible for resolving a specific version from a packument. But currently it's signature also includes errors it can't really produce as well as having context, like the source, injected into it only to produce it as output.

This is not really necessary. We should keep this function simple and add context in the client functions. Refactored for this purpose.