### PR TITLE
refactor: npm search service to io

### DIFF
--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -4,10 +4,7 @@ import { CmdOptions } from "./options";
 import { formatAsTable } from "./output-formatting";
 import { AsyncResult, Ok, Result } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import {
-  SearchedPackument,
-  SearchRegistryService,
-} from "../services/search-registry";
+import { SearchedPackument, SearchRegistry } from "../io/npm-search";
 import { Registry } from "../domain/registry";
 import { FetchAllPackuments } from "../io/all-packuments-io";
 import { Logger } from "npmlog";
@@ -31,7 +28,7 @@ export type SearchCmd = (
  */
 export function makeSearchCmd(
   parseEnv: ParseEnvService,
-  searchRegistry: SearchRegistryService,
+  searchRegistry: SearchRegistry,
   fetchAllPackuments: FetchAllPackuments,
   log: Logger
 ): SearchCmd {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,7 +9,7 @@ import { CmdOptions } from "./options";
 import { makeAddCmd } from "./cmd-add";
 import { makeAuthNpmrcService } from "../services/npmrc-auth";
 import { makeNpmLoginService } from "../services/npm-login";
-import { makeSearchRegistryService } from "../services/search-registry";
+import { makeRegistrySearcher } from "../io/npm-search";
 import pkg from "../../package.json";
 import { makeSearchCmd } from "./cmd-search";
 import { makeViewCmd } from "./cmd-view";
@@ -62,6 +62,7 @@ const saveNpmrc = makeNpmrcSaver(writeFile);
 const loadProjectVersion = makeProjectVersionLoader(readFile);
 const fetchPackument = makePackumentFetcher(regClient);
 const fetchAllPackuments = makeAllPackumentsFetcher();
+const searchRegistry = makeRegistrySearcher();
 
 const parseEnv = makeParseEnvService(
   log,
@@ -72,7 +73,6 @@ const parseEnv = makeParseEnvService(
 );
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);
 const npmLogin = makeNpmLoginService(regClient);
-const searchRegistry = makeSearchRegistryService();
 const resolveRemotePackument =
   makeResolveRemotePackumentService(fetchPackument);
 const resolveLatestVersion = makeResolveLatestVersionService(fetchPackument);

--- a/src/io/all-packuments-io.ts
+++ b/src/io/all-packuments-io.ts
@@ -5,7 +5,7 @@ import { assertIsHttpError } from "../utils/error-type-guards";
 import {
   getNpmFetchOptions,
   SearchedPackument,
-} from "../services/search-registry";
+} from "./npm-search";
 import { DomainName } from "../domain/domain-name";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 

--- a/src/io/npm-search.ts
+++ b/src/io/npm-search.ts
@@ -18,11 +18,11 @@ export type SearchedPackument = Readonly<
 >;
 
 /**
- * Service function for searching packuments on a registry.
+ * Function for searching packuments on a registry.
  * @param registry The registry to search.
  * @param keyword The keyword to search.
  */
-export type SearchRegistryService = (
+export type SearchRegistry = (
   registry: Registry,
   keyword: string
 ) => AsyncResult<ReadonlyArray<SearchedPackument>, HttpErrorBase>;
@@ -42,9 +42,9 @@ export const getNpmFetchOptions = function (
 };
 
 /**
- * Makes a {@link SearchRegistryService} function.
+ * Makes a {@link SearchRegistry} function.
  */
-export function makeSearchRegistryService(): SearchRegistryService {
+export function makeRegistrySearcher(): SearchRegistry {
   return (registry, keyword) => {
     return new AsyncResult(
       npmSearch(keyword, getNpmFetchOptions(registry))

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -4,8 +4,8 @@ import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import {
   SearchedPackument,
-  SearchRegistryService,
-} from "../../src/services/search-registry";
+  SearchRegistry,
+} from "../../src/io/npm-search";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
@@ -30,7 +30,7 @@ function makeDependencies() {
     Ok({ registry: { url: exampleRegistryUrl, auth: null } } as Env)
   );
 
-  const searchRegistry = mockService<SearchRegistryService>();
+  const searchRegistry = mockService<SearchRegistry>();
   searchRegistry.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
 
   const getAllPackuments = mockService<FetchAllPackuments>();

--- a/test/io/npm-search.test.ts
+++ b/test/io/npm-search.test.ts
@@ -1,7 +1,7 @@
 import npmSearch from "libnpmsearch";
 import search from "libnpmsearch";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { makeSearchRegistryService } from "../../src/services/search-registry";
+import { makeRegistrySearcher } from "../../src/io/npm-search";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 
@@ -13,11 +13,11 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const searchRegistry = makeSearchRegistryService();
+  const searchRegistry = makeRegistrySearcher();
   return { searchRegistry } as const;
 }
 
-describe("search service", () => {
+describe("npm search", () => {
   it("should fail for error response", async () => {
     const expected = {
       message: "Idk, it failed",


### PR DESCRIPTION
The service for searching keywords on a npm registry is mostly an abstraction for an external library. It does not really have any business logic. As such it should be a io function and not a service.