### PR TITLE
refactor: upmconfig load logic

### DIFF
--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,5 +1,5 @@
 import { AuthenticationError, NpmLoginService } from "../services/npm-login";
-import { GetUpmConfigDir, GetUpmConfigDirError } from "../io/upm-config-io";
+import { GetUpmConfigPath, GetUpmConfigPathError } from "../io/upm-config-io";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "../domain/upm-config";
 import { coerceRegistryUrl } from "../domain/registry-url";
@@ -21,7 +21,7 @@ import { SaveAuthToUpmConfig, UpmAuthStoreError } from "../services/upm-auth";
  */
 export type LoginError =
   | EnvParseError
-  | GetUpmConfigDirError
+  | GetUpmConfigPathError
   | AuthenticationError
   | NpmrcLoadError
   | NpmrcSaveError
@@ -55,7 +55,7 @@ export function makeLoginCmd(
   parseEnv: ParseEnvService,
   authNpmrc: AuthNpmrcService,
   npmLogin: NpmLoginService,
-  getUpmConfigDir: GetUpmConfigDir,
+  getUpmConfigPath: GetUpmConfigPath,
   saveAuthToUpmConfig: SaveAuthToUpmConfig,
   log: Logger
 ): LoginCmd {
@@ -77,15 +77,15 @@ export function makeLoginCmd(
 
     const alwaysAuth = options.alwaysAuth || false;
 
-    const configDirResult = await getUpmConfigDir(env.wsl, env.systemUser)
+    const configPathResult = await getUpmConfigPath(env.wsl, env.systemUser)
       .promise;
-    if (configDirResult.isErr()) return configDirResult;
-    const configDir = configDirResult.value;
+    if (configPathResult.isErr()) return configPathResult;
+    const configPath = configPathResult.value;
 
     if (options.basicAuth) {
       // basic auth
       const _auth = encodeBasicAuth(username, password);
-      const result = await saveAuthToUpmConfig(configDir, loginRegistry, {
+      const result = await saveAuthToUpmConfig(configPath, loginRegistry, {
         email,
         alwaysAuth,
         _auth,
@@ -120,7 +120,7 @@ export function makeLoginCmd(
         log.notice("config", `saved to npm config: ${configPath}`)
       );
 
-      const storeResult = await saveAuthToUpmConfig(configDir, loginRegistry, {
+      const storeResult = await saveAuthToUpmConfig(configPath, loginRegistry, {
         email,
         alwaysAuth,
         token,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,7 +30,7 @@ import {
 import npmlog from "npmlog";
 import { makeResolveLatestVersionService } from "../services/resolve-latest-version";
 import {
-  makeUpmConfigDirGetter,
+  makeUpmConfigPathGetter,
   makeUpmConfigLoader,
 } from "../io/upm-config-io";
 import { makeTextReader, makeTextWriter } from "../io/file-io";
@@ -56,7 +56,7 @@ const readFile = makeTextReader();
 const writeFile = makeTextWriter();
 const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter(writeFile);
-const getUpmConfigDir = makeUpmConfigDirGetter(getHomePath);
+const getUpmConfigPath = makeUpmConfigPathGetter(getHomePath);
 const loadUpmConfig = makeUpmConfigLoader(readFile);
 const findNpmrcPath = makeNpmrcPathFinder(getHomePath);
 const loadNpmrc = makeNpmrcLoader(readFile);
@@ -69,7 +69,7 @@ const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
 
 const parseEnv = makeParseEnvService(
   log,
-  getUpmConfigDir,
+  getUpmConfigPath,
   loadUpmConfig,
   getCwd,
   loadProjectVersion
@@ -101,7 +101,7 @@ const loginCmd = makeLoginCmd(
   parseEnv,
   authNpmrc,
   npmLogin,
-  getUpmConfigDir,
+  getUpmConfigPath,
   saveAuthToUpmConfig,
   log
 );

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import {
-  GetUpmConfigDir,
-  GetUpmConfigDirError,
+  GetUpmConfigPath,
+  GetUpmConfigPathError,
   LoadUpmConfig,
   UpmConfigLoadError,
 } from "../io/upm-config-io";
@@ -41,7 +41,7 @@ export type Env = Readonly<{
 }>;
 
 export type EnvParseError =
-  | GetUpmConfigDirError
+  | GetUpmConfigPathError
   | UpmConfigLoadError
   | ProjectVersionLoadError;
 
@@ -119,7 +119,7 @@ export type ParseEnvService = (
  */
 export function makeParseEnvService(
   log: Logger,
-  getUpmConfigDir: GetUpmConfigDir,
+  getUpmConfigPath: GetUpmConfigPath,
   loadUpmConfig: LoadUpmConfig,
   getCwd: GetCwd,
   loadProjectVersion: LoadProjectVersion
@@ -146,7 +146,7 @@ export function makeParseEnvService(
     const wsl = determineWsl(options);
 
     // registries
-    const upmConfigResult = await getUpmConfigDir(wsl, systemUser).andThen(
+    const upmConfigResult = await getUpmConfigPath(wsl, systemUser).andThen(
       loadUpmConfig
     ).promise;
     if (upmConfigResult.isErr()) return upmConfigResult;

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -2,7 +2,7 @@ import { TokenAuth, UPMConfig } from "../../src/domain/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
 import { Env, makeParseEnvService } from "../../src/services/parse-env";
 import { Err, Ok } from "ts-results-es";
-import { GetUpmConfigDir, LoadUpmConfig } from "../../src/io/upm-config-io";
+import { GetUpmConfigPath, LoadUpmConfig } from "../../src/io/upm-config-io";
 import { IOError, NotFoundError } from "../../src/io/file-io";
 import { FileParseError } from "../../src/common-errors";
 import { makeEditorVersion } from "../../src/domain/editor-version";
@@ -36,9 +36,9 @@ const testProjectVersion = "2021.3.1f1";
 function makeDependencies() {
   const log = makeMockLogger();
 
-  const getUpmConfigDir = mockService<GetUpmConfigDir>();
+  const getUpmConfigPath = mockService<GetUpmConfigPath>();
   // The root directory does not contain an upm-config
-  getUpmConfigDir.mockReturnValue(Ok(testRootPath).toAsyncResult());
+  getUpmConfigPath.mockReturnValue(Ok(testRootPath).toAsyncResult());
 
   const loadUpmConfig = mockService<LoadUpmConfig>();
   mockUpmConfig(loadUpmConfig, null);
@@ -52,7 +52,7 @@ function makeDependencies() {
 
   const parseEnv = makeParseEnvService(
     log,
-    getUpmConfigDir,
+    getUpmConfigPath,
     loadUpmConfig,
     getCwd,
     loadProjectVersion
@@ -60,7 +60,7 @@ function makeDependencies() {
   return {
     parseEnv,
     log,
-    getUpmConfigDir,
+    getUpmConfigPath,
     loadUpmConfig,
     loadProjectVersion,
   } as const;
@@ -289,9 +289,9 @@ describe("env", () => {
 
   describe("upm-config", () => {
     it("should fail if upm-config dir cannot be determined", async () => {
-      const { parseEnv, getUpmConfigDir } = makeDependencies();
+      const { parseEnv, getUpmConfigPath } = makeDependencies();
       const expected = new NoWslError();
-      getUpmConfigDir.mockReturnValue(Err(expected).toAsyncResult());
+      getUpmConfigPath.mockReturnValue(Err(expected).toAsyncResult());
 
       const result = await parseEnv({ _global: {} });
 


### PR DESCRIPTION
Currently we have a service function for determining the directory in which the upmconfig is located. On load and save the actual file path of the config is constructed from this directory.

There is no need for this delayed path construction. We can instead make the service resolve the actual path of the config file right away. This makes client code a little shorter.