### PR TITLE
fix: bad declaration file

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -28,11 +28,7 @@ import {
   UnityProjectManifest,
 } from "../domain/project-manifest";
 import { CmdOptions } from "./options";
-import {
-  PackumentResolveError,
-  pickMostFixable,
-  
-} from "../packument-resolving";
+import { PackumentResolveError, pickMostFixable } from "../packument-resolving";
 import { SemanticVersion } from "../domain/semantic-version";
 import { areArraysEqual } from "../utils/array-utils";
 import { Err, Ok, Result } from "ts-results-es";
@@ -52,7 +48,7 @@ import { logValidDependency } from "./dependency-logging";
 import { unityRegistryUrl } from "../domain/registry-url";
 import { tryGetTargetEditorVersionFor } from "../domain/package-manifest";
 import { FetchPackumentError } from "../services/fetch-packument";
-import {VersionNotFoundError} from "../domain/packument";
+import { VersionNotFoundError } from "../domain/packument";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -6,10 +6,7 @@ import {
   splitPackageReference,
 } from "../domain/package-reference";
 import { CmdOptions } from "./options";
-import {
-  PackumentResolveError,
-  
-} from "../packument-resolving";
+import { PackumentResolveError } from "../packument-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { Ok, Result } from "ts-results-es";
 import {
@@ -18,7 +15,7 @@ import {
 } from "../services/dependency-resolving";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
-import {VersionNotFoundError} from "../domain/packument";
+import { VersionNotFoundError } from "../domain/packument";
 
 export type DepsError = EnvParseError | DependencyResolveError;
 

--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -3,7 +3,7 @@ import { EnvParseError, ParseEnvService } from "../services/parse-env";
 import { CmdOptions } from "./options";
 import { formatAsTable } from "./output-formatting";
 import { AsyncResult, Ok, Result } from "ts-results-es";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import {
   SearchedPackument,
   SearchRegistryService,

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -4,13 +4,10 @@ import {
 } from "../io/project-manifest-io";
 import { NotFoundError } from "../io/file-io";
 import { Logger } from "npmlog";
-import {
-  PackumentResolveError,
-  
-} from "../packument-resolving";
+import { PackumentResolveError } from "../packument-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { DomainName } from "../domain/domain-name";
-import {VersionNotFoundError} from "../domain/packument";
+import { VersionNotFoundError } from "../domain/packument";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -125,4 +125,3 @@ export const trySaveUpmConfig = (
   const content = TOML.stringify(config);
   return writeFile(configPath, content).map(() => configPath);
 };
-

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -19,8 +19,8 @@ import {
 } from "./resolve-latest-version";
 import { Err, Ok, Result } from "ts-results-es";
 import { FetchPackumentError } from "./fetch-packument";
-import { HttpErrorBase } from "npm-registry-fetch";
 import { PackumentNotFoundError } from "../common-errors";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 export type DependencyBase = {
   /**

--- a/src/services/fetch-packument.ts
+++ b/src/services/fetch-packument.ts
@@ -2,7 +2,7 @@ import RegClient from "another-npm-registry-client";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { UnityPackument } from "../domain/packument";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { DomainName } from "../domain/domain-name";
 import { Registry } from "../domain/registry";
 

--- a/src/services/get-all-packuments.ts
+++ b/src/services/get-all-packuments.ts
@@ -1,9 +1,10 @@
 import { Registry } from "../domain/registry";
 import { AsyncResult, Err, Ok } from "ts-results-es";
-import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
+import npmFetch from "npm-registry-fetch";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { getNpmFetchOptions, SearchedPackument } from "./search-registry";
 import { DomainName } from "../domain/domain-name";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 /**
  * The result of querying the /-/all endpoint.

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -4,7 +4,7 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import { SemanticVersion } from "../domain/semantic-version";
 import { PackumentNotFoundError } from "../common-errors";
 import { FetchPackumentError, FetchPackumentService } from "./fetch-packument";
-import {NoVersionsError, tryGetLatestVersion} from "../domain/packument";
+import { NoVersionsError, tryGetLatestVersion } from "../domain/packument";
 import { recordKeys } from "../utils/record-utils";
 
 /**

--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -5,11 +5,10 @@ import {
   PackumentResolveError,
   ResolvableVersion,
   ResolvedPackument,
-  
 } from "../packument-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { FetchPackumentError, FetchPackumentService } from "./fetch-packument";
-import {tryResolvePackumentVersion} from "../domain/packument";
+import { tryResolvePackumentVersion } from "../domain/packument";
 
 /**
  * Service function for resolving remove packuments.

--- a/src/services/search-registry.ts
+++ b/src/services/search-registry.ts
@@ -1,10 +1,11 @@
 import { AsyncResult, Err, Ok } from "ts-results-es";
-import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
+import npmFetch from "npm-registry-fetch";
 import npmSearch from "libnpmsearch";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { UnityPackument } from "../domain/packument";
 import { SemanticVersion } from "../domain/semantic-version";
 import { Registry } from "../domain/registry";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 /**
  * A type representing a searched packument. Instead of having all versions

--- a/src/types/npm-registry-fetch.d.ts
+++ b/src/types/npm-registry-fetch.d.ts
@@ -1,8 +1,0 @@
-import { Response } from "node-fetch";
-
-declare module "npm-registry-fetch" {
-  class HttpErrorBase extends Error {
-    statusCode: Response["status"];
-    code: `E${Response["status"]}}` | `E${string}`;
-  }
-}

--- a/src/types/npm-registry-fetch/lib/errors.d.ts
+++ b/src/types/npm-registry-fetch/lib/errors.d.ts
@@ -1,0 +1,8 @@
+import {Response} from "node-fetch";
+
+declare module "npm-registry-fetch/lib/errors" {
+  export class HttpErrorBase extends Error {
+    statusCode: Response["status"];
+    code: `E${Response["status"]}}` | `E${string}`;
+  }
+}

--- a/src/utils/error-type-guards.ts
+++ b/src/utils/error-type-guards.ts
@@ -1,5 +1,5 @@
-import { HttpErrorBase } from "npm-registry-fetch";
 import assert, { AssertionError } from "assert";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 /**
  * @throws {AssertionError} The given parameter is not an error.

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -30,7 +30,7 @@ import {
   WriteProjectManifest,
 } from "../../src/io/project-manifest-io";
 import { makePackageReference } from "../../src/domain/package-reference";
-import {VersionNotFoundError} from "../../src/domain/packument";
+import { VersionNotFoundError } from "../../src/domain/packument";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -11,7 +11,7 @@ import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { ResolveDependenciesService } from "../../src/services/dependency-resolving";
 import { mockService } from "../services/service.mock";
-import {VersionNotFoundError} from "../../src/domain/packument";
+import { VersionNotFoundError } from "../../src/domain/packument";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../src/services/search-registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import {
   AllPackumentsResult,
   GetAllPackumentsService,

--- a/test/services/fetch-packument.test.ts
+++ b/test/services/fetch-packument.test.ts
@@ -1,6 +1,6 @@
 import { buildPackument } from "../domain/data-packument";
 import { makeFetchPackumentService } from "../../src/services/fetch-packument";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { makeDomainName } from "../../src/domain/domain-name";
 import RegClient from "another-npm-registry-client";
 import { Registry } from "../../src/domain/registry";

--- a/test/services/get-all-packuments.test.ts
+++ b/test/services/get-all-packuments.test.ts
@@ -1,7 +1,8 @@
-import npmFetch, { HttpErrorBase } from "npm-registry-fetch";
+import npmFetch from "npm-registry-fetch";
 import { makeGetAllPackumentsService } from "../../src/services/get-all-packuments";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 jest.mock("npm-registry-fetch");
 

--- a/test/services/npm-login.test.ts
+++ b/test/services/npm-login.test.ts
@@ -4,7 +4,7 @@ import {
   makeNpmLoginService,
 } from "../../src/services/npm-login";
 import RegClient from "another-npm-registry-client";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { mockRegClientAddUserResult } from "./registry-client.mock";
 

--- a/test/services/packument-resolving.mock.ts
+++ b/test/services/packument-resolving.mock.ts
@@ -1,8 +1,8 @@
 import { Err } from "ts-results-es";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import {
-    tryResolvePackumentVersion,
-    UnityPackument
+  tryResolvePackumentVersion,
+  UnityPackument,
 } from "../../src/domain/packument";
 import { RegistryUrl } from "../../src/domain/registry-url";
 import { ResolveRemotePackumentService } from "../../src/services/resolve-remote-packument";

--- a/test/services/registry-client.mock.ts
+++ b/test/services/registry-client.mock.ts
@@ -1,6 +1,6 @@
 import RegClient, { AddUserResponse } from "another-npm-registry-client";
 import { UnityPackument } from "../../src/domain/packument";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { Response } from "request";
 
 export function mockRegClientGetResult(

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -4,7 +4,7 @@ import { makeResolveLatestVersionService } from "../../src/services/resolve-late
 import { makeDomainName } from "../../src/domain/domain-name";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { Ok } from "ts-results-es";
-import {NoVersionsError, UnityPackument} from "../../src/domain/packument";
+import { NoVersionsError, UnityPackument } from "../../src/domain/packument";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";

--- a/test/services/search-registry.test.ts
+++ b/test/services/search-registry.test.ts
@@ -1,6 +1,6 @@
 import npmSearch from "libnpmsearch";
 import search from "libnpmsearch";
-import { HttpErrorBase } from "npm-registry-fetch";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { makeSearchRegistryService } from "../../src/services/search-registry";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";


### PR DESCRIPTION
The declaration files for `npm-registry-fetch` package do not expose the error-class it throws when a fetch failed. Because of this, we wrote our own declaration file for it.

The declaration file was incorrectly written. It placed the error class into the packages `index` file even though it is inside `lib/errors`. After updating the declaration and relevant imports the error is now fixed.

See #319.