### PR TITLE
refactor: all-packuments service to io

### DIFF
--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -9,7 +9,7 @@ import {
   SearchRegistryService,
 } from "../services/search-registry";
 import { Registry } from "../domain/registry";
-import { GetAllPackumentsService } from "../services/get-all-packuments";
+import { FetchAllPackuments } from "../io/all-packuments-io";
 import { Logger } from "npmlog";
 
 export type SearchError = EnvParseError | HttpErrorBase;
@@ -32,7 +32,7 @@ export type SearchCmd = (
 export function makeSearchCmd(
   parseEnv: ParseEnvService,
   searchRegistry: SearchRegistryService,
-  getAllPackuments: GetAllPackumentsService,
+  fetchAllPackuments: FetchAllPackuments,
   log: Logger
 ): SearchCmd {
   function searchEndpoint(
@@ -49,7 +49,7 @@ export function makeSearchCmd(
     registry: Registry,
     keyword: string
   ): AsyncResult<SearchedPackument[], HttpErrorBase> {
-    return getAllPackuments(registry).map((allPackuments) => {
+    return fetchAllPackuments(registry).map((allPackuments) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { _updated, ...packumentEntries } = allPackuments;
       const packuments = Object.values(packumentEntries);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,7 @@ import pkg from "../../package.json";
 import { makeSearchCmd } from "./cmd-search";
 import { makeViewCmd } from "./cmd-view";
 import { makeResolveDependenciesService } from "../services/dependency-resolving";
-import { makeGetAllPackumentsService } from "../services/get-all-packuments";
+import { makeAllPackumentsFetcher } from "../io/all-packuments-io";
 import {
   mustBeDomainName,
   mustBePackageReference,
@@ -42,7 +42,7 @@ import {
 import { makeCwdGetter, makeHomePathGetter } from "../io/special-paths";
 import { makeProjectVersionLoader } from "../io/project-version-io";
 import { makeSaveAuthToUpmConfigService } from "../services/upm-auth";
-import {makePackumentFetcher} from "../io/packument-io";
+import { makePackumentFetcher } from "../io/packument-io";
 
 // Composition root
 
@@ -60,6 +60,8 @@ const findNpmrcPath = makeNpmrcPathFinder(getHomePath);
 const loadNpmrc = makeNpmrcLoader(readFile);
 const saveNpmrc = makeNpmrcSaver(writeFile);
 const loadProjectVersion = makeProjectVersionLoader(readFile);
+const fetchPackument = makePackumentFetcher(regClient);
+const fetchAllPackuments = makeAllPackumentsFetcher();
 
 const parseEnv = makeParseEnvService(
   log,
@@ -68,7 +70,6 @@ const parseEnv = makeParseEnvService(
   getCwd,
   loadProjectVersion
 );
-const fetchPackument = makePackumentFetcher(regClient);
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);
 const npmLogin = makeNpmLoginService(regClient);
 const searchRegistry = makeSearchRegistryService();
@@ -79,7 +80,6 @@ const resolveDependencies = makeResolveDependenciesService(
   resolveRemotePackument,
   resolveLatestVersion
 );
-const getAllPackuments = makeGetAllPackumentsService();
 const saveAuthToUpmConfig = makeSaveAuthToUpmConfigService(
   loadUpmConfig,
   writeFile
@@ -104,7 +104,7 @@ const loginCmd = makeLoginCmd(
 const searchCmd = makeSearchCmd(
   parseEnv,
   searchRegistry,
-  getAllPackuments,
+  fetchAllPackuments,
   log
 );
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log);

--- a/src/io/all-packuments-io.ts
+++ b/src/io/all-packuments-io.ts
@@ -2,35 +2,38 @@ import { Registry } from "../domain/registry";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import npmFetch from "npm-registry-fetch";
 import { assertIsHttpError } from "../utils/error-type-guards";
-import { getNpmFetchOptions, SearchedPackument } from "./search-registry";
+import {
+  getNpmFetchOptions,
+  SearchedPackument,
+} from "../services/search-registry";
 import { DomainName } from "../domain/domain-name";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 /**
  * The result of querying the /-/all endpoint.
  */
-export type AllPackumentsResult = Readonly<{
+export type AllPackumentsR = Readonly<{
   _updated: number;
   [name: DomainName]: SearchedPackument;
 }>;
 
 /**
- * Service for getting all packuments from a registry.
+ * Function for getting fetching packuments from a npm registry.
  * @param registry The registry to get packuments for.
  */
-export type GetAllPackumentsService = (
+export type FetchAllPackuments = (
   registry: Registry
-) => AsyncResult<AllPackumentsResult, HttpErrorBase>;
+) => AsyncResult<AllPackumentsR, HttpErrorBase>;
 
 /**
- * Makes a {@link GetAllPackumentsService} service.
+ * Makes a {@link FetchAllPackuments} function.
  */
-export function makeGetAllPackumentsService(): GetAllPackumentsService {
+export function makeAllPackumentsFetcher(): FetchAllPackuments {
   return (registry) => {
     return new AsyncResult(
       npmFetch
         .json("/-/all", getNpmFetchOptions(registry))
-        .then((result) => Ok(result as AllPackumentsResult))
+        .then((result) => Ok(result as AllPackumentsR))
         .catch((error) => {
           assertIsHttpError(error);
           return Err(error);

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -10,9 +10,9 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import {
-  AllPackumentsResult,
-  GetAllPackumentsService,
-} from "../../src/services/get-all-packuments";
+  AllPackumentsR,
+  FetchAllPackuments,
+} from "../../src/io/all-packuments-io";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 
@@ -33,12 +33,12 @@ function makeDependencies() {
   const searchRegistry = mockService<SearchRegistryService>();
   searchRegistry.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
 
-  const getAllPackuments = mockService<GetAllPackumentsService>();
+  const getAllPackuments = mockService<FetchAllPackuments>();
   getAllPackuments.mockReturnValue(
     Ok({
       _updated: 9999,
       [exampleSearchResult.name]: exampleSearchResult,
-    } as AllPackumentsResult).toAsyncResult()
+    } as AllPackumentsR).toAsyncResult()
   );
 
   const log = makeMockLogger();

--- a/test/io/all-packuments-io.test.ts
+++ b/test/io/all-packuments-io.test.ts
@@ -1,5 +1,5 @@
 import npmFetch from "npm-registry-fetch";
-import { makeGetAllPackumentsService } from "../../src/services/get-all-packuments";
+import { makeAllPackumentsFetcher } from "../../src/io/all-packuments-io";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
@@ -12,11 +12,11 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const getAllPackuments = makeGetAllPackumentsService();
+  const getAllPackuments = makeAllPackumentsFetcher();
   return { getAllPackuments } as const;
 }
 
-describe("get all packuments service", () => {
+describe("fetch all packuments", () => {
   it("should fail on error response", async () => {
     const expected = {
       message: "Idk, it failed",


### PR DESCRIPTION
Change the get-all-packuments service to an io function because it mostly just abstracts interaction with the outside world without contributing any business logic. Also renamed it to "fetchAllPackuments" to better fit with other similar functions.