### PR TITLE
refactor: extract search service

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -48,7 +48,7 @@ import { logValidDependency } from "./dependency-logging";
 import { unityRegistryUrl } from "../domain/registry-url";
 import { tryGetTargetEditorVersionFor } from "../domain/package-manifest";
 import { VersionNotFoundError } from "../domain/packument";
-import {FetchPackumentError} from "../io/packument-io";
+import { FetchPackumentError } from "../io/packument-io";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";

--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -2,12 +2,10 @@ import * as os from "os";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
 import { CmdOptions } from "./options";
 import { formatAsTable } from "./output-formatting";
-import { AsyncResult, Ok, Result } from "ts-results-es";
+import { Ok, Result } from "ts-results-es";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { SearchedPackument, SearchRegistry } from "../io/npm-search";
-import { Registry } from "../domain/registry";
-import { FetchAllPackuments } from "../io/all-packuments-io";
 import { Logger } from "npmlog";
+import { SearchPackages } from "../services/search-packages";
 
 export type SearchError = EnvParseError | HttpErrorBase;
 
@@ -28,66 +26,33 @@ export type SearchCmd = (
  */
 export function makeSearchCmd(
   parseEnv: ParseEnvService,
-  searchRegistry: SearchRegistry,
-  fetchAllPackuments: FetchAllPackuments,
+  searchPackages: SearchPackages,
   log: Logger
 ): SearchCmd {
-  function searchEndpoint(
-    registry: Registry,
-    keyword: string
-  ): AsyncResult<ReadonlyArray<SearchedPackument>, HttpErrorBase> {
-    return searchRegistry(registry, keyword).map((results) => {
-      log.verbose("npmsearch", results.join(os.EOL));
-      return results;
-    });
-  }
-
-  function searchOld(
-    registry: Registry,
-    keyword: string
-  ): AsyncResult<SearchedPackument[], HttpErrorBase> {
-    return fetchAllPackuments(registry).map((allPackuments) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { _updated, ...packumentEntries } = allPackuments;
-      const packuments = Object.values(packumentEntries);
-
-      log.verbose("endpoint.all", packuments.join(os.EOL));
-
-      // filter keyword
-      const klc = keyword.toLowerCase();
-
-      return packuments.filter((packument) =>
-        packument.name.toLowerCase().includes(klc)
-      );
-    });
-  }
-
   return async (keyword, options) => {
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) return envResult;
     const env = envResult.value;
 
-    // search endpoint
-    let result = await searchEndpoint(env.registry, keyword).promise;
-
-    // search old search
-    if (result.isErr()) {
+    let usedEndpoint = "npmsearch";
+    const searchResult = await searchPackages(env.registry, keyword, () => {
+      usedEndpoint = "endpoint.all";
       log.warn("", "fast search endpoint is not available, using old search.");
-      result = await searchOld(env.registry, keyword).promise;
-    }
-    if (result.isErr()) {
+    }).promise;
+
+    if (searchResult.isErr()) {
       log.warn("", "/-/all endpoint is not available");
-      return result;
+      return searchResult;
     }
 
-    const results = result.value;
-
+    const results = searchResult.value;
     if (results.length === 0) {
       log.notice("", `No matches found for "${keyword}"`);
       return Ok(undefined);
     }
 
+    log.verbose(usedEndpoint, results.map((it) => it.name).join(os.EOL));
     console.log(formatAsTable(results));
     return Ok(undefined);
   };

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -16,7 +16,7 @@ import {
 } from "../common-errors";
 import { Logger } from "npmlog";
 
-import {FetchPackument} from "../io/packument-io";
+import { FetchPackument } from "../io/packument-io";
 
 export type ViewOptions = CmdOptions;
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -43,6 +43,7 @@ import { makeCwdGetter, makeHomePathGetter } from "../io/special-paths";
 import { makeProjectVersionLoader } from "../io/project-version-io";
 import { makeSaveAuthToUpmConfigService } from "../services/upm-auth";
 import { makePackumentFetcher } from "../io/packument-io";
+import { makePackagesSearcher } from "../services/search-packages";
 
 // Composition root
 
@@ -84,6 +85,7 @@ const saveAuthToUpmConfig = makeSaveAuthToUpmConfigService(
   loadUpmConfig,
   writeFile
 );
+const searchPackages = makePackagesSearcher(searchRegistry, fetchAllPackuments);
 
 const addCmd = makeAddCmd(
   parseEnv,
@@ -101,12 +103,7 @@ const loginCmd = makeLoginCmd(
   saveAuthToUpmConfig,
   log
 );
-const searchCmd = makeSearchCmd(
-  parseEnv,
-  searchRegistry,
-  fetchAllPackuments,
-  log
-);
+const searchCmd = makeSearchCmd(parseEnv, searchPackages, log);
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log);
 const removeCmd = makeRemoveCmd(
   parseEnv,

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -20,7 +20,7 @@ import {
 import { Err, Ok, Result } from "ts-results-es";
 import { PackumentNotFoundError } from "../common-errors";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import {FetchPackumentError} from "../io/packument-io";
+import { FetchPackumentError } from "../io/packument-io";
 
 export type DependencyBase = {
   /**

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -5,7 +5,7 @@ import { SemanticVersion } from "../domain/semantic-version";
 import { PackumentNotFoundError } from "../common-errors";
 import { NoVersionsError, tryGetLatestVersion } from "../domain/packument";
 import { recordKeys } from "../utils/record-utils";
-import {FetchPackumentError, FetchPackument} from "../io/packument-io";
+import { FetchPackumentError, FetchPackument } from "../io/packument-io";
 
 /**
  * Error which may occur when resolving the latest version for a package.

--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -8,7 +8,7 @@ import {
 } from "../packument-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { tryResolvePackumentVersion } from "../domain/packument";
-import {FetchPackumentError, FetchPackument} from "../io/packument-io";
+import { FetchPackumentError, FetchPackument } from "../io/packument-io";
 
 /**
  * Service function for resolving remove packuments.

--- a/src/services/search-packages.ts
+++ b/src/services/search-packages.ts
@@ -1,0 +1,45 @@
+import { Registry } from "../domain/registry";
+import { AsyncResult } from "ts-results-es";
+import { SearchedPackument, SearchRegistry } from "../io/npm-search";
+import { FetchAllPackuments } from "../io/all-packuments-io";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+
+export type SearchPackagesError = HttpErrorBase;
+
+export type SearchPackages = (
+  registry: Registry,
+  keyword: string,
+  onUseAllFallback?: () => void
+) => AsyncResult<ReadonlyArray<SearchedPackument>, SearchPackagesError>;
+
+export function makePackagesSearcher(
+  searchRegistry: SearchRegistry,
+  fetchAllPackuments: FetchAllPackuments
+): SearchPackages {
+  function searchInAll(
+    registry: Registry,
+    keyword: string
+  ): AsyncResult<SearchedPackument[], HttpErrorBase> {
+    return fetchAllPackuments(registry).map((allPackuments) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { _updated, ...packumentEntries } = allPackuments;
+      const packuments = Object.values(packumentEntries);
+
+      // filter keyword
+      const klc = keyword.toLowerCase();
+
+      return packuments.filter((packument) =>
+        packument.name.toLowerCase().includes(klc)
+      );
+    });
+  }
+
+  return (registry, keyword, onUseOldSearch) => {
+    // search endpoint
+    return searchRegistry(registry, keyword).orElse(() => {
+      // search old search
+      onUseOldSearch && onUseOldSearch();
+      return searchInAll(registry, keyword);
+    });
+  };
+}

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -2,19 +2,13 @@ import { makeSearchCmd, SearchOptions } from "../../src/cli/cmd-search";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
-import {
-  SearchedPackument,
-  SearchRegistry,
-} from "../../src/io/npm-search";
+import { SearchedPackument } from "../../src/io/npm-search";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import {
-  AllPackuments,
-  FetchAllPackuments,
-} from "../../src/io/all-packuments-io";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
+import { SearchPackages } from "../../src/services/search-packages";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -30,30 +24,16 @@ function makeDependencies() {
     Ok({ registry: { url: exampleRegistryUrl, auth: null } } as Env)
   );
 
-  const searchRegistry = mockService<SearchRegistry>();
-  searchRegistry.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
-
-  const getAllPackuments = mockService<FetchAllPackuments>();
-  getAllPackuments.mockReturnValue(
-    Ok({
-      _updated: 9999,
-      [exampleSearchResult.name]: exampleSearchResult,
-    } as AllPackuments).toAsyncResult()
-  );
+  const searchPackages = mockService<SearchPackages>();
+  searchPackages.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
 
   const log = makeMockLogger();
 
-  const searchCmd = makeSearchCmd(
-    parseEnv,
-    searchRegistry,
-    getAllPackuments,
-    log
-  );
+  const searchCmd = makeSearchCmd(parseEnv, searchPackages, log);
   return {
     searchCmd,
     parseEnv,
-    searchRegistry,
-    getAllPackuments,
+    searchPackages,
     log,
   } as const;
 }
@@ -66,72 +46,106 @@ describe("cmd-search", () => {
     },
   };
 
-  describe("search endpoint", () => {
-    it("should print packument information", async () => {
-      const consoleSpy = jest.spyOn(console, "log");
-      const { searchCmd } = makeDependencies();
+  it("should print packument information", async () => {
+    const consoleSpy = jest.spyOn(console, "log");
+    const { searchCmd } = makeDependencies();
 
-      const searchResult = await searchCmd("package-a", options);
+    await searchCmd("package-a", options);
 
-      expect(searchResult).toBeOk();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("package-a")
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1.0.0"));
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("2019-10-02")
-      );
-    });
-
-    it("should notify of unknown packument", async () => {
-      const { searchCmd, searchRegistry, log } = makeDependencies();
-      searchRegistry.mockReturnValue(Ok([]).toAsyncResult());
-
-      const searchResult = await searchCmd("pkg-not-exist", options);
-
-      expect(searchResult).toBeOk();
-      expect(log.notice).toHaveLogLike(
-        "",
-        expect.stringContaining("No matches found")
-      );
-    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("package-a")
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1.0.0"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("2019-10-02")
+    );
   });
 
-  describe("old search", () => {
-    it("should print packument information", async () => {
-      const consoleSpy = jest.spyOn(console, "log");
-      const { searchCmd, searchRegistry, log } = makeDependencies();
-      searchRegistry.mockReturnValue(Err({} as HttpErrorBase).toAsyncResult());
+  it("should print all found packument names when using new search", async () => {
+    const { searchCmd, log } = makeDependencies();
 
-      const searchResult = await searchCmd("package-a", options);
+    await searchCmd("package-a", options);
 
-      expect(searchResult).toBeOk();
-      expect(log.warn).toHaveLogLike(
-        "",
-        expect.stringContaining("fast search endpoint is not available")
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("package-a")
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1.0.0"));
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("2019-10-02")
-      );
-    });
+    expect(log.verbose).toHaveBeenCalledWith(
+      "npmsearch",
+      expect.stringContaining("package-a")
+    );
+  });
 
-    it("should notify of unknown packument", async () => {
-      const { searchCmd, searchRegistry, log, getAllPackuments } =
-        makeDependencies();
-      searchRegistry.mockReturnValue(Err({} as HttpErrorBase).toAsyncResult());
-      getAllPackuments.mockReturnValue(Ok({ _updated: 9999 }).toAsyncResult());
+  it("should be ok if no network error occurred", async () => {
+    const { searchCmd } = makeDependencies();
 
-      const searchResult = await searchCmd("pkg-not-exist", options);
+    const result = await searchCmd("pkg-not-exist", options);
 
-      expect(searchResult).toBeOk();
-      expect(log.notice).toHaveLogLike(
-        "",
-        expect.stringContaining("No matches found")
-      );
-    });
+    expect(result).toBeOk();
+  });
+
+  it("should notify of unknown packument", async () => {
+    const { searchCmd, searchPackages, log } = makeDependencies();
+    searchPackages.mockReturnValue(Ok([]).toAsyncResult());
+
+    await searchCmd("pkg-not-exist", options);
+
+    expect(log.notice).toHaveLogLike(
+      "",
+      expect.stringContaining("No matches found")
+    );
+  });
+
+  it("should fail if packuments could not be searched", async () => {
+    const expected = { statusCode: 500 } as HttpErrorBase;
+    const { searchCmd, searchPackages } = makeDependencies();
+    searchPackages.mockReturnValue(Err(expected).toAsyncResult());
+
+    const result = await searchCmd("package-a", options);
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+
+  it("should notify if packuments could not be searched", async () => {
+    const expected = { statusCode: 500 } as HttpErrorBase;
+    const { searchCmd, searchPackages, log } = makeDependencies();
+    searchPackages.mockReturnValue(Err(expected).toAsyncResult());
+
+    await searchCmd("package-a", options);
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "",
+      "/-/all endpoint is not available"
+    );
+  });
+
+  it("should notify when falling back to old search", async () => {
+    const { searchCmd, searchPackages, log } = makeDependencies();
+    searchPackages.mockImplementation(
+      (_registry, _keyword, onUseAllFallback) => {
+        onUseAllFallback && onUseAllFallback();
+        return Ok([]).toAsyncResult();
+      }
+    );
+
+    await searchCmd("package-a", options);
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "",
+      expect.stringContaining("using old search")
+    );
+  });
+
+  it("should print all found packument names when using old search", async () => {
+    const { searchCmd, searchPackages, log } = makeDependencies();
+    searchPackages.mockImplementation(
+      (_registry, _keyword, onUseAllFallback) => {
+        onUseAllFallback && onUseAllFallback();
+        return Ok([exampleSearchResult]).toAsyncResult();
+      }
+    );
+
+    await searchCmd("package-a", options);
+
+    expect(log.verbose).toHaveBeenCalledWith(
+      "endpoint.all",
+      expect.stringContaining("package-a")
+    );
   });
 });

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -15,7 +15,7 @@ import { makeMockLogger } from "./log.mock";
 import { buildPackument } from "../domain/data-packument";
 import { mockService } from "../services/service.mock";
 
-import {FetchPackument} from "../../src/io/packument-io";
+import { FetchPackument } from "../../src/io/packument-io";
 
 const somePackage = makeDomainName("com.some.package");
 const somePackument = buildPackument(somePackage, (packument) =>

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -7,7 +7,7 @@ import { NoVersionsError, UnityPackument } from "../../src/domain/packument";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import {FetchPackument} from "../../src/io/packument-io";
+import { FetchPackument } from "../../src/io/packument-io";
 
 describe("resolve latest version service", () => {
   const somePackage = makeDomainName("com.some.package");

--- a/test/services/resolve-remote-packument.test.ts
+++ b/test/services/resolve-remote-packument.test.ts
@@ -7,7 +7,7 @@ import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { buildPackument } from "../domain/data-packument";
-import {FetchPackument} from "../../src/io/packument-io";
+import { FetchPackument } from "../../src/io/packument-io";
 
 describe("resolve remote packument service", () => {
   const somePackage = makeDomainName("com.some.package");

--- a/test/services/search-packages.test.ts
+++ b/test/services/search-packages.test.ts
@@ -1,0 +1,117 @@
+import { mockService } from "./service.mock";
+import { SearchedPackument, SearchRegistry } from "../../src/io/npm-search";
+import {
+  AllPackuments,
+  FetchAllPackuments,
+} from "../../src/io/all-packuments-io";
+import { makePackagesSearcher } from "../../src/services/search-packages";
+import { Registry } from "../../src/domain/registry";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+import { Err, Ok } from "ts-results-es";
+import { makeDomainName } from "../../src/domain/domain-name";
+import { makeSemanticVersion } from "../../src/domain/semantic-version";
+
+describe("search packages", () => {
+  const exampleRegistry: Registry = {
+    url: exampleRegistryUrl,
+    auth: null,
+  };
+
+  const exampleKeyword = "package-a";
+
+  const exampleHttpError = { statusCode: 500 } as HttpErrorBase;
+
+  const exampleSearchResult: SearchedPackument = {
+    name: makeDomainName("com.example.package-a"),
+    versions: { [makeSemanticVersion("1.0.0")]: "latest" },
+    description: "A demo package",
+    date: new Date(2019, 9, 2, 3, 2, 38),
+    "dist-tags": { latest: makeSemanticVersion("1.0.0") },
+  };
+
+  const exampleAllPackumentsResult = {
+    _updated: 99999,
+    [exampleSearchResult.name]: exampleSearchResult,
+  } as AllPackuments;
+
+  function makeDependencies() {
+    const searchRegistry = mockService<SearchRegistry>();
+    searchRegistry.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
+
+    const fetchAllPackument = mockService<FetchAllPackuments>();
+    fetchAllPackument.mockReturnValue(
+      Ok(exampleAllPackumentsResult).toAsyncResult()
+    );
+
+    const searchPackages = makePackagesSearcher(
+      searchRegistry,
+      fetchAllPackument
+    );
+    return { searchPackages, searchRegistry, fetchAllPackument } as const;
+  }
+
+  it("should search using search api first", async () => {
+    const { searchPackages } = makeDependencies();
+
+    const result = await searchPackages(exampleRegistry, exampleKeyword)
+      .promise;
+
+    expect(result).toBeOk((actual) =>
+      expect(actual).toEqual([exampleSearchResult])
+    );
+  });
+
+  it("should not notify of fallback when using search api", async () => {
+    const { searchPackages } = makeDependencies();
+
+    const fallback = jest.fn();
+    await searchPackages(exampleRegistry, exampleKeyword, fallback).promise;
+
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("should search using old search if search api is not available", async () => {
+    const { searchPackages, searchRegistry } = makeDependencies();
+    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+
+    const result = await searchPackages(exampleRegistry, exampleKeyword)
+      .promise;
+
+    expect(result).toBeOk((actual) =>
+      expect(actual).toEqual([exampleSearchResult])
+    );
+  });
+
+  it("should notify of using old search", async () => {
+    const { searchPackages, searchRegistry } = makeDependencies();
+    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+
+    const fallback = jest.fn();
+    await searchPackages(exampleRegistry, exampleKeyword, fallback).promise;
+
+    expect(fallback).toHaveBeenCalled();
+  });
+
+  it("should not find packages not matching the keyword using old search", async () => {
+    const { searchPackages, searchRegistry } = makeDependencies();
+    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+
+    const result = await searchPackages(exampleRegistry, "some other keyword")
+      .promise;
+
+    expect(result).toBeOk((actual) => expect(actual).toEqual([]));
+  });
+
+  it("should fail if both search strategies fail", async () => {
+    const { searchPackages, searchRegistry, fetchAllPackument } =
+      makeDependencies();
+    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+    fetchAllPackument.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+
+    const result = await searchPackages(exampleRegistry, exampleKeyword)
+      .promise;
+
+    expect(result).toBeError();
+  });
+});


### PR DESCRIPTION
This change extracts the business logic for searching packages into its own service making the search-cmd function now only concerned with cli related code.

Also improves tests to cover more scenarios.