### PR TITLE
refactor: inject dependencies

### DIFF
--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -20,6 +20,7 @@ import { Ok, Result } from "ts-results-es";
 import { NpmrcLoadError, NpmrcSaveError } from "../io/npmrc-io";
 import { AuthNpmrcService } from "../services/npmrc-auth";
 import { Logger } from "npmlog";
+import { WriteTextFile } from "../io/file-io";
 
 /**
  * Errors which may occur when logging in.
@@ -60,6 +61,7 @@ export function makeLoginCmd(
   parseEnv: ParseEnvService,
   authNpmrc: AuthNpmrcService,
   npmLogin: NpmLoginService,
+  writeFile: WriteTextFile,
   getUpmConfigDir: GetUpmConfigDir,
   loadUpmConfig: LoadUpmConfig,
   log: Logger
@@ -92,6 +94,7 @@ export function makeLoginCmd(
       const _auth = encodeBasicAuth(username, password);
       const result = await tryStoreUpmAuth(
         loadUpmConfig,
+        writeFile,
         configDir,
         loginRegistry,
         {
@@ -132,6 +135,7 @@ export function makeLoginCmd(
 
       const storeResult = await tryStoreUpmAuth(
         loadUpmConfig,
+        writeFile,
         configDir,
         loginRegistry,
         {

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,8 +1,8 @@
 import { AuthenticationError, NpmLoginService } from "../services/npm-login";
 import {
+  GetUpmConfigDir,
   GetUpmConfigDirError,
   LoadUpmConfig,
-  tryGetUpmConfigDir,
   tryStoreUpmAuth,
   UpmAuthStoreError,
 } from "../io/upm-config-io";
@@ -60,6 +60,7 @@ export function makeLoginCmd(
   parseEnv: ParseEnvService,
   authNpmrc: AuthNpmrcService,
   npmLogin: NpmLoginService,
+  getUpmConfigDir: GetUpmConfigDir,
   loadUpmConfig: LoadUpmConfig,
   log: Logger
 ): LoginCmd {
@@ -81,7 +82,7 @@ export function makeLoginCmd(
 
     const alwaysAuth = options.alwaysAuth || false;
 
-    const configDirResult = await tryGetUpmConfigDir(env.wsl, env.systemUser)
+    const configDirResult = await getUpmConfigDir(env.wsl, env.systemUser)
       .promise;
     if (configDirResult.isErr()) return configDirResult;
     const configDir = configDirResult.value;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,18 +31,20 @@ import {
 import npmlog from "npmlog";
 import { makeResolveLatestVersionService } from "../services/resolve-latest-version";
 import { makeUpmConfigLoader } from "../io/upm-config-io";
+import { makeTextReader } from "../io/file-io";
 
 // Composition root
 
 const log = npmlog;
 const regClient = new RegClient({ log });
-const loadProjectManifest = makeProjectManifestLoader();
+const readFile = makeTextReader();
+const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter();
-const loadUpmConfig = makeUpmConfigLoader();
+const loadUpmConfig = makeUpmConfigLoader(readFile);
 
-const parseEnv = makeParseEnvService(log, loadUpmConfig);
+const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile);
 const fetchPackument = makeFetchPackumentService(regClient);
-const authNpmrc = makeAuthNpmrcService();
+const authNpmrc = makeAuthNpmrcService(readFile);
 const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -42,6 +42,7 @@ import {
 } from "../io/npmrc-io";
 import { makeCwdGetter, makeHomePathGetter } from "../io/special-paths";
 import { makeProjectVersionLoader } from "../io/project-version-io";
+import { makeSaveAuthToUpmConfigService } from "../services/upm-auth";
 
 // Composition root
 
@@ -79,6 +80,10 @@ const resolveDependencies = makeResolveDependenciesService(
   resolveLatestVersion
 );
 const getAllPackuments = makeGetAllPackumentsService();
+const saveAuthToUpmConfig = makeSaveAuthToUpmConfigService(
+  loadUpmConfig,
+  writeFile
+);
 
 const addCmd = makeAddCmd(
   parseEnv,
@@ -92,9 +97,8 @@ const loginCmd = makeLoginCmd(
   parseEnv,
   authNpmrc,
   npmLogin,
-  writeFile,
   getUpmConfigDir,
-  loadUpmConfig,
+  saveAuthToUpmConfig,
   log
 );
 const searchCmd = makeSearchCmd(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,11 @@ import {
   makeUpmConfigLoader,
 } from "../io/upm-config-io";
 import { makeTextReader } from "../io/file-io";
-import { makeNpmrcLoader, makeNpmrcPathFinder } from "../io/npmrc-io";
+import {
+  makeNpmrcLoader,
+  makeNpmrcPathFinder,
+  makeNpmrcSaver,
+} from "../io/npmrc-io";
 import { makeCwdGetter } from "../io/special-paths";
 
 // Composition root
@@ -50,6 +54,7 @@ const getUpmConfigDir = makeUpmConfigDirGetter();
 const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder();
 const loadNpmrc = makeNpmrcLoader(readFile);
+const saveNpmrc = makeNpmrcSaver();
 
 const parseEnv = makeParseEnvService(
   log,
@@ -59,7 +64,7 @@ const parseEnv = makeParseEnvService(
   getCwd
 );
 const fetchPackument = makeFetchPackumentService(regClient);
-const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc);
+const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);
 const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,7 +30,10 @@ import {
 } from "../io/project-manifest-io";
 import npmlog from "npmlog";
 import { makeResolveLatestVersionService } from "../services/resolve-latest-version";
-import { makeUpmConfigLoader } from "../io/upm-config-io";
+import {
+  makeUpmConfigDirGetter,
+  makeUpmConfigLoader,
+} from "../io/upm-config-io";
 import { makeTextReader } from "../io/file-io";
 import { makeNpmrcPathFinder } from "../io/npmrc-io";
 import { makeCwdGetter } from "../io/special-paths";
@@ -43,10 +46,17 @@ const getCwd = makeCwdGetter();
 const readFile = makeTextReader();
 const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter();
+const getUpmConfigDir = makeUpmConfigDirGetter();
 const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder();
 
-const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile, getCwd);
+const parseEnv = makeParseEnvService(
+  log,
+  getUpmConfigDir,
+  loadUpmConfig,
+  readFile,
+  getCwd
+);
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, readFile);
 const npmLogin = makeNpmLoginService(regClient);
@@ -72,6 +82,7 @@ const loginCmd = makeLoginCmd(
   parseEnv,
   authNpmrc,
   npmLogin,
+  getUpmConfigDir,
   loadUpmConfig,
   log
 );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,7 +40,7 @@ import {
   makeNpmrcPathFinder,
   makeNpmrcSaver,
 } from "../io/npmrc-io";
-import { makeCwdGetter } from "../io/special-paths";
+import { makeCwdGetter, makeHomePathGetter } from "../io/special-paths";
 import { makeProjectVersionLoader } from "../io/project-version-io";
 
 // Composition root
@@ -48,13 +48,14 @@ import { makeProjectVersionLoader } from "../io/project-version-io";
 const log = npmlog;
 const regClient = new RegClient({ log });
 const getCwd = makeCwdGetter();
+const getHomePath = makeHomePathGetter();
 const readFile = makeTextReader();
 const writeFile = makeTextWriter();
 const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter(writeFile);
-const getUpmConfigDir = makeUpmConfigDirGetter();
+const getUpmConfigDir = makeUpmConfigDirGetter(getHomePath);
 const loadUpmConfig = makeUpmConfigLoader(readFile);
-const findNpmrcPath = makeNpmrcPathFinder();
+const findNpmrcPath = makeNpmrcPathFinder(getHomePath);
 const loadNpmrc = makeNpmrcLoader(readFile);
 const saveNpmrc = makeNpmrcSaver(writeFile);
 const loadProjectVersion = makeProjectVersionLoader(readFile);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,6 +41,7 @@ import {
   makeNpmrcSaver,
 } from "../io/npmrc-io";
 import { makeCwdGetter } from "../io/special-paths";
+import { makeProjectVersionLoader } from "../io/project-version-io";
 
 // Composition root
 
@@ -56,13 +57,14 @@ const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder();
 const loadNpmrc = makeNpmrcLoader(readFile);
 const saveNpmrc = makeNpmrcSaver(writeFile);
+const loadProjectVersion = makeProjectVersionLoader(readFile);
 
 const parseEnv = makeParseEnvService(
   log,
   getUpmConfigDir,
   loadUpmConfig,
-  readFile,
-  getCwd
+  getCwd,
+  loadProjectVersion
 );
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,7 @@ import {
   makeUpmConfigLoader,
 } from "../io/upm-config-io";
 import { makeTextReader } from "../io/file-io";
-import { makeNpmrcPathFinder } from "../io/npmrc-io";
+import { makeNpmrcLoader, makeNpmrcPathFinder } from "../io/npmrc-io";
 import { makeCwdGetter } from "../io/special-paths";
 
 // Composition root
@@ -49,6 +49,7 @@ const writeProjectManifest = makeProjectManifestWriter();
 const getUpmConfigDir = makeUpmConfigDirGetter();
 const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder();
+const loadNpmrc = makeNpmrcLoader(readFile);
 
 const parseEnv = makeParseEnvService(
   log,
@@ -58,7 +59,7 @@ const parseEnv = makeParseEnvService(
   getCwd
 );
 const fetchPackument = makeFetchPackumentService(regClient);
-const authNpmrc = makeAuthNpmrcService(findNpmrcPath, readFile);
+const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc);
 const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -34,7 +34,7 @@ import {
   makeUpmConfigDirGetter,
   makeUpmConfigLoader,
 } from "../io/upm-config-io";
-import { makeTextReader } from "../io/file-io";
+import { makeTextReader, makeTextWriter } from "../io/file-io";
 import {
   makeNpmrcLoader,
   makeNpmrcPathFinder,
@@ -48,13 +48,14 @@ const log = npmlog;
 const regClient = new RegClient({ log });
 const getCwd = makeCwdGetter();
 const readFile = makeTextReader();
+const writeFile = makeTextWriter();
 const loadProjectManifest = makeProjectManifestLoader(readFile);
-const writeProjectManifest = makeProjectManifestWriter();
+const writeProjectManifest = makeProjectManifestWriter(writeFile);
 const getUpmConfigDir = makeUpmConfigDirGetter();
 const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder();
 const loadNpmrc = makeNpmrcLoader(readFile);
-const saveNpmrc = makeNpmrcSaver();
+const saveNpmrc = makeNpmrcSaver(writeFile);
 
 const parseEnv = makeParseEnvService(
   log,
@@ -88,6 +89,7 @@ const loginCmd = makeLoginCmd(
   parseEnv,
   authNpmrc,
   npmLogin,
+  writeFile,
   getUpmConfigDir,
   loadUpmConfig,
   log

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,18 +33,20 @@ import { makeResolveLatestVersionService } from "../services/resolve-latest-vers
 import { makeUpmConfigLoader } from "../io/upm-config-io";
 import { makeTextReader } from "../io/file-io";
 import { makeNpmrcPathFinder } from "../io/npmrc-io";
+import { makeCwdGetter } from "../io/special-paths";
 
 // Composition root
 
 const log = npmlog;
 const regClient = new RegClient({ log });
+const getCwd = makeCwdGetter();
 const readFile = makeTextReader();
 const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter();
 const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder();
 
-const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile);
+const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile, getCwd);
 const fetchPackument = makeFetchPackumentService(regClient);
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, readFile);
 const npmLogin = makeNpmLoginService(regClient);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ import npmlog from "npmlog";
 import { makeResolveLatestVersionService } from "../services/resolve-latest-version";
 import { makeUpmConfigLoader } from "../io/upm-config-io";
 import { makeTextReader } from "../io/file-io";
+import { makeNpmrcPathFinder } from "../io/npmrc-io";
 
 // Composition root
 
@@ -41,10 +42,11 @@ const readFile = makeTextReader();
 const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter();
 const loadUpmConfig = makeUpmConfigLoader(readFile);
+const findNpmrcPath = makeNpmrcPathFinder();
 
 const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile);
 const fetchPackument = makeFetchPackumentService(regClient);
-const authNpmrc = makeAuthNpmrcService(readFile);
+const authNpmrc = makeAuthNpmrcService(findNpmrcPath, readFile);
 const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =

--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -38,11 +38,6 @@ export class IOError extends CustomError {
   }
 }
 
-/**
- * Error for when a file-write failed.
- */
-export type FileWriteError = IOError;
-
 function fsOperation<T>(op: () => Promise<T>) {
   return new AsyncResult(Result.wrapAsync(op)).mapErr((error) => {
     assertIsNodeError(error);
@@ -76,17 +71,29 @@ export function makeTextReader(): ReadTextFile {
 }
 
 /**
- * Attempts to overwrite the content of a text file.
+ * Error for when a file-write failed.
+ */
+export type FileWriteError = IOError;
+
+/**
+ * Function for overwriting the content of a text file. Creates the file
+ * if it does not exist.
  * @param filePath The path to the file.
  * @param content The content to write.
  */
-export function tryWriteTextToFile(
+export type WriteTextFile = (
   filePath: string,
   content: string
-): AsyncResult<void, FileWriteError> {
-  return fsOperation(() => fse.ensureDir(path.dirname(filePath))).andThen(() =>
-    fsOperation(() => fs.writeFile(filePath, content))
-  );
+) => AsyncResult<void, FileWriteError>;
+
+/**
+ * Makes a {@link WriteTextFile} function.
+ */
+export function makeTextWriter(): WriteTextFile {
+  return (filePath, content) =>
+    fsOperation(() => fse.ensureDir(path.dirname(filePath))).andThen(() =>
+      fsOperation(() => fs.writeFile(filePath, content))
+    );
 }
 
 /**

--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -39,11 +39,6 @@ export class IOError extends CustomError {
 }
 
 /**
- * Error for when a file-read failed.
- */
-export type FileReadError = NotFoundError | IOError;
-
-/**
  * Error for when a file-write failed.
  */
 export type FileWriteError = IOError;
@@ -56,18 +51,28 @@ function fsOperation<T>(op: () => Promise<T>) {
 }
 
 /**
- * Attempts to read the content of a text file.
- * @param path The path to the file.
+ * Error for when a file-read failed.
  */
-export function tryReadTextFromFile(
-  path: string
-): AsyncResult<string, FileReadError> {
-  return fsOperation(() => fs.readFile(path, { encoding: "utf8" })).mapErr(
-    (error) => {
-      if (error.cause!.code === "ENOENT") return new NotFoundError(path);
-      return error;
-    }
-  );
+export type FileReadError = NotFoundError | IOError;
+
+/**
+ * Function for loading the content of a text file.
+ * @param path The path to the file.
+ * @returns The files text content.
+ */
+export type ReadTextFile = (path: string) => AsyncResult<string, FileReadError>;
+
+/**
+ * Makes a {@link ReadTextFile} function.
+ */
+export function makeTextReader(): ReadTextFile {
+  return (path) =>
+    fsOperation(() => fs.readFile(path, { encoding: "utf8" })).mapErr(
+      (error) => {
+        if (error.cause!.code === "ENOENT") return new NotFoundError(path);
+        return error;
+      }
+    );
 }
 
 /**

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -23,10 +23,22 @@ export type NpmrcLoadError = IOError;
 export type NpmrcSaveError = FileWriteError;
 
 /**
- * Tries to get the npmrc path based on env.
+ * Error for when npmrc path could not be determined.
  */
-export function tryGetNpmrcPath(): Result<string, RequiredEnvMissingError> {
-  return tryGetHomePath().map((homePath) => path.join(homePath, ".npmrc"));
+export type FindNpmrcError = RequiredEnvMissingError;
+
+/**
+ * Function for determining the path of the users .npmrc file.
+ * @returns The path to the file.
+ */
+export type FindNpmrcPath = () => Result<string, FindNpmrcError>;
+
+/**
+ * Makes a {@link FindNpmrcPath} function.
+ */
+export function makeNpmrcPathFinder(): FindNpmrcPath {
+  return () =>
+    tryGetHomePath().map((homePath) => path.join(homePath, ".npmrc"));
 }
 
 /**

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -4,7 +4,7 @@ import {
   IOError,
   NotFoundError,
   ReadTextFile,
-  tryWriteTextToFile,
+  WriteTextFile,
 } from "./file-io";
 import { EOL } from "node:os";
 import { Npmrc } from "../domain/npmrc";
@@ -75,9 +75,9 @@ export type SaveNpmrc = (
 /**
  * Makes a {@link SaveNpmrc} function.
  */
-export function makeNpmrcSaver(): SaveNpmrc {
+export function makeNpmrcSaver(writeFile: WriteTextFile): SaveNpmrc {
   return (path, npmrc) => {
     const content = npmrc.join(EOL);
-    return tryWriteTextToFile(path, content);
+    return writeFile(path, content);
   };
 }

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -10,7 +10,7 @@ import { EOL } from "node:os";
 import { Npmrc } from "../domain/npmrc";
 import path from "path";
 import { RequiredEnvMissingError } from "./upm-config-io";
-import { tryGetHomePath } from "./special-paths";
+import { GetHomePath } from "./special-paths";
 
 /**
  * Error for when npmrc path could not be determined.
@@ -26,9 +26,8 @@ export type FindNpmrcPath = () => Result<string, FindNpmrcError>;
 /**
  * Makes a {@link FindNpmrcPath} function.
  */
-export function makeNpmrcPathFinder(): FindNpmrcPath {
-  return () =>
-    tryGetHomePath().map((homePath) => path.join(homePath, ".npmrc"));
+export function makeNpmrcPathFinder(getHomePath: GetHomePath): FindNpmrcPath {
+  return () => getHomePath().map((homePath) => path.join(homePath, ".npmrc"));
 }
 
 /**

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -3,7 +3,7 @@ import {
   FileWriteError,
   IOError,
   NotFoundError,
-  tryReadTextFromFile,
+  ReadTextFile,
   tryWriteTextToFile,
 } from "./file-io";
 import { EOL } from "node:os";
@@ -34,9 +34,10 @@ export function tryGetNpmrcPath(): Result<string, RequiredEnvMissingError> {
  * @param path The path to load from.
  */
 export function tryLoadNpmrc(
+  readFile: ReadTextFile,
   path: string
 ): AsyncResult<Npmrc | null, NpmrcLoadError> {
-  return tryReadTextFromFile(path)
+  return readFile(path)
     .map<Npmrc | null>((content) => content.split(EOL))
     .orElse((error) =>
       error instanceof NotFoundError ? Ok(null) : Err(error)

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -13,11 +13,6 @@ import { RequiredEnvMissingError } from "./upm-config-io";
 import { tryGetHomePath } from "./special-paths";
 
 /**
- * Error that might occur when loading a npmrc.
- */
-export type NpmrcLoadError = IOError;
-
-/**
  * Error that might occur when saving a npmrc.
  */
 export type NpmrcSaveError = FileWriteError;
@@ -42,18 +37,29 @@ export function makeNpmrcPathFinder(): FindNpmrcPath {
 }
 
 /**
- * Attempts to load an .npmrc. It will load all lines from the file.
- * @param path The path to load from.
+ * Error that might occur when loading a npmrc.
  */
-export function tryLoadNpmrc(
-  readFile: ReadTextFile,
+export type NpmrcLoadError = IOError;
+
+/**
+ * Function for loading npmrc.
+ * @param path The path to load from.
+ * @returns The npmrc's lines or null if not found.
+ */
+export type LoadNpmrc = (
   path: string
-): AsyncResult<Npmrc | null, NpmrcLoadError> {
-  return readFile(path)
-    .map<Npmrc | null>((content) => content.split(EOL))
-    .orElse((error) =>
-      error instanceof NotFoundError ? Ok(null) : Err(error)
-    );
+) => AsyncResult<Npmrc | null, NpmrcLoadError>;
+
+/**
+ * Makes a {@link LoadNpmrc} function.
+ */
+export function makeNpmrcLoader(readFile: ReadTextFile): LoadNpmrc {
+  return (path) =>
+    readFile(path)
+      .map<Npmrc | null>((content) => content.split(EOL))
+      .orElse((error) =>
+        error instanceof NotFoundError ? Ok(null) : Err(error)
+      );
 }
 
 /**

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -13,11 +13,6 @@ import { RequiredEnvMissingError } from "./upm-config-io";
 import { tryGetHomePath } from "./special-paths";
 
 /**
- * Error that might occur when saving a npmrc.
- */
-export type NpmrcSaveError = FileWriteError;
-
-/**
  * Error for when npmrc path could not be determined.
  */
 export type FindNpmrcError = RequiredEnvMissingError;
@@ -63,14 +58,26 @@ export function makeNpmrcLoader(readFile: ReadTextFile): LoadNpmrc {
 }
 
 /**
- * Attempts to save a npmrc. Overwrites the content of the file.
+ * Error that might occur when saving a npmrc.
+ */
+export type NpmrcSaveError = FileWriteError;
+
+/**
+ * Function for saving npmrc files. Overwrites the content of the file.
  * @param path The path to the file.
  * @param npmrc The new lines for the file.
  */
-export function trySaveNpmrc(
+export type SaveNpmrc = (
   path: string,
   npmrc: Npmrc
-): AsyncResult<void, NpmrcSaveError> {
-  const content = npmrc.join(EOL);
-  return tryWriteTextToFile(path, content);
+) => AsyncResult<void, NpmrcSaveError>;
+
+/**
+ * Makes a {@link SaveNpmrc} function.
+ */
+export function makeNpmrcSaver(): SaveNpmrc {
+  return (path, npmrc) => {
+    const content = npmrc.join(EOL);
+    return tryWriteTextToFile(path, content);
+  };
 }

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -8,7 +8,7 @@ import { AsyncResult } from "ts-results-es";
 import {
   IOError,
   NotFoundError,
-  tryReadTextFromFile,
+  ReadTextFile,
   tryWriteTextToFile,
 } from "./file-io";
 import { tryParseJson } from "../utils/string-parsing";
@@ -38,11 +38,13 @@ export type LoadProjectManifest = (
 /**
  * Makes a {@link LoadProjectManifest} function.
  */
-export function makeProjectManifestLoader(): LoadProjectManifest {
+export function makeProjectManifestLoader(
+  readFile: ReadTextFile
+): LoadProjectManifest {
   return (projectPath) => {
     const manifestPath = manifestPathFor(projectPath);
     return (
-      tryReadTextFromFile(manifestPath)
+      readFile(manifestPath)
         .andThen(tryParseJson)
         // TODO: Actually validate the json structure
         .map((json) => json as unknown as UnityProjectManifest)

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -5,12 +5,7 @@ import {
 import path from "path";
 import { FileParseError } from "../common-errors";
 import { AsyncResult } from "ts-results-es";
-import {
-  IOError,
-  NotFoundError,
-  ReadTextFile,
-  tryWriteTextToFile,
-} from "./file-io";
+import { IOError, NotFoundError, ReadTextFile, WriteTextFile } from "./file-io";
 import { tryParseJson } from "../utils/string-parsing";
 
 /**
@@ -74,12 +69,14 @@ export type WriteProjectManifest = (
 /**
  * Makes a {@link WriteProjectManifest} function.
  */
-export function makeProjectManifestWriter(): WriteProjectManifest {
+export function makeProjectManifestWriter(
+  writeFile: WriteTextFile
+): WriteProjectManifest {
   return (projectPath, manifest) => {
     const manifestPath = manifestPathFor(projectPath);
     manifest = pruneManifest(manifest);
     const json = JSON.stringify(manifest, null, 2);
 
-    return tryWriteTextToFile(manifestPath, json);
+    return writeFile(manifestPath, json);
   };
 }

--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { FileParseError } from "../common-errors";
-import { FileReadError, tryReadTextFromFile } from "./file-io";
+import { FileReadError, ReadTextFile } from "./file-io";
 import { StringFormatError, tryParseYaml } from "../utils/string-parsing";
 
 export type ProjectVersionLoadError =
@@ -18,11 +18,12 @@ function projectVersionTxtPathFor(projectDirPath: string) {
  * @param projectDirPath The path to the projects root directory.
  */
 export function tryLoadProjectVersion(
+  readFile: ReadTextFile,
   projectDirPath: string
 ): AsyncResult<string, ProjectVersionLoadError> {
   const filePath = projectVersionTxtPathFor(projectDirPath);
 
-  return tryReadTextFromFile(filePath)
+  return readFile(filePath)
     .andThen(tryParseYaml)
     .andThen((content) => {
       if (

--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -4,38 +4,50 @@ import { FileParseError } from "../common-errors";
 import { FileReadError, ReadTextFile } from "./file-io";
 import { StringFormatError, tryParseYaml } from "../utils/string-parsing";
 
-export type ProjectVersionLoadError =
-  | FileReadError
-  | StringFormatError
-  | FileParseError;
-
 function projectVersionTxtPathFor(projectDirPath: string) {
   return path.join(projectDirPath, "ProjectSettings", "ProjectVersion.txt");
 }
 
 /**
- * Attempts to load a projects editor-version from ProjectVersion.txt.
- * @param projectDirPath The path to the projects root directory.
+ * Error which may occur when loading a project-version.
  */
-export function tryLoadProjectVersion(
-  readFile: ReadTextFile,
+export type ProjectVersionLoadError =
+  | FileReadError
+  | StringFormatError
+  | FileParseError;
+
+/**
+ * Function for loading a projects editor version string.
+ * @param projectDirPath The path to the projects root directory.
+ * @returns A string describing the projects editor version ie 2020.2.1f1.
+ */
+export type LoadProjectVersion = (
   projectDirPath: string
-): AsyncResult<string, ProjectVersionLoadError> {
-  const filePath = projectVersionTxtPathFor(projectDirPath);
+) => AsyncResult<string, ProjectVersionLoadError>;
 
-  return readFile(filePath)
-    .andThen(tryParseYaml)
-    .andThen((content) => {
-      if (
-        !(
-          typeof content === "object" &&
-          content !== null &&
-          "m_EditorVersion" in content &&
-          typeof content.m_EditorVersion === "string"
+/**
+ * Makes a {@link LoadProjectVersion} function.
+ */
+export function makeProjectVersionLoader(
+  readFile: ReadTextFile
+): LoadProjectVersion {
+  return (projectDirPath) => {
+    const filePath = projectVersionTxtPathFor(projectDirPath);
+
+    return readFile(filePath)
+      .andThen(tryParseYaml)
+      .andThen((content) => {
+        if (
+          !(
+            typeof content === "object" &&
+            content !== null &&
+            "m_EditorVersion" in content &&
+            typeof content.m_EditorVersion === "string"
+          )
         )
-      )
-        return Err(new FileParseError(filePath, "Project-version"));
+          return Err(new FileParseError(filePath, "Project-version"));
 
-      return Ok(content.m_EditorVersion);
-    });
+        return Ok(content.m_EditorVersion);
+      });
+  };
 }

--- a/src/io/special-paths.ts
+++ b/src/io/special-paths.ts
@@ -102,3 +102,16 @@ export function tryGetEditorInstallPath(
 
   return Err(new OSNotSupportedError(platform));
 }
+
+/**
+ * Function that gets the current working directories path.
+ * @returns The path.
+ */
+export type GetCwd = () => string;
+
+/**
+ * Makes a {@link GetCwd} function.
+ */
+export function makeCwdGetter(): GetCwd {
+  return process.cwd;
+}

--- a/src/io/special-paths.ts
+++ b/src/io/special-paths.ts
@@ -1,6 +1,5 @@
 import { Err, Ok, Result } from "ts-results-es";
 import { RequiredEnvMissingError } from "./upm-config-io";
-import { tryGetEnv } from "../utils/env-util";
 import os from "os";
 import { CustomError } from "ts-custom-error";
 import {
@@ -11,6 +10,7 @@ import {
   stringifyEditorVersion,
 } from "../domain/editor-version";
 import { EditorVersionNotSupportedError } from "../common-errors";
+import { tryGetEnv } from "../utils/env-util";
 
 /**
  * Error for when a specific OS does not support a specific editor-version.
@@ -47,13 +47,26 @@ export class OSNotSupportedError extends CustomError {
 }
 
 /**
- * Attempts to get the current users home-directory.
+ * Error which may occur when getting the users home path.
  */
-export function tryGetHomePath(): Result<string, RequiredEnvMissingError> {
-  const homePath = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
-  if (homePath === null)
-    return Err(new RequiredEnvMissingError("USERPROFILE", "HOME"));
-  return Ok(homePath);
+export type GetHomePathError = RequiredEnvMissingError;
+
+/**
+ * Function for getting the path of the users home directory.
+ * @returns The path to the directory.
+ */
+export type GetHomePath = () => Result<string, GetHomePathError>;
+
+/**
+ * Makes a {@link GetHomePath} function.
+ */
+export function makeHomePathGetter(): GetHomePath {
+  return () => {
+    const homePath = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
+    if (homePath === null)
+      return Err(new RequiredEnvMissingError("USERPROFILE", "HOME"));
+    return Ok(homePath);
+  };
 }
 
 /**

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import TOML from "@iarna/toml";
-import { addAuth, UpmAuth, UPMConfig } from "../domain/upm-config";
-import { RegistryUrl } from "../domain/registry-url";
+import { UPMConfig } from "../domain/upm-config";
 import { CustomError } from "ts-custom-error";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { IOError, NotFoundError, ReadTextFile, WriteTextFile } from "./file-io";
@@ -127,23 +126,3 @@ export const trySaveUpmConfig = (
   return writeFile(configPath, content).map(() => configPath);
 };
 
-/**
- * Errors which may occur when storing an {@link UpmAuth} to the file-system.
- */
-export type UpmAuthStoreError = UpmConfigLoadError | IOError;
-
-/**
- * Stores authentication information in the projects upm config.
- */
-export const tryStoreUpmAuth = function (
-  loadUpmConfig: LoadUpmConfig,
-  writeFile: WriteTextFile,
-  configDir: string,
-  registry: RegistryUrl,
-  auth: UpmAuth
-): AsyncResult<string, UpmAuthStoreError> {
-  return loadUpmConfig(configDir)
-    .map((maybeConfig) => maybeConfig || {})
-    .map((config) => addAuth(registry, auth, config))
-    .andThen((config) => trySaveUpmConfig(writeFile, config, configDir));
-};

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -7,7 +7,7 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import {
   IOError,
   NotFoundError,
-  tryReadTextFromFile,
+  ReadTextFile,
   tryWriteTextToFile,
 } from "./file-io";
 import { tryGetEnv } from "../utils/env-util";
@@ -82,12 +82,12 @@ export type LoadUpmConfig = (
 /**
  * Makes a {@link LoadUpmConfig} function.
  */
-export function makeUpmConfigLoader(): LoadUpmConfig {
+export function makeUpmConfigLoader(readFile: ReadTextFile): LoadUpmConfig {
   return (directory) => {
     const configPath = path.join(directory, configFileName);
 
     return (
-      tryReadTextFromFile(configPath)
+      readFile(configPath)
         .andThen(tryParseToml)
         // TODO: Actually validate
         .map<UPMConfig | null>((toml) => toml as UPMConfig)

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -6,10 +6,10 @@ import { CustomError } from "ts-custom-error";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { IOError, NotFoundError, ReadTextFile, WriteTextFile } from "./file-io";
 import { tryGetEnv } from "../utils/env-util";
-import { tryGetHomePath } from "./special-paths";
 import { StringFormatError, tryParseToml } from "../utils/string-parsing";
 import { tryGetWslPath, WslPathError } from "./wsl";
 import { ChildProcessError } from "../utils/process";
+import { GetHomePath } from "./special-paths";
 
 const configFileName = ".upmconfig.toml";
 
@@ -46,7 +46,9 @@ export type GetUpmConfigDir = (
 /**
  * Makes a {@link GetUpmConfigDir} function.
  */
-export function makeUpmConfigDirGetter(): GetUpmConfigDir {
+export function makeUpmConfigDirGetter(
+  getHomePath: GetHomePath
+): GetUpmConfigDir {
   return (wsl, systemUser) => {
     const systemUserSubPath = "Unity/config/ServiceAccounts";
     if (wsl) {
@@ -67,7 +69,7 @@ export function makeUpmConfigDirGetter(): GetUpmConfigDir {
       return Ok(path.join(profilePath, systemUserSubPath)).toAsyncResult();
     }
 
-    return tryGetHomePath().toAsyncResult();
+    return getHomePath().toAsyncResult();
   };
 }
 

--- a/src/services/npmrc-auth.ts
+++ b/src/services/npmrc-auth.ts
@@ -1,9 +1,9 @@
 import { RegistryUrl } from "../domain/registry-url";
 import { AsyncResult } from "ts-results-es";
 import {
+  FindNpmrcPath,
   NpmrcLoadError,
   NpmrcSaveError,
-  tryGetNpmrcPath,
   tryLoadNpmrc,
   trySaveNpmrc,
 } from "../io/npmrc-io";
@@ -31,10 +31,13 @@ export type AuthNpmrcService = (
   token: string
 ) => AsyncResult<string, NpmrcAuthTokenUpdateError>;
 
-export function makeAuthNpmrcService(readFile: ReadTextFile): AuthNpmrcService {
+export function makeAuthNpmrcService(
+  findPath: FindNpmrcPath,
+  readFile: ReadTextFile
+): AuthNpmrcService {
   return (registry, token) => {
     // read config
-    return tryGetNpmrcPath()
+    return findPath()
       .toAsyncResult()
       .andThen((configPath) =>
         tryLoadNpmrc(readFile, configPath)

--- a/src/services/npmrc-auth.ts
+++ b/src/services/npmrc-auth.ts
@@ -2,14 +2,13 @@ import { RegistryUrl } from "../domain/registry-url";
 import { AsyncResult } from "ts-results-es";
 import {
   FindNpmrcPath,
+  LoadNpmrc,
   NpmrcLoadError,
   NpmrcSaveError,
-  tryLoadNpmrc,
   trySaveNpmrc,
 } from "../io/npmrc-io";
 import { emptyNpmrc, setToken } from "../domain/npmrc";
 import { RequiredEnvMissingError } from "../io/upm-config-io";
-import { ReadTextFile } from "../io/file-io";
 
 /**
  * Error that might occur when updating an auth-token inside a npmrc file.
@@ -33,14 +32,14 @@ export type AuthNpmrcService = (
 
 export function makeAuthNpmrcService(
   findPath: FindNpmrcPath,
-  readFile: ReadTextFile
+  loadNpmrc: LoadNpmrc
 ): AuthNpmrcService {
   return (registry, token) => {
     // read config
     return findPath()
       .toAsyncResult()
       .andThen((configPath) =>
-        tryLoadNpmrc(readFile, configPath)
+        loadNpmrc(configPath)
           .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
           .map((npmrc) => setToken(npmrc, registry, token))
           .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))

--- a/src/services/npmrc-auth.ts
+++ b/src/services/npmrc-auth.ts
@@ -9,6 +9,7 @@ import {
 } from "../io/npmrc-io";
 import { emptyNpmrc, setToken } from "../domain/npmrc";
 import { RequiredEnvMissingError } from "../io/upm-config-io";
+import { ReadTextFile } from "../io/file-io";
 
 /**
  * Error that might occur when updating an auth-token inside a npmrc file.
@@ -30,13 +31,13 @@ export type AuthNpmrcService = (
   token: string
 ) => AsyncResult<string, NpmrcAuthTokenUpdateError>;
 
-export function makeAuthNpmrcService(): AuthNpmrcService {
+export function makeAuthNpmrcService(readFile: ReadTextFile): AuthNpmrcService {
   return (registry, token) => {
     // read config
     return tryGetNpmrcPath()
       .toAsyncResult()
       .andThen((configPath) =>
-        tryLoadNpmrc(configPath)
+        tryLoadNpmrc(readFile, configPath)
           .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
           .map((npmrc) => setToken(npmrc, registry, token))
           .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))

--- a/src/services/npmrc-auth.ts
+++ b/src/services/npmrc-auth.ts
@@ -5,7 +5,7 @@ import {
   LoadNpmrc,
   NpmrcLoadError,
   NpmrcSaveError,
-  trySaveNpmrc,
+  SaveNpmrc,
 } from "../io/npmrc-io";
 import { emptyNpmrc, setToken } from "../domain/npmrc";
 import { RequiredEnvMissingError } from "../io/upm-config-io";
@@ -32,7 +32,8 @@ export type AuthNpmrcService = (
 
 export function makeAuthNpmrcService(
   findPath: FindNpmrcPath,
-  loadNpmrc: LoadNpmrc
+  loadNpmrc: LoadNpmrc,
+  saveNpmrc: SaveNpmrc
 ): AuthNpmrcService {
   return (registry, token) => {
     // read config
@@ -42,7 +43,7 @@ export function makeAuthNpmrcService(
         loadNpmrc(configPath)
           .map((maybeNpmrc) => maybeNpmrc ?? emptyNpmrc)
           .map((npmrc) => setToken(npmrc, registry, token))
-          .andThen((npmrc) => trySaveNpmrc(configPath, npmrc))
+          .andThen((npmrc) => saveNpmrc(configPath, npmrc))
           .map(() => configPath)
       );
   };

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
 import {
+  GetUpmConfigDir,
   GetUpmConfigDirError,
   LoadUpmConfig,
-  tryGetUpmConfigDir,
   UpmConfigLoadError,
 } from "../io/upm-config-io";
 import path from "path";
@@ -119,6 +119,7 @@ export type ParseEnvService = (
  */
 export function makeParseEnvService(
   log: Logger,
+  getUpmConfigDir: GetUpmConfigDir,
   loadUpmConfig: LoadUpmConfig,
   readFile: ReadTextFile,
   getCwd: GetCwd
@@ -145,7 +146,7 @@ export function makeParseEnvService(
     const wsl = determineWsl(options);
 
     // registries
-    const upmConfigResult = await tryGetUpmConfigDir(wsl, systemUser).andThen(
+    const upmConfigResult = await getUpmConfigDir(wsl, systemUser).andThen(
       loadUpmConfig
     ).promise;
     if (upmConfigResult.isErr()) return upmConfigResult;

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -12,10 +12,10 @@ import { CmdOptions } from "../cli/options";
 import { FileParseError } from "../common-errors";
 import { Ok, Result } from "ts-results-es";
 import {
+  LoadProjectVersion,
   ProjectVersionLoadError,
-  tryLoadProjectVersion,
 } from "../io/project-version-io";
-import { NotFoundError, ReadTextFile } from "../io/file-io";
+import { NotFoundError } from "../io/file-io";
 import { tryGetEnv } from "../utils/env-util";
 import {
   isRelease,
@@ -121,8 +121,8 @@ export function makeParseEnvService(
   log: Logger,
   getUpmConfigDir: GetUpmConfigDir,
   loadUpmConfig: LoadUpmConfig,
-  readFile: ReadTextFile,
-  getCwd: GetCwd
+  getCwd: GetCwd,
+  loadProjectVersion: LoadProjectVersion
 ): ParseEnvService {
   return async (options) => {
     // log level
@@ -159,8 +159,7 @@ export function makeParseEnvService(
     const cwd = determineCwd(getCwd, options);
 
     // editor version
-    const projectVersionLoadResult = await tryLoadProjectVersion(readFile, cwd)
-      .promise;
+    const projectVersionLoadResult = await loadProjectVersion(cwd).promise;
     if (projectVersionLoadResult.isErr()) {
       if (projectVersionLoadResult.error instanceof NotFoundError)
         log.warn(

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -24,6 +24,7 @@ import {
 } from "../domain/editor-version";
 import { Registry } from "../domain/registry";
 import { Logger } from "npmlog";
+import { GetCwd } from "../io/special-paths";
 
 export type Env = Readonly<{
   cwd: string;
@@ -44,10 +45,10 @@ export type EnvParseError =
   | UpmConfigLoadError
   | ProjectVersionLoadError;
 
-function determineCwd(options: CmdOptions): string {
+function determineCwd(getCwd: GetCwd, options: CmdOptions): string {
   return options._global.chdir !== undefined
     ? path.resolve(options._global.chdir)
-    : process.cwd();
+    : getCwd();
 }
 
 function determineWsl(options: CmdOptions): boolean {
@@ -119,7 +120,8 @@ export type ParseEnvService = (
 export function makeParseEnvService(
   log: Logger,
   loadUpmConfig: LoadUpmConfig,
-  readFile: ReadTextFile
+  readFile: ReadTextFile,
+  getCwd: GetCwd
 ): ParseEnvService {
   return async (options) => {
     // log level
@@ -153,7 +155,7 @@ export function makeParseEnvService(
     const upstreamRegistry = determineUpstreamRegistry(options);
 
     // cwd
-    const cwd = determineCwd(options);
+    const cwd = determineCwd(getCwd, options);
 
     // editor version
     const projectVersionLoadResult = await tryLoadProjectVersion(readFile, cwd)

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -15,7 +15,7 @@ import {
   ProjectVersionLoadError,
   tryLoadProjectVersion,
 } from "../io/project-version-io";
-import { NotFoundError } from "../io/file-io";
+import { NotFoundError, ReadTextFile } from "../io/file-io";
 import { tryGetEnv } from "../utils/env-util";
 import {
   isRelease,
@@ -118,7 +118,8 @@ export type ParseEnvService = (
  */
 export function makeParseEnvService(
   log: Logger,
-  loadUpmConfig: LoadUpmConfig
+  loadUpmConfig: LoadUpmConfig,
+  readFile: ReadTextFile
 ): ParseEnvService {
   return async (options) => {
     // log level
@@ -155,7 +156,8 @@ export function makeParseEnvService(
     const cwd = determineCwd(options);
 
     // editor version
-    const projectVersionLoadResult = await tryLoadProjectVersion(cwd).promise;
+    const projectVersionLoadResult = await tryLoadProjectVersion(readFile, cwd)
+      .promise;
     if (projectVersionLoadResult.isErr()) {
       if (projectVersionLoadResult.error instanceof NotFoundError)
         log.warn(

--- a/src/services/upm-auth.ts
+++ b/src/services/upm-auth.ts
@@ -1,0 +1,43 @@
+import { IOError, WriteTextFile } from "../io/file-io";
+import { RegistryUrl } from "../domain/registry-url";
+import { addAuth, UpmAuth } from "../domain/upm-config";
+import { AsyncResult } from "ts-results-es";
+import {
+  LoadUpmConfig,
+  trySaveUpmConfig,
+  UpmConfigLoadError,
+} from "../io/upm-config-io";
+
+/**
+ * Errors which may occur when storing an {@link UpmAuth} to the file-system.
+ */
+export type UpmAuthStoreError = UpmConfigLoadError | IOError;
+
+/**
+ * Service function for storing authentication information in an upmconfig file.
+ * @param configDir Path to the directory in which the upmconfig file is
+ * located.
+ * @param registry Url of the registry for which to authenticate.
+ * @param auth Authentication information.
+ * @returns The path of the upmconfig file.
+ */
+export type SaveAuthToUpmConfig = (
+  configDir: string,
+  registry: RegistryUrl,
+  auth: UpmAuth
+) => AsyncResult<string, UpmAuthStoreError>;
+
+/**
+ * Makes a {@link SaveAuthToUpmConfig} function.
+ */
+export function makeSaveAuthToUpmConfigService(
+  loadUpmConfig: LoadUpmConfig,
+  writeFile: WriteTextFile
+): SaveAuthToUpmConfig {
+  // TODO: Add tests for this service
+  return (configDir, registry, auth) =>
+    loadUpmConfig(configDir)
+      .map((maybeConfig) => maybeConfig || {})
+      .map((config) => addAuth(registry, auth, config))
+      .andThen((config) => trySaveUpmConfig(writeFile, config, configDir));
+}

--- a/test/io/npmrc-io.test.ts
+++ b/test/io/npmrc-io.test.ts
@@ -16,9 +16,6 @@ import { GetHomePath } from "../../src/io/special-paths";
 import { RequiredEnvMissingError } from "../../src/io/upm-config-io";
 import { mockService } from "../services/service.mock";
 
-jest.mock("../../src/io/file-io");
-jest.mock("../../src/io/special-paths");
-
 describe("npmrc-io", () => {
   describe("get path", () => {
     function makeDependencies() {

--- a/test/io/npmrc-io.test.ts
+++ b/test/io/npmrc-io.test.ts
@@ -9,7 +9,7 @@ import { EOL } from "node:os";
 import {
   makeNpmrcLoader,
   makeNpmrcPathFinder,
-  trySaveNpmrc,
+  makeNpmrcSaver,
 } from "../../src/io/npmrc-io";
 import path from "path";
 import { tryGetHomePath } from "../../src/io/special-paths";
@@ -83,25 +83,32 @@ describe("npmrc-io", () => {
   });
 
   describe("save", () => {
+    function makeDependencies() {
+      const saveNpmrc = makeNpmrcSaver();
+      return { saveNpmrc } as const;
+    }
+
     it("should be ok when write succeeds", async () => {
+      const { saveNpmrc } = makeDependencies();
       const path = "/valid/path/.npmrc";
       jest
         .mocked(tryWriteTextToFile)
         .mockReturnValue(new AsyncResult(Ok(undefined)));
 
-      const result = await trySaveNpmrc(path, ["key=value"]).promise;
+      const result = await saveNpmrc(path, ["key=value"]).promise;
 
       expect(result).toBeOk();
     });
 
     it("should fail when write fails", async () => {
+      const { saveNpmrc } = makeDependencies();
       const expected = new IOError();
       const path = "/invalid/path/.npmrc";
       jest
         .mocked(tryWriteTextToFile)
         .mockReturnValue(new AsyncResult(Err(expected)));
 
-      const result = await trySaveNpmrc(path, ["key=value"]).promise;
+      const result = await saveNpmrc(path, ["key=value"]).promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
     });

--- a/test/io/npmrc-io.test.ts
+++ b/test/io/npmrc-io.test.ts
@@ -7,7 +7,7 @@ import {
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { EOL } from "node:os";
 import {
-  tryGetNpmrcPath,
+  makeNpmrcPathFinder,
   tryLoadNpmrc,
   trySaveNpmrc,
 } from "../../src/io/npmrc-io";
@@ -21,22 +21,30 @@ jest.mock("../../src/io/special-paths");
 
 describe("npmrc-io", () => {
   describe("get path", () => {
+    function makeDependencies() {
+      const findPath = makeNpmrcPathFinder();
+
+      return { findPath } as const;
+    }
+
     it("should be [Home]/.npmrc", () => {
+      const { findPath } = makeDependencies();
       const home = path.join(path.sep, "user", "dir");
       const expected = path.join(home, ".npmrc");
       jest.mocked(tryGetHomePath).mockReturnValue(Ok(home));
 
-      const result = tryGetNpmrcPath();
+      const result = findPath();
 
       expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
     });
 
     it("should fail if home could not be determined", () => {
+      const { findPath } = makeDependencies();
       jest
         .mocked(tryGetHomePath)
         .mockReturnValue(Err(new RequiredEnvMissingError()));
 
-      const result = tryGetNpmrcPath();
+      const result = findPath();
 
       expect(result).toBeError();
     });

--- a/test/io/project-version-io.mock.ts
+++ b/test/io/project-version-io.mock.ts
@@ -2,21 +2,23 @@ import {
   ReleaseVersion,
   stringifyEditorVersion,
 } from "../../src/domain/editor-version";
-import * as projectVersionIoModule from "../../src/io/project-version-io";
 import { Ok } from "ts-results-es";
+import { LoadProjectVersion } from "../../src/io/project-version-io";
 
 /**
- * Mocks return values for calls to {@link tryLoadProjectVersion}.
+ * Mocks return values for calls to a {@link LoadProjectVersion} function.
+ * @param loadProjectVersion The function to mock.
  * @param editorVersion The editor-version to return. Can be specified as a
  * raw string or an {@link ReleaseVersion} object.
  */
-export function mockProjectVersion(editorVersion: ReleaseVersion | string) {
+export function mockProjectVersion(
+  loadProjectVersion: jest.MockedFunction<LoadProjectVersion>,
+  editorVersion: ReleaseVersion | string
+) {
   const versionString =
     typeof editorVersion === "string"
       ? editorVersion
       : stringifyEditorVersion(editorVersion);
 
-  jest
-    .spyOn(projectVersionIoModule, "tryLoadProjectVersion")
-    .mockReturnValue(Ok(versionString).toAsyncResult());
+  loadProjectVersion.mockReturnValue(Ok(versionString).toAsyncResult());
 }

--- a/test/io/special-paths.test.ts
+++ b/test/io/special-paths.test.ts
@@ -1,9 +1,9 @@
 import path from "path";
 import { tryGetEnv } from "../../src/utils/env-util";
 import {
+  makeHomePathGetter,
   OSNotSupportedError,
   tryGetEditorInstallPath,
-  tryGetHomePath,
   VersionNotSupportedOnOsError,
 } from "../../src/io/special-paths";
 import os from "os";
@@ -14,32 +14,41 @@ jest.mock("../../src/utils/env-util");
 
 describe("special-paths", () => {
   describe("home", () => {
+    function makeDependencies() {
+      const getHomePath = makeHomePathGetter();
+
+      return { getHomePath } as const;
+    }
+
     it("should be USERPROFILE if defined", () => {
+      const { getHomePath } = makeDependencies();
       const expected = path.join(path.sep, "user", "dir");
       jest
         .mocked(tryGetEnv)
         .mockImplementation((key) => (key === "USERPROFILE" ? expected : null));
 
-      const result = tryGetHomePath();
+      const result = getHomePath();
 
       expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
     });
 
     it("should be HOME if USERPROFILE is not defined", () => {
+      const { getHomePath } = makeDependencies();
       const expected = path.join(path.sep, "user", "dir");
       jest
         .mocked(tryGetEnv)
         .mockImplementation((key) => (key === "HOME" ? expected : null));
 
-      const result = tryGetHomePath();
+      const result = getHomePath();
 
       expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
     });
 
     it("should fail if HOME and USERPROFILE are not defined", () => {
+      const { getHomePath } = makeDependencies();
       jest.mocked(tryGetEnv).mockReturnValue(null);
 
-      const result = tryGetHomePath();
+      const result = getHomePath();
 
       expect(result).toBeError();
     });

--- a/test/io/upm-config-io.test.ts
+++ b/test/io/upm-config-io.test.ts
@@ -1,7 +1,7 @@
 import {
+  makeUpmConfigDirGetter,
   makeUpmConfigLoader,
   RequiredEnvMissingError,
-  tryGetUpmConfigDir,
 } from "../../src/io/upm-config-io";
 import { tryGetHomePath } from "../../src/io/special-paths";
 import { Err, Ok } from "ts-results-es";
@@ -14,21 +14,29 @@ jest.mock("../../src/io/special-paths");
 
 describe("upm-config-io", () => {
   describe("get directory", () => {
+    function makeDependencies() {
+      const getUpmConfigDir = makeUpmConfigDirGetter();
+
+      return { getUpmConfigDir } as const;
+    }
+
     describe("no wsl and no system-user", () => {
       it("should be home path", async () => {
+        const { getUpmConfigDir } = makeDependencies();
         const expected = "/some/home/dir/";
         jest.mocked(tryGetHomePath).mockReturnValue(Ok(expected));
 
-        const result = await tryGetUpmConfigDir(false, false).promise;
+        const result = await getUpmConfigDir(false, false).promise;
 
         expect(result).toBeOk((actual) => expect(actual).toEqual(expected));
       });
 
       it("should fail if home could not be determined", async () => {
+        const { getUpmConfigDir } = makeDependencies();
         const expected = new RequiredEnvMissingError();
         jest.mocked(tryGetHomePath).mockReturnValue(Err(expected));
 
-        const result = await tryGetUpmConfigDir(false, false).promise;
+        const result = await getUpmConfigDir(false, false).promise;
 
         expect(result).toBeError((actual) => expect(actual).toEqual(expected));
       });

--- a/test/services/fetch-packument.test.ts
+++ b/test/services/fetch-packument.test.ts
@@ -7,8 +7,6 @@ import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { mockRegClientGetResult } from "./registry-client.mock";
 
-jest.mock("another-npm-registry-client");
-
 const packageA = makeDomainName("package-a");
 const exampleRegistry: Registry = {
   url: exampleRegistryUrl,

--- a/test/services/npmrc-auth.test.ts
+++ b/test/services/npmrc-auth.test.ts
@@ -7,16 +7,19 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import { RequiredEnvMissingError } from "../../src/io/upm-config-io";
 import { emptyNpmrc, setToken } from "../../src/domain/npmrc";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { IOError } from "../../src/io/file-io";
+import { IOError, ReadTextFile } from "../../src/io/file-io";
 import { makeAuthNpmrcService } from "../../src/services/npmrc-auth";
+import { mockService } from "./service.mock";
 
 const exampleNpmrcPath = "/users/someuser/.npmrc";
 
 jest.mock("../../src/io/npmrc-io");
 
 function makeDependencies() {
-  const authNpmrc = makeAuthNpmrcService();
-  return { authNpmrc } as const;
+  const readFile = mockService<ReadTextFile>();
+
+  const authNpmrc = makeAuthNpmrcService(readFile);
+  return { authNpmrc, readFile } as const;
 }
 
 describe("npmrc-auth", () => {

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -54,9 +54,6 @@ describe("env", () => {
   beforeEach(() => {
     // By default, we simulate the following:
 
-    // The following directories exist
-    jest.mocked(fs.existsSync).mockReturnValue(true);
-
     // process.cwd is in the root directory.
     jest.mocked(process.cwd).mockReturnValue(testRootPath);
 

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -4,7 +4,6 @@ import { Env, makeParseEnvService } from "../../src/services/parse-env";
 import { tryLoadProjectVersion } from "../../src/io/project-version-io";
 import { Err, Ok } from "ts-results-es";
 import { LoadUpmConfig, tryGetUpmConfigDir } from "../../src/io/upm-config-io";
-import fs from "fs";
 import { IOError, NotFoundError, ReadTextFile } from "../../src/io/file-io";
 import { FileParseError } from "../../src/common-errors";
 import { makeEditorVersion } from "../../src/domain/editor-version";
@@ -14,6 +13,7 @@ import { mockProjectVersion } from "../io/project-version-io.mock";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { makeMockLogger } from "../cli/log.mock";
 import { mockService } from "./service.mock";
+import { GetCwd } from "../../src/io/special-paths";
 
 jest.mock("../../src/io/project-version-io");
 jest.mock("../../src/io/upm-config-io");
@@ -46,16 +46,17 @@ function makeDependencies() {
 
   const readFile = mockService<ReadTextFile>();
 
-  const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile);
+  // process.cwd is in the root directory.
+  const getCwd = mockService<GetCwd>();
+  getCwd.mockReturnValue(testRootPath);
+
+  const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile, getCwd);
   return { parseEnv, log, loadUpmConfig } as const;
 }
 
 describe("env", () => {
   beforeEach(() => {
     // By default, we simulate the following:
-
-    // process.cwd is in the root directory.
-    jest.mocked(process.cwd).mockReturnValue(testRootPath);
 
     // The root directory does not contain an upm-config
     jest

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -5,7 +5,7 @@ import { tryLoadProjectVersion } from "../../src/io/project-version-io";
 import { Err, Ok } from "ts-results-es";
 import { LoadUpmConfig, tryGetUpmConfigDir } from "../../src/io/upm-config-io";
 import fs from "fs";
-import { IOError, NotFoundError } from "../../src/io/file-io";
+import { IOError, NotFoundError, ReadTextFile } from "../../src/io/file-io";
 import { FileParseError } from "../../src/common-errors";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { NoWslError } from "../../src/io/wsl";
@@ -44,7 +44,9 @@ function makeDependencies() {
   const loadUpmConfig = mockService<LoadUpmConfig>();
   mockUpmConfig(loadUpmConfig, null);
 
-  const parseEnv = makeParseEnvService(log, loadUpmConfig);
+  const readFile = mockService<ReadTextFile>();
+
+  const parseEnv = makeParseEnvService(log, loadUpmConfig, readFile);
   return { parseEnv, log, loadUpmConfig } as const;
 }
 


### PR DESCRIPTION
This change completes the process that I was working on over the last weeks where functions get side-effect functions injected into them instead of importing them directly.

This makes them easier to test as well as making dependencies between services clearer.