### PR TITLE
refactor: revert previous fix

### DIFF
--- a/src/io/all-packuments-io.ts
+++ b/src/io/all-packuments-io.ts
@@ -9,14 +9,10 @@ import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 /**
  * The result of querying the /-/all endpoint.
  */
-export type AllPackuments = Readonly<
-  | {
-      _updated: number;
-    }
-  | {
-      [name: DomainName]: SearchedPackument;
-    }
->;
+export type AllPackuments = Readonly<{
+  _updated: number;
+  [name: DomainName]: SearchedPackument;
+}>;
 
 /**
  * Function for getting fetching packuments from a npm registry.


### PR DESCRIPTION
Was to greedy and skipped the tests in https://github.com/openupm/openupm-cli/commit/659f16c7287f728a98c53954cba12ddc80b03232. This actually breaked the code because deconstructing does not work anymore.

Seems like what i wanted to do in that change is not possible. https://github.com/openupm/openupm-cli/commit/659f16c7287f728a98c53954cba12ddc80b03232