### PR TITLE
refactor: resolve packument service

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,7 @@ import { makeProjectVersionLoader } from "../io/project-version-io";
 import { makeSaveAuthToUpmConfigService } from "../services/upm-auth";
 import { makePackumentFetcher } from "../io/packument-io";
 import { makePackagesSearcher } from "../services/search-packages";
+import { makeRemotePackumentResolver } from "../services/resolve-remote-packument";
 
 // Composition root
 
@@ -64,6 +65,7 @@ const loadProjectVersion = makeProjectVersionLoader(readFile);
 const fetchPackument = makePackumentFetcher(regClient);
 const fetchAllPackuments = makeAllPackumentsFetcher();
 const searchRegistry = makeRegistrySearcher();
+const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
 
 const parseEnv = makeParseEnvService(
   log,
@@ -111,7 +113,7 @@ const removeCmd = makeRemoveCmd(
   writeProjectManifest,
   log
 );
-const viewCmd = makeViewCmd(parseEnv, fetchPackument, log);
+const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument, log);
 
 // update-notifier
 

--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -1,0 +1,64 @@
+import { AsyncResult, Ok } from "ts-results-es";
+import { UnityPackument } from "../domain/packument";
+import { Registry } from "../domain/registry";
+import { DomainName } from "../domain/domain-name";
+import { FetchPackument, FetchPackumentError } from "../io/packument-io";
+import { RegistryUrl } from "../domain/registry-url";
+
+/**
+ * A resolved remote Unity packument.
+ */
+export type ResolvedPackument = {
+  /**
+   * The packument.
+   */
+  packument: UnityPackument;
+  /**
+   * The url of the registry from which the packument was resolved.
+   */
+  source: RegistryUrl;
+};
+
+/**
+ * Error which may occur when resolving a remote packument.
+ */
+export type ResolveRemotePackumentError = FetchPackumentError;
+
+/**
+ * Function for resolving a remote packument. Here "resolve" means searching
+ * a list of registries and returning the first found packument.
+ * @param packageName The name of the packument to search.
+ * @param sources A list of registries which should be searched in order.
+ * @returns The first found packument or null if not found in any registry.
+ */
+export type ResolveRemotePackument = (
+  packageName: DomainName,
+  sources: ReadonlyArray<Registry>
+) => AsyncResult<ResolvedPackument | null, ResolveRemotePackumentError>;
+
+/**
+ * Makes a {@link ResolveRemotePackument} function.
+ */
+export function makeRemotePackumentResolver(
+  fetchPackument: FetchPackument
+): ResolveRemotePackument {
+  return (packageName, sources) =>
+    sources.reduce(
+      (prevResult, source) =>
+        prevResult.andThen((foundPackument) =>
+          foundPackument !== null
+            ? Ok(foundPackument).toAsyncResult()
+            : fetchPackument(source, packageName).map((packument) =>
+                packument !== null
+                  ? {
+                      packument,
+                      source: source.url,
+                    }
+                  : null
+              )
+        ),
+      <AsyncResult<ResolvedPackument | null, ResolveRemotePackumentError>>(
+        Ok(null).toAsyncResult()
+      )
+    );
+}

--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -63,13 +63,19 @@ export function makeRemotePackumentResolver(
   }
 
   const resolveRecursively: ResolveRemotePackument = (packageName, sources) => {
+    // If there are no more sources to search then can return with no packument
     if (sources.length === 0) return noPackumentResult;
 
+    // Determine current and fallback sources
     const currentSource = sources[0]!;
     const fallbackSources = sources.slice(1);
 
+    // Resolve from the current source first
     return tryResolveFrom(currentSource, packageName).andThen(
       (maybePackument) =>
+        // Afterward check if we got a packument.
+        // If yes we can return it, otherwhise we enter the next level
+        // of the recursion with the remaining registries.
         maybePackument !== null
           ? Ok(maybePackument).toAsyncResult()
           : resolveRecursively(packageName, fallbackSources)

--- a/test/services/resolve-remote-packument.test.ts
+++ b/test/services/resolve-remote-packument.test.ts
@@ -1,0 +1,98 @@
+import { makeRemotePackumentResolver } from "../../src/services/resolve-remote-packument";
+import { makeDomainName } from "../../src/domain/domain-name";
+import { Registry } from "../../src/domain/registry";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { unityRegistryUrl } from "../../src/domain/registry-url";
+import { buildPackument } from "../domain/data-packument";
+import { mockService } from "./service.mock";
+import { FetchPackument } from "../../src/io/packument-io";
+import { Err, Ok } from "ts-results-es";
+import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+
+describe("resolve remove packument", () => {
+  const exampleName = makeDomainName("com.some.package");
+
+  const exampleRegistryA: Registry = { url: exampleRegistryUrl, auth: null };
+
+  const exampleRegistryB: Registry = { url: unityRegistryUrl, auth: null };
+
+  const examplePackument = buildPackument(exampleName);
+
+  function makeDependencies() {
+    const fetchPackument = mockService<FetchPackument>();
+    fetchPackument.mockReturnValue(Ok(examplePackument).toAsyncResult());
+
+    const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
+    return { resolveRemotePackument, fetchPackument } as const;
+  }
+
+  it("should find packument in first registry if possible", async () => {
+    const { resolveRemotePackument } = makeDependencies();
+
+    const result = await resolveRemotePackument(exampleName, [
+      exampleRegistryA,
+      exampleRegistryB,
+    ]).promise;
+
+    expect(result).toBeOk((actual) =>
+      expect(actual).toEqual({
+        packument: examplePackument,
+        source: exampleRegistryA.url,
+      })
+    );
+  });
+
+  it("should find packument in first registry if possible", async () => {
+    const { resolveRemotePackument, fetchPackument } = makeDependencies();
+    fetchPackument.mockImplementation((registry) =>
+      Ok(
+        registry === exampleRegistryB ? examplePackument : null
+      ).toAsyncResult()
+    );
+
+    const result = await resolveRemotePackument(exampleName, [
+      exampleRegistryA,
+      exampleRegistryB,
+    ]).promise;
+
+    expect(result).toBeOk((actual) =>
+      expect(actual).toEqual({
+        packument: examplePackument,
+        source: exampleRegistryB.url,
+      })
+    );
+  });
+
+  it("should be null if not providing any registries", async () => {
+    const { resolveRemotePackument } = makeDependencies();
+
+    const result = await resolveRemotePackument(exampleName, []).promise;
+
+    expect(result).toBeOk((actual) => expect(actual).toBeNull());
+  });
+
+  it("should be null if packument is not found in any registry", async () => {
+    const { resolveRemotePackument, fetchPackument } = makeDependencies();
+    fetchPackument.mockReturnValue(Ok(null).toAsyncResult());
+
+    const result = await resolveRemotePackument(exampleName, [
+      exampleRegistryA,
+      exampleRegistryB,
+    ]).promise;
+
+    expect(result).toBeOk((actual) => expect(actual).toBeNull());
+  });
+
+  it("should fail if any packument fetch failed", async () => {
+    const expected = { statusCode: 500 } as HttpErrorBase;
+    const { resolveRemotePackument, fetchPackument } = makeDependencies();
+    fetchPackument.mockReturnValue(Err(expected).toAsyncResult());
+
+    const result = await resolveRemotePackument(exampleName, [
+      exampleRegistryA,
+      exampleRegistryB,
+    ]).promise;
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+});


### PR DESCRIPTION
This PR adds a service for resolving packuments by searching a list of source registries in order. For now this is only used in cmd-view (which has the nice effect of making the cmd function cli-logic only), but it could also be used in other places in the future, especially when it comes to #49.