### PR TITLE
refactor: clean up upm auth

### DIFF
--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -91,7 +91,7 @@ export function makeLoginCmd(
         _auth,
       } satisfies BasicAuth).promise;
       if (result.isErr()) return result;
-      log.notice("config", "saved unity config at " + result.value);
+      log.notice("config", "saved unity config at " + configPath);
     } else {
       // npm login
       const loginResult = await npmLogin(
@@ -126,7 +126,7 @@ export function makeLoginCmd(
         token,
       } satisfies TokenAuth).promise;
       if (storeResult.isErr()) return storeResult;
-      log.notice("config", "saved unity config at " + storeResult.value);
+      log.notice("config", "saved unity config at " + configPath);
     }
 
     return Ok(undefined);

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -115,13 +115,12 @@ export type UpmConfigSaveError = IOError;
  * Save the upm config.
  * @param config The config to save.
  * @param configFilePath The path of the file that should be saved to.
- * @returns The path to which the file was saved.
  */
 export const trySaveUpmConfig = (
   writeFile: WriteTextFile,
   config: UPMConfig,
   configFilePath: string
-): AsyncResult<string, UpmConfigSaveError> => {
+): AsyncResult<void, UpmConfigSaveError> => {
   const content = TOML.stringify(config);
-  return writeFile(configFilePath, content).map(() => configFilePath);
+  return writeFile(configFilePath, content);
 };

--- a/src/services/upm-auth.ts
+++ b/src/services/upm-auth.ts
@@ -15,17 +15,15 @@ export type UpmAuthStoreError = UpmConfigLoadError | IOError;
 
 /**
  * Service function for storing authentication information in an upmconfig file.
- * @param configDir Path to the directory in which the upmconfig file is
- * located.
+ * @param configPath Path to the upmconfig file.
  * @param registry Url of the registry for which to authenticate.
  * @param auth Authentication information.
- * @returns The path of the upmconfig file.
  */
 export type SaveAuthToUpmConfig = (
-  configDir: string,
+  configPath: string,
   registry: RegistryUrl,
   auth: UpmAuth
-) => AsyncResult<string, UpmAuthStoreError>;
+) => AsyncResult<void, UpmAuthStoreError>;
 
 /**
  * Makes a {@link SaveAuthToUpmConfig} function.
@@ -35,9 +33,9 @@ export function makeSaveAuthToUpmConfigService(
   writeFile: WriteTextFile
 ): SaveAuthToUpmConfig {
   // TODO: Add tests for this service
-  return (configDir, registry, auth) =>
-    loadUpmConfig(configDir)
+  return (configPath, registry, auth) =>
+    loadUpmConfig(configPath)
       .map((maybeConfig) => maybeConfig || {})
       .map((config) => addAuth(registry, auth, config))
-      .andThen((config) => trySaveUpmConfig(writeFile, config, configDir));
+      .andThen((config) => trySaveUpmConfig(writeFile, config, configPath));
 }


### PR DESCRIPTION
Currently we return the path of the upm config file we modified after a save so that the path can be in logging. This is done because previously we only had access to the configs directory path in the client code.

Since #337 we also have access to the file path in client code and so dont need this return value.