### PR TITLE
test: add basic e2e tests

### DIFF
--- a/test/e2e/common.ts
+++ b/test/e2e/common.ts
@@ -1,0 +1,47 @@
+import os from "os";
+import path from "path";
+import childProcess from "child_process";
+
+const testDirBasePath = path.resolve(os.tmpdir(), "openupm-cli");
+
+/**
+ * Makes a temporary directory path for a test.
+ * @param testName A short string identifying the test or test-suite.
+ * @returns The path.
+ */
+export function makeTestDirPath(testName: string): string {
+  return path.join(testDirBasePath, testName);
+}
+
+export type AppOutput = {
+  stdOut: string[];
+  stdErr: string[];
+  code: number;
+};
+
+/**
+ * Runs Openupm.
+ * @param args Strings containing commands, arguments and options.
+ * @returns The runs status-code.
+ */
+export function runOpenupm(args: string[]): Promise<AppOutput> {
+  const openupmProcess = childProcess.fork("./lib/index.js", args, {
+    stdio: "pipe",
+  });
+
+  const stdOut = Array.of<string>();
+  const stdErr = Array.of<string>();
+
+  openupmProcess.stdout!.on("data", (data) => stdOut.push(data.toString()));
+  openupmProcess.stderr!.on("data", (data) => stdErr.push(data.toString()));
+
+  return new Promise<AppOutput>((resolve) =>
+    openupmProcess.on("exit", (code) =>
+      resolve({
+        stdOut,
+        stdErr,
+        code: code!,
+      })
+    )
+  );
+}

--- a/test/e2e/help.test.ts
+++ b/test/e2e/help.test.ts
@@ -1,0 +1,17 @@
+import { runOpenupm } from "./common";
+
+describe("help", () => {
+  it("should show help when running with no commands", async () => {
+    const output = await runOpenupm([]);
+
+    expect(output.stdErr).toEqual(
+      expect.arrayContaining([expect.stringContaining("Usage")])
+    );
+  });
+
+  it("should exit with 0", async () => {
+    const output = await runOpenupm([]);
+
+    expect(output.code).toEqual(1);
+  });
+});

--- a/test/e2e/unknown.test.ts
+++ b/test/e2e/unknown.test.ts
@@ -1,0 +1,25 @@
+import { runOpenupm } from "./common";
+
+describe("unknown command", () => {
+  it("should warn of unknown command", async () => {
+    const output = await runOpenupm(["unknown-command"]);
+
+    expect(output.stdErr).toEqual(
+      expect.arrayContaining([expect.stringContaining("unknown command")])
+    );
+  });
+
+  it("should suggest to run with help", async () => {
+    const output = await runOpenupm(["unknown-command"]);
+
+    expect(output.stdErr).toEqual(
+      expect.arrayContaining([expect.stringContaining("see --help")])
+    );
+  });
+
+  it("should exit with 1", async () => {
+    const output = await runOpenupm(["unknown-command"]);
+
+    expect(output.code).toEqual(1);
+  });
+});

--- a/test/e2e/version.test.ts
+++ b/test/e2e/version.test.ts
@@ -1,0 +1,18 @@
+import { runOpenupm } from "./common";
+import pkgJson from "../../package.json";
+
+describe("version", () => {
+  it("should print current version", async () => {
+    const output = await runOpenupm(["--version"]);
+
+    expect(output.stdOut).toEqual(
+      expect.arrayContaining([expect.stringContaining(pkgJson.version)])
+    );
+  });
+
+  it("should exit with 0", async () => {
+    const output = await runOpenupm(["--version"]);
+
+    expect(output.code).toEqual(0);
+  });
+});


### PR DESCRIPTION
This PR adds some basic e2e tests that test the app on the CLI level. This first batch of tests is mostly just to see if it works as expected.