### PR TITLE
refactor: extract login service

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,8 +30,8 @@ import {
 import npmlog from "npmlog";
 import { makeResolveLatestVersionService } from "../services/resolve-latest-version";
 import {
-  makeUpmConfigPathGetter,
   makeUpmConfigLoader,
+  makeUpmConfigPathGetter,
 } from "../io/upm-config-io";
 import { makeTextReader, makeTextWriter } from "../io/file-io";
 import {
@@ -45,6 +45,7 @@ import { makeSaveAuthToUpmConfigService } from "../services/upm-auth";
 import { makePackumentFetcher } from "../io/packument-io";
 import { makePackagesSearcher } from "../services/search-packages";
 import { makeRemotePackumentResolver } from "../services/resolve-remote-packument";
+import { makeLoginService } from "../services/login";
 
 // Composition root
 
@@ -88,6 +89,7 @@ const saveAuthToUpmConfig = makeSaveAuthToUpmConfigService(
   writeFile
 );
 const searchPackages = makePackagesSearcher(searchRegistry, fetchAllPackuments);
+const login = makeLoginService(saveAuthToUpmConfig, npmLogin, authNpmrc);
 
 const addCmd = makeAddCmd(
   parseEnv,
@@ -97,14 +99,7 @@ const addCmd = makeAddCmd(
   writeProjectManifest,
   log
 );
-const loginCmd = makeLoginCmd(
-  parseEnv,
-  authNpmrc,
-  npmLogin,
-  getUpmConfigPath,
-  saveAuthToUpmConfig,
-  log
-);
+const loginCmd = makeLoginCmd(parseEnv, getUpmConfigPath, login, log);
 const searchCmd = makeSearchCmd(parseEnv, searchPackages, log);
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log);
 const removeCmd = makeRemoveCmd(

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -1,0 +1,89 @@
+import { AsyncResult } from "ts-results-es";
+import { BasicAuth, encodeBasicAuth, TokenAuth } from "../domain/upm-config";
+import { RegistryUrl } from "../domain/registry-url";
+import { SaveAuthToUpmConfig, UpmAuthStoreError } from "./upm-auth";
+import { NpmLoginError, NpmLoginService } from "./npm-login";
+import { AuthNpmrcService, NpmrcAuthTokenUpdateError } from "./npmrc-auth";
+
+/**
+ * Error which may occur when logging in a user.
+ */
+export type LoginError =
+  | UpmAuthStoreError
+  | NpmLoginError
+  | NpmrcAuthTokenUpdateError;
+
+/**
+ * Function for logging in a user to a npm registry. Supports both basic and
+ * token-based authentication.
+ * @param username The username with which to login.
+ * @param password The password with which to login.
+ * @param email The email with which to login.
+ * @param alwaysAuth Whether to always authenticate.
+ * @param registry The url of the npm registry with which to authenticate.
+ * @param configPath Path of the upm-config file in which to store
+ * authentication information.
+ * @param authMode Whether to use basic or token-based authentication.
+ * @param onNpmAuthSuccess Callback that notifies when authentication
+ * with the npm registry was successful. Only called with token-based
+ * authentication.
+ * @param onNpmrcUpdated Callback that notifies when the .npmrc file was
+ * updated. Only called with token-based authentication.
+ */
+export type LoginService = (
+  username: string,
+  password: string,
+  email: string,
+  alwaysAuth: boolean,
+  registry: RegistryUrl,
+  configPath: string,
+  authMode: "basic" | "token",
+  onNpmAuthSuccess: () => void,
+  onNpmrcUpdated: (npmrcPath: string) => void
+) => AsyncResult<void, LoginError>;
+
+/**
+ * Makes a {@link LoginService} function.
+ */
+export function makeLoginService(
+  saveAuthToUpmConfig: SaveAuthToUpmConfig,
+  npmLogin: NpmLoginService,
+  authNpmrc: AuthNpmrcService
+): LoginService {
+  return (
+    username,
+    password,
+    email,
+    alwaysAuth,
+    registry,
+    configPath,
+    authMode,
+    onNpmAuthSuccess,
+    onNpmrcUpdated
+  ) => {
+    if (authMode === "basic") {
+      // basic auth
+      const _auth = encodeBasicAuth(username, password);
+      return saveAuthToUpmConfig(configPath, registry, {
+        email,
+        alwaysAuth,
+        _auth,
+      } satisfies BasicAuth);
+    }
+
+    // npm login
+    return npmLogin(registry, username, password, email).andThen((token) => {
+      onNpmAuthSuccess();
+      // write npm token
+      return authNpmrc(registry, token).andThen((npmrcPath) => {
+        onNpmrcUpdated(npmrcPath);
+        // Save config
+        return saveAuthToUpmConfig(configPath, registry, {
+          email,
+          alwaysAuth,
+          token,
+        } satisfies TokenAuth);
+      });
+    });
+  };
+}

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -1,0 +1,138 @@
+import { IOError } from "../../src/io/file-io";
+import { Err, Ok } from "ts-results-es";
+import { makeLoginCmd } from "../../src/cli/cmd-login";
+import { mockService } from "../services/service.mock";
+import { Env, ParseEnvService } from "../../src/services/parse-env";
+import {
+  GetUpmConfigPath,
+  RequiredEnvMissingError,
+} from "../../src/io/upm-config-io";
+import { LoginService } from "../../src/services/login";
+import { makeMockLogger } from "./log.mock";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { unityRegistryUrl } from "../../src/domain/registry-url";
+import { makeEditorVersion } from "../../src/domain/editor-version";
+import { AuthenticationError } from "../../src/services/npm-login";
+
+const defaultEnv = {
+  cwd: "/users/some-user/projects/SomeProject",
+  upstream: true,
+  registry: { url: exampleRegistryUrl, auth: null },
+  upstreamRegistry: { url: unityRegistryUrl, auth: null },
+  editorVersion: makeEditorVersion(2022, 2, 1, "f", 2),
+} as Env;
+const exampleUser = "user";
+const examplePassword = "pass";
+const exampleEmail = "user@email.com";
+const exampleUpmConfigPath = "/user/home/.upmconfig.toml";
+
+describe("cmd-login", () => {
+  function makeDependencies() {
+    const parseEnv = mockService<ParseEnvService>();
+    parseEnv.mockResolvedValue(Ok(defaultEnv));
+
+    const getUpmConfigPath = mockService<GetUpmConfigPath>();
+    getUpmConfigPath.mockReturnValue(Ok(exampleUpmConfigPath).toAsyncResult());
+
+    const login = mockService<LoginService>();
+    login.mockReturnValue(Ok(undefined).toAsyncResult());
+
+    const log = makeMockLogger();
+
+    const loginCmd = makeLoginCmd(parseEnv, getUpmConfigPath, login, log);
+    return { loginCmd, parseEnv, getUpmConfigPath, login, log } as const;
+  }
+
+  it("should fail if env could not be parsed", async () => {
+    const expected = new IOError();
+    const { loginCmd, parseEnv } = makeDependencies();
+    parseEnv.mockResolvedValue(Err(expected));
+
+    const result = await loginCmd({ _global: {} });
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+
+  // TODO: Add tests for prompting logic
+
+  it("should fail if upm config path could not be determined", async () => {
+    const expected = new RequiredEnvMissingError();
+    const { loginCmd, getUpmConfigPath } = makeDependencies();
+    getUpmConfigPath.mockReturnValue(Err(expected).toAsyncResult());
+
+    const result = await loginCmd({
+      username: exampleUser,
+      password: examplePassword,
+      email: exampleEmail,
+      _global: { registry: exampleRegistryUrl },
+    });
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+
+  it("should fail if login failed", async () => {
+    const expected = new RequiredEnvMissingError();
+    const { loginCmd, login } = makeDependencies();
+    login.mockReturnValue(Err(expected).toAsyncResult());
+
+    const result = await loginCmd({
+      username: exampleUser,
+      password: examplePassword,
+      email: exampleEmail,
+      _global: { registry: exampleRegistryUrl },
+    });
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+
+  it("should notify if unauthorized", async () => {
+    const { loginCmd, login, log } = makeDependencies();
+    login.mockReturnValue(
+      Err(new AuthenticationError(401, "oof")).toAsyncResult()
+    );
+
+    await loginCmd({
+      username: exampleUser,
+      password: examplePassword,
+      email: exampleEmail,
+      _global: { registry: exampleRegistryUrl },
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "401",
+      "Incorrect username or password"
+    );
+  });
+
+  it("should notify of other login errors", async () => {
+    const { loginCmd, login, log } = makeDependencies();
+    login.mockReturnValue(
+      Err(new AuthenticationError(500, "oof")).toAsyncResult()
+    );
+
+    await loginCmd({
+      username: exampleUser,
+      password: examplePassword,
+      email: exampleEmail,
+      _global: { registry: exampleRegistryUrl },
+    });
+
+    expect(log.error).toHaveBeenCalledWith("500", "oof");
+  });
+
+  it("should notify of success", async () => {
+    const { loginCmd, log } = makeDependencies();
+
+    await loginCmd({
+      username: exampleUser,
+      password: examplePassword,
+      email: exampleEmail,
+      _global: { registry: exampleRegistryUrl },
+    });
+
+    expect(log.notice).toHaveBeenCalledWith(
+      "config",
+      expect.stringContaining("saved unity config")
+    );
+  });
+});

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -1,0 +1,208 @@
+import { makeLoginService } from "../../src/services/login";
+import { mockService } from "./service.mock";
+import { SaveAuthToUpmConfig } from "../../src/services/upm-auth";
+import {
+  AuthenticationError,
+  NpmLoginService,
+} from "../../src/services/npm-login";
+import { AuthNpmrcService } from "../../src/services/npmrc-auth";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { Err, Ok } from "ts-results-es";
+import { IOError } from "../../src/io/file-io";
+
+const exampleUser = "user";
+const examplePassword = "pass";
+const exampleEmail = "user@email.com";
+const exampleConfigPath = "/user/home/.upmconfig.toml";
+const exampleNpmrcPath = "/user/home/.npmrc";
+const exampleToken = "some token";
+
+describe("login", () => {
+  function makeDependencies() {
+    const saveAuthToUpmConfig = mockService<SaveAuthToUpmConfig>();
+    saveAuthToUpmConfig.mockReturnValue(Ok(undefined).toAsyncResult());
+
+    const npmLogin = mockService<NpmLoginService>();
+    npmLogin.mockReturnValue(Ok(exampleToken).toAsyncResult());
+
+    const authNpmrc = mockService<AuthNpmrcService>();
+    authNpmrc.mockReturnValue(Ok(exampleNpmrcPath).toAsyncResult());
+
+    const login = makeLoginService(saveAuthToUpmConfig, npmLogin, authNpmrc);
+    return { login, saveAuthToUpmConfig, npmLogin, authNpmrc } as const;
+  }
+
+  describe("basic auth", () => {
+    it("should save encoded auth data", async () => {
+      const { login, saveAuthToUpmConfig } = makeDependencies();
+
+      await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "basic",
+        () => {},
+        () => {}
+      ).promise;
+
+      expect(saveAuthToUpmConfig).toHaveBeenCalledWith(
+        exampleConfigPath,
+        exampleRegistryUrl,
+        {
+          email: exampleEmail,
+          alwaysAuth: true,
+          _auth: "dXNlcjpwYXNz",
+        }
+      );
+    });
+
+    it("should fail if config write fails", async () => {
+      const expected = new IOError();
+      const { login, saveAuthToUpmConfig } = makeDependencies();
+      saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
+
+      const result = await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "basic",
+        () => {},
+        () => {}
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+  });
+
+  describe("token auth", () => {
+    it("should fail if npm login fails", async () => {
+      const expected = new AuthenticationError(401, "uh oh");
+      const { login, npmLogin } = makeDependencies();
+      npmLogin.mockReturnValue(Err(expected).toAsyncResult());
+
+      const result = await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "token",
+        () => {},
+        () => {}
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should notify of npm login success", async () => {
+      const { login } = makeDependencies();
+      const onNpmAuthSuccess = jest.fn();
+
+      await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "token",
+        onNpmAuthSuccess,
+        () => {}
+      ).promise;
+
+      expect(onNpmAuthSuccess).toHaveBeenCalled();
+    });
+
+    it("should fail if npmrc auth fails", async () => {
+      const expected = new IOError();
+      const { login, authNpmrc } = makeDependencies();
+      authNpmrc.mockReturnValue(Err(expected).toAsyncResult());
+
+      const result = await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "token",
+        () => {},
+        () => {}
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+
+    it("should notify of npmrc auth success", async () => {
+      const { login } = makeDependencies();
+      const onNpmrcUpdated = jest.fn();
+
+      await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "token",
+        () => {},
+        onNpmrcUpdated
+      ).promise;
+
+      expect(onNpmrcUpdated).toHaveBeenCalledWith(exampleNpmrcPath);
+    });
+
+    it("should save token", async () => {
+      const { login, saveAuthToUpmConfig } = makeDependencies();
+
+      await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "token",
+        () => {},
+        () => {}
+      ).promise;
+
+      expect(saveAuthToUpmConfig).toHaveBeenCalledWith(
+        exampleConfigPath,
+        exampleRegistryUrl,
+        {
+          email: exampleEmail,
+          alwaysAuth: true,
+          token: exampleToken,
+        }
+      );
+    });
+
+    it("should fail if config write fails", async () => {
+      const expected = new IOError();
+      const { login, saveAuthToUpmConfig } = makeDependencies();
+      saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
+
+      const result = await login(
+        exampleUser,
+        examplePassword,
+        exampleEmail,
+        true,
+        exampleRegistryUrl,
+        exampleConfigPath,
+        "token",
+        () => {},
+        () => {}
+      ).promise;
+
+      expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    });
+  });
+});


### PR DESCRIPTION
Extract login logic into a separate service to keep the logic inside the cmd function focused on cli concerns. Also add tests for both the cli function and the new service.