### PR TITLE
refactor: rename types/module

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -28,7 +28,10 @@ import {
   UnityProjectManifest,
 } from "../domain/project-manifest";
 import { CmdOptions } from "./options";
-import { PackumentResolveError, pickMostFixable } from "../packument-resolving";
+import {
+  PackumentVersionResolveError,
+  pickMostFixable,
+} from "../packument-version-resolving";
 import { SemanticVersion } from "../domain/semantic-version";
 import { areArraysEqual } from "../utils/array-utils";
 import { Err, Ok, Result } from "ts-results-es";
@@ -81,7 +84,7 @@ export type AddOptions = CmdOptions<{
 export type AddError =
   | EnvParseError
   | ManifestLoadError
-  | PackumentResolveError
+  | PackumentVersionResolveError
   | FetchPackumentError
   | InvalidPackumentDataError
   | EditorIncompatibleError

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -6,7 +6,7 @@ import {
   splitPackageReference,
 } from "../domain/package-reference";
 import { CmdOptions } from "./options";
-import { PackumentResolveError } from "../packument-resolving";
+import { PackumentVersionResolveError } from "../packument-version-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { Ok, Result } from "ts-results-es";
 import {
@@ -33,7 +33,7 @@ export type DepsCmd = (
   options: DepsOptions
 ) => Promise<Result<void, DepsError>>;
 
-function errorPrefixForError(error: PackumentResolveError): string {
+function errorPrefixForError(error: PackumentVersionResolveError): string {
   if (error instanceof PackumentNotFoundError) return "missing dependency";
   else if (error instanceof VersionNotFoundError)
     return "missing dependency version";

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -4,7 +4,7 @@ import {
 } from "../io/project-manifest-io";
 import { NotFoundError } from "../io/file-io";
 import { Logger } from "npmlog";
-import { PackumentResolveError } from "../packument-resolving";
+import { PackumentVersionResolveError } from "../packument-version-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { DomainName } from "../domain/domain-name";
 import { VersionNotFoundError } from "../domain/packument";
@@ -32,12 +32,12 @@ export function logManifestSaveError(log: Logger, error: ManifestWriteError) {
 }
 
 /**
- * Logs a {@link PackumentResolveError} to the console.
+ * Logs a {@link PackumentVersionResolveError} to the console.
  */
 export function logPackumentResolveError(
   log: Logger,
   packageName: DomainName,
-  error: PackumentResolveError
+  error: PackumentVersionResolveError
 ) {
   if (error instanceof PackumentNotFoundError)
     log.error("404", `package not found: ${packageName}`);

--- a/src/domain/packument.ts
+++ b/src/domain/packument.ts
@@ -6,7 +6,7 @@ import { Dist, Maintainer } from "@npm/types";
 import { CustomError } from "ts-custom-error";
 import { Err, Ok, Result } from "ts-results-es";
 import { recordKeys } from "../utils/record-utils";
-import { ResolvableVersion } from "../packument-resolving";
+import { ResolvableVersion } from "../packument-version-resolving";
 
 /**
  * Contains information about a specific version of a package. This is based on

--- a/src/packument-version-resolving.ts
+++ b/src/packument-version-resolving.ts
@@ -24,7 +24,7 @@ export type ResolvableVersion =
 /**
  * A successfully resolved packument-version.
  */
-export interface ResolvedPackument {
+export interface ResolvedPackumentVersion {
   /**
    * The packument from which the version was resolved.
    */
@@ -42,7 +42,7 @@ export interface ResolvedPackument {
 /**
  * A failed attempt at resolving a packument-version.
  */
-export type PackumentResolveError =
+export type PackumentVersionResolveError =
   | PackumentNotFoundError
   | NoVersionsError
   | VersionNotFoundError;
@@ -59,7 +59,7 @@ export function tryResolveFromCache(
   source: RegistryUrl,
   packumentName: DomainName,
   requestedVersion: ResolvableVersion
-): Result<ResolvedPackument, PackumentResolveError> {
+): Result<ResolvedPackumentVersion, PackumentVersionResolveError> {
   const cachedPackument = tryGetFromCache(cache, source, packumentName);
   if (cachedPackument === null) return Err(new PackumentNotFoundError());
 
@@ -79,9 +79,9 @@ export function tryResolveFromCache(
  * @returns The more fixable failure.
  */
 export function pickMostFixable(
-  a: Err<PackumentResolveError>,
-  b: Err<PackumentResolveError>
-): Err<PackumentResolveError> {
+  a: Err<PackumentVersionResolveError>,
+  b: Err<PackumentVersionResolveError>
+): Err<PackumentVersionResolveError> {
   // Anything is more fixable than packument-not-found
   if (
     a.error instanceof PackumentNotFoundError &&

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -2,12 +2,12 @@ import { DomainName, isInternalPackage } from "../domain/domain-name";
 import { SemanticVersion } from "../domain/semantic-version";
 import { addToCache, emptyPackumentCache } from "../packument-cache";
 import {
-  PackumentResolveError,
+  PackumentVersionResolveError,
   pickMostFixable,
   ResolvableVersion,
-  ResolvedPackument,
+  ResolvedPackumentVersion,
   tryResolveFromCache,
-} from "../packument-resolving";
+} from "../packument-version-resolving";
 import { RegistryUrl } from "../domain/registry-url";
 import { Registry } from "../domain/registry";
 import { ResolveRemotePackumentVersionService } from "./resolve-remote-packument-version";
@@ -53,7 +53,7 @@ export interface ValidDependency extends DependencyBase {
  * A dependency that could not be resolved.
  */
 export interface InvalidDependency extends DependencyBase {
-  reason: PackumentResolveError;
+  reason: PackumentVersionResolveError;
 }
 
 type NameVersionPair = Readonly<[DomainName, SemanticVersion]>;
@@ -158,8 +158,8 @@ export function makeResolveDependenciesService(
 
         // Search all given registries.
         let resolveResult: Result<
-          ResolvedPackument,
-          PackumentResolveError | HttpErrorBase
+          ResolvedPackumentVersion,
+          PackumentVersionResolveError | HttpErrorBase
         > = Err(new PackumentNotFoundError());
         for (const source of sources) {
           const result = await tryResolveFromRegistry(

--- a/src/services/resolve-remote-packument-version.ts
+++ b/src/services/resolve-remote-packument-version.ts
@@ -2,10 +2,10 @@ import { DomainName } from "../domain/domain-name";
 import { Registry } from "../domain/registry";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import {
-  PackumentResolveError,
+  PackumentVersionResolveError,
   ResolvableVersion,
-  ResolvedPackument,
-} from "../packument-resolving";
+  ResolvedPackumentVersion,
+} from "../packument-version-resolving";
 import { PackumentNotFoundError } from "../common-errors";
 import { tryResolvePackumentVersion } from "../domain/packument";
 import { FetchPackument, FetchPackumentError } from "../io/packument-io";
@@ -14,7 +14,7 @@ import { FetchPackument, FetchPackumentError } from "../io/packument-io";
  * Error which may occur when resolving a remove packument version.
  */
 export type ResolveRemotePackumentVersionError =
-  | PackumentResolveError
+  | PackumentVersionResolveError
   | FetchPackumentError;
 
 /**
@@ -27,7 +27,7 @@ export type ResolveRemotePackumentVersionService = (
   packageName: DomainName,
   requestedVersion: ResolvableVersion,
   source: Registry
-) => AsyncResult<ResolvedPackument, ResolveRemotePackumentVersionError>;
+) => AsyncResult<ResolvedPackumentVersion, ResolveRemotePackumentVersionError>;
 
 /**
  * Makes a {@link ResolveRemotePackumentVersionService} function.


### PR DESCRIPTION
The module and types related to resolving packument versions did not contain the "version" in their name.