### PR TITLE
refactor: rename service

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -42,7 +42,7 @@ import {
   DependencyResolveError,
   ResolveDependenciesService,
 } from "../services/dependency-resolving";
-import { ResolveRemotePackumentService } from "../services/resolve-remote-packument";
+import { ResolveRemotePackumentVersionService } from "../services/resolve-remote-packument";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
 import { unityRegistryUrl } from "../domain/registry-url";
@@ -104,7 +104,7 @@ type AddCmd = (
  */
 export function makeAddCmd(
   parseEnv: ParseEnvService,
-  resolveRemotePackument: ResolveRemotePackumentService,
+  resolveRemotePackumentVersion: ResolveRemotePackumentVersionService,
   resolveDependencies: ResolveDependenciesService,
   loadProjectManifest: LoadProjectManifest,
   writeProjectManifest: WriteProjectManifest,
@@ -136,13 +136,13 @@ export function makeAddCmd(
       const pkgsInScope = Array.of<DomainName>();
       let versionToAdd = requestedVersion;
       if (requestedVersion === undefined || !isPackageUrl(requestedVersion)) {
-        let resolveResult = await resolveRemotePackument(
+        let resolveResult = await resolveRemotePackumentVersion(
           name,
           requestedVersion,
           env.registry
         ).promise;
         if (resolveResult.isErr() && env.upstream) {
-          const upstreamResult = await resolveRemotePackument(
+          const upstreamResult = await resolveRemotePackumentVersion(
             name,
             requestedVersion,
             env.upstreamRegistry

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,7 +22,7 @@ import {
 } from "./validators";
 import RegClient from "another-npm-registry-client";
 import { makeParseEnvService } from "../services/parse-env";
-import { makeResolveRemotePackumentService } from "../services/resolve-remote-packument";
+import { makeResolveRemotePackumentVersionService } from "../services/resolve-remote-packument";
 import {
   makeProjectManifestLoader,
   makeProjectManifestWriter,
@@ -74,11 +74,11 @@ const parseEnv = makeParseEnvService(
 );
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);
 const npmLogin = makeNpmLoginService(regClient);
-const resolveRemotePackument =
-  makeResolveRemotePackumentService(fetchPackument);
+const resolveRemovePackumentVersion =
+  makeResolveRemotePackumentVersionService(fetchPackument);
 const resolveLatestVersion = makeResolveLatestVersionService(fetchPackument);
 const resolveDependencies = makeResolveDependenciesService(
-  resolveRemotePackument,
+  resolveRemovePackumentVersion,
   resolveLatestVersion
 );
 const saveAuthToUpmConfig = makeSaveAuthToUpmConfigService(
@@ -89,7 +89,7 @@ const searchPackages = makePackagesSearcher(searchRegistry, fetchAllPackuments);
 
 const addCmd = makeAddCmd(
   parseEnv,
-  resolveRemotePackument,
+  resolveRemovePackumentVersion,
   resolveDependencies,
   loadProjectManifest,
   writeProjectManifest,

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -10,7 +10,7 @@ import {
 } from "../packument-resolving";
 import { RegistryUrl } from "../domain/registry-url";
 import { Registry } from "../domain/registry";
-import { ResolveRemotePackumentService } from "./resolve-remote-packument";
+import { ResolveRemotePackumentVersionService } from "./resolve-remote-packument";
 import { areArraysEqual } from "../utils/array-utils";
 import { dependenciesOf } from "../domain/package-manifest";
 import {
@@ -85,7 +85,7 @@ export type ResolveDependenciesService = (
  * Makes a {@link ResolveDependenciesService} function.
  */
 export function makeResolveDependenciesService(
-  resolveRemotePackument: ResolveRemotePackumentService,
+  resolveRemovePackumentVersion: ResolveRemotePackumentVersionService,
   resolveLatestVersion: ResolveLatestVersionService
 ): ResolveDependenciesService {
   // TODO: Add tests for this service
@@ -125,8 +125,11 @@ export function makeResolveDependenciesService(
       if (cacheResult.isOk()) return cacheResult;
 
       // Then registry
-      return await resolveRemotePackument(packumentName, version, registry)
-        .promise;
+      return await resolveRemovePackumentVersion(
+        packumentName,
+        version,
+        registry
+      ).promise;
     }
 
     while (pendingList.length > 0) {

--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -8,29 +8,33 @@ import {
 } from "../packument-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { tryResolvePackumentVersion } from "../domain/packument";
-import { FetchPackumentError, FetchPackument } from "../io/packument-io";
+import { FetchPackument, FetchPackumentError } from "../io/packument-io";
 
 /**
- * Service function for resolving remove packuments.
+ * Error which may occur when resolving a remove packument version.
+ */
+export type ResolveRemotePackumentVersionError =
+  | PackumentResolveError
+  | FetchPackumentError;
+
+/**
+ * Service function for resolving remove packument versions.
  * @param packageName The name of the package to resolve.
  * @param requestedVersion The version that should be resolved.
  * @param source The registry to resolve the packument from.
  */
-export type ResolveRemotePackumentService = (
+export type ResolveRemotePackumentVersionService = (
   packageName: DomainName,
   requestedVersion: ResolvableVersion,
   source: Registry
-) => AsyncResult<
-  ResolvedPackument,
-  PackumentResolveError | FetchPackumentError
->;
+) => AsyncResult<ResolvedPackument, ResolveRemotePackumentVersionError>;
 
 /**
- * Makes a {@link ResolveRemotePackumentService} function.
+ * Makes a {@link ResolveRemotePackumentVersionService} function.
  */
-export function makeResolveRemotePackumentService(
+export function makeResolveRemotePackumentVersionService(
   fetchPackument: FetchPackument
-): ResolveRemotePackumentService {
+): ResolveRemotePackumentVersionService {
   return (packageName, requestedVersion, source) =>
     fetchPackument(source, packageName)
       .andThen((maybePackument) => {

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -24,7 +24,7 @@ import { buildProjectManifest } from "../domain/data-project-manifest";
 import { ResolveDependenciesService } from "../../src/services/dependency-resolving";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { mockService } from "../services/service.mock";
-import { ResolveRemotePackumentService } from "../../src/services/resolve-remote-packument";
+import { ResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument";
 import {
   LoadProjectManifest,
   WriteProjectManifest,
@@ -65,9 +65,10 @@ function makeDependencies() {
   const parseEnv = mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
-  const resolveRemotePackument = mockService<ResolveRemotePackumentService>();
+  const resolveRemovePackumentVersion =
+    mockService<ResolveRemotePackumentVersionService>();
   mockResolvedPackuments(
-    resolveRemotePackument,
+    resolveRemovePackumentVersion,
     [exampleRegistryUrl, somePackument],
     [exampleRegistryUrl, otherPackument]
   );
@@ -103,7 +104,7 @@ function makeDependencies() {
 
   const addCmd = makeAddCmd(
     parseEnv,
-    resolveRemotePackument,
+    resolveRemovePackumentVersion,
     resolveDependencies,
     loadProjectManifest,
     writeProjectManifest,
@@ -112,7 +113,7 @@ function makeDependencies() {
   return {
     addCmd,
     parseEnv,
-    resolveRemotePackument,
+    resolveRemovePackumentVersion,
     resolveDependencies,
     loadProjectManifest,
     writeProjectManifest,
@@ -152,8 +153,8 @@ describe("cmd-add", () => {
   });
 
   it("should fail if package could not be resolved", async () => {
-    const { addCmd, resolveRemotePackument } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument);
+    const { addCmd, resolveRemovePackumentVersion } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion);
 
     const result = await addCmd(somePackage, { _global: {} });
 
@@ -163,8 +164,8 @@ describe("cmd-add", () => {
   });
 
   it("should notify if package could not be resolved", async () => {
-    const { addCmd, resolveRemotePackument, log } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument);
+    const { addCmd, resolveRemovePackumentVersion, log } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion);
 
     await addCmd(somePackage, { _global: {} });
 
@@ -216,8 +217,8 @@ describe("cmd-add", () => {
   });
 
   it("should notify if package editor version is not valid", async () => {
-    const { addCmd, resolveRemotePackument, log } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion, log } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
@@ -233,8 +234,8 @@ describe("cmd-add", () => {
   });
 
   it("should suggest running with force if package editor version is not valid", async () => {
-    const { addCmd, resolveRemotePackument, log } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion, log } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
@@ -250,8 +251,8 @@ describe("cmd-add", () => {
   });
 
   it("should fail if package editor version is not valid and not running with force", async () => {
-    const { addCmd, resolveRemotePackument } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
@@ -266,8 +267,8 @@ describe("cmd-add", () => {
   });
 
   it("should add package with invalid editor version when running with force", async () => {
-    const { addCmd, resolveRemotePackument } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       badEditorPackument,
     ]);
@@ -281,8 +282,8 @@ describe("cmd-add", () => {
   });
 
   it("should notify if package is incompatible with editor", async () => {
-    const { addCmd, resolveRemotePackument, log } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion, log } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
@@ -298,8 +299,8 @@ describe("cmd-add", () => {
   });
 
   it("should suggest to run with force if package is incompatible with editor", async () => {
-    const { addCmd, resolveRemotePackument, log } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion, log } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
@@ -315,8 +316,8 @@ describe("cmd-add", () => {
   });
 
   it("should fail if package is incompatible with editor and not running with force", async () => {
-    const { addCmd, resolveRemotePackument } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
@@ -331,8 +332,8 @@ describe("cmd-add", () => {
   });
 
   it("should add package with incompatible with editor when running with force", async () => {
-    const { addCmd, resolveRemotePackument } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       exampleRegistryUrl,
       incompatiblePackument,
     ]);
@@ -384,8 +385,8 @@ describe("cmd-add", () => {
   });
 
   it("should not fetch dependencies for upstream packages", async () => {
-    const { addCmd, resolveRemotePackument, log } = makeDependencies();
-    mockResolvedPackuments(resolveRemotePackument, [
+    const { addCmd, resolveRemovePackumentVersion, log } = makeDependencies();
+    mockResolvedPackuments(resolveRemovePackumentVersion, [
       unityRegistryUrl,
       somePackument,
     ]);

--- a/test/services/packument-resolving.mock.ts
+++ b/test/services/packument-resolving.mock.ts
@@ -5,22 +5,22 @@ import {
   UnityPackument,
 } from "../../src/domain/packument";
 import { RegistryUrl } from "../../src/domain/registry-url";
-import { ResolveRemotePackumentService } from "../../src/services/resolve-remote-packument";
+import { ResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument";
 
 type MockEntry = [RegistryUrl, UnityPackument];
 
 /**
- * Mocks the results of a {@link ResolveRemotePackumentService}.
- * @param resolveRemotePackument The service to mock.
+ * Mocks the results of a {@link ResolveRemotePackumentVersionService}.
+ * @param resolveRemovePackumentVersion The service to mock.
  * @param entries The entries of the mocked registry. Each entry contains
  * the url under which the packument is registered and the packument. All
  * packuments not given in this list are assumed to not exist.
  */
 export function mockResolvedPackuments(
-  resolveRemotePackument: jest.MockedFunction<ResolveRemotePackumentService>,
+  resolveRemovePackumentVersion: jest.MockedFunction<ResolveRemotePackumentVersionService>,
   ...entries: MockEntry[]
 ) {
-  return resolveRemotePackument.mockImplementation(
+  return resolveRemovePackumentVersion.mockImplementation(
     (name, requestedVersion, registry) => {
       const matchingEntry = entries.find(
         (entry) => entry[0] === registry.url && entry[1].name === name

--- a/test/services/resolve-remote-packument.test.ts
+++ b/test/services/resolve-remote-packument.test.ts
@@ -1,5 +1,5 @@
 import { mockService } from "./service.mock";
-import { makeResolveRemotePackumentService } from "../../src/services/resolve-remote-packument";
+import { makeResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument";
 import { Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
@@ -19,16 +19,17 @@ describe("resolve remote packument service", () => {
   function makeDependencies() {
     const fetchPackument = mockService<FetchPackument>();
 
-    const resolveRemotePackument =
-      makeResolveRemotePackumentService(fetchPackument);
-    return { resolveRemotePackument, fetchPackument } as const;
+    const resolveRemovePackumentVersion =
+      makeResolveRemotePackumentVersionService(fetchPackument);
+    return { resolveRemovePackumentVersion, fetchPackument } as const;
   }
 
   it("should fail if packument was not found", async () => {
-    const { resolveRemotePackument, fetchPackument } = makeDependencies();
+    const { resolveRemovePackumentVersion, fetchPackument } =
+      makeDependencies();
     fetchPackument.mockReturnValue(Ok(null).toAsyncResult());
 
-    const result = await resolveRemotePackument(
+    const result = await resolveRemovePackumentVersion(
       somePackage,
       someVersion,
       someRegistry
@@ -40,7 +41,8 @@ describe("resolve remote packument service", () => {
   });
 
   it("should give resolved packument-version", async () => {
-    const { resolveRemotePackument, fetchPackument } = makeDependencies();
+    const { resolveRemovePackumentVersion, fetchPackument } =
+      makeDependencies();
     const packument = buildPackument(somePackage, (packument) =>
       packument.addVersion(someVersion, (version) =>
         version.addDependency("com.other.package", "1.0.0")
@@ -48,7 +50,7 @@ describe("resolve remote packument service", () => {
     );
     fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
 
-    const result = await resolveRemotePackument(
+    const result = await resolveRemovePackumentVersion(
       somePackage,
       someVersion,
       someRegistry


### PR DESCRIPTION
The service for resolving remote packument versions was called "ResolveRemotePackumentService". This does not correctly describe its purpose which is to fetch a specific version of a packument.