### PR TITLE
refactor: fs error type

### DIFF
--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -2,21 +2,21 @@ import {
   ManifestLoadError,
   ManifestWriteError,
 } from "../io/project-manifest-io";
-import { NotFoundError } from "../io/file-io";
 import { Logger } from "npmlog";
 import { PackumentVersionResolveError } from "../packument-version-resolving";
-import { PackumentNotFoundError } from "../common-errors";
+import { FileParseError, PackumentNotFoundError } from "../common-errors";
 import { DomainName } from "../domain/domain-name";
 import { VersionNotFoundError } from "../domain/packument";
+import { FsError, FsErrorReason } from "../io/file-io";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.
  */
 export function logManifestLoadError(log: Logger, error: ManifestLoadError) {
   const prefix = "manifest";
-  if (error instanceof NotFoundError)
+  if (error instanceof FsError && error.reason === FsErrorReason.Missing)
     log.error(prefix, `manifest at ${error.path} does not exist`);
-  else {
+  else if (error instanceof FileParseError) {
     log.error(prefix, `failed to parse manifest at ${error.path}`);
     if (error.cause !== undefined) log.error(prefix, error.cause.message);
   }

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -1,5 +1,6 @@
 import { CustomError } from "ts-custom-error";
 import { EditorVersion } from "./domain/editor-version";
+import {StringFormatError} from "./utils/string-parsing";
 
 /**
  * Error for when the packument was not found.
@@ -40,7 +41,7 @@ export class FileParseError extends CustomError {
     /**
      * The error that caused this one.
      */
-    readonly cause?: Error
+    readonly cause?: StringFormatError
   ) {
     super("A file could not be parsed into a specific target type.");
   }

--- a/src/io/builtin-packages.ts
+++ b/src/io/builtin-packages.ts
@@ -7,7 +7,7 @@ import {
 import { DomainName } from "../domain/domain-name";
 import { CustomError } from "ts-custom-error";
 import path from "path";
-import { FsError, NotFoundError, tryGetDirectoriesIn } from "./file-io";
+import { FsError, FsErrorReason, tryGetDirectoriesIn } from "./file-io";
 
 /**
  * Error for when an editor-version is not installed.
@@ -59,7 +59,7 @@ export function makeBuiltInPackagesFinder(): FindBuiltInPackages {
           // We can assume correct format
           .map((names) => names as DomainName[])
           .mapErr((error) =>
-            error instanceof NotFoundError
+            error.reason === FsErrorReason.Missing
               ? new EditorNotInstalledError(editorVersion)
               : error
           )

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -2,7 +2,7 @@ import { AsyncResult, Err, Ok, Result } from "ts-results-es";
 import {
   FileWriteError,
   FsError,
-  NotFoundError,
+  FsErrorReason,
   ReadTextFile,
   WriteTextFile,
 } from "./file-io";
@@ -52,7 +52,7 @@ export function makeNpmrcLoader(readFile: ReadTextFile): LoadNpmrc {
     readFile(path)
       .map<Npmrc | null>((content) => content.split(EOL))
       .orElse((error) =>
-        error instanceof NotFoundError ? Ok(null) : Err(error)
+        error.reason == FsErrorReason.Missing ? Ok(null) : Err(error)
       );
 }
 

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -3,7 +3,7 @@ import TOML from "@iarna/toml";
 import { UPMConfig } from "../domain/upm-config";
 import { CustomError } from "ts-custom-error";
 import { AsyncResult, Err, Ok } from "ts-results-es";
-import { FsError, NotFoundError, ReadTextFile, WriteTextFile } from "./file-io";
+import { FsError, FsErrorReason, ReadTextFile, WriteTextFile } from "./file-io";
 import { tryGetEnv } from "../utils/env-util";
 import { StringFormatError, tryParseToml } from "../utils/string-parsing";
 import { tryGetWslPath, WslPathError } from "./wsl";
@@ -102,7 +102,9 @@ export function makeUpmConfigLoader(readFile: ReadTextFile): LoadUpmConfig {
       // TODO: Actually validate
       .map<UPMConfig | null>((toml) => toml as UPMConfig)
       .orElse((error) =>
-        error instanceof NotFoundError ? Ok(null) : Err(error)
+        error instanceof FsError && error.reason === FsErrorReason.Missing
+          ? Ok(null)
+          : Err(error)
       );
 }
 

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -10,7 +10,7 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { Err, Ok } from "ts-results-es";
-import { FsError, NotFoundError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import {
   mockProjectManifest,
   mockProjectManifestWriteResult,
@@ -123,7 +123,7 @@ function makeDependencies() {
 
 describe("cmd-add", () => {
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError();
+    const expected = new FsError("", FsErrorReason.Other);
     const { addCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
@@ -139,7 +139,7 @@ describe("cmd-add", () => {
     const result = await addCmd(somePackage, { _global: {} });
 
     expect(result).toBeError((actual) =>
-      expect(actual).toBeInstanceOf(NotFoundError)
+      expect(actual).toBeInstanceOf(FsError)
     );
   });
 
@@ -683,7 +683,7 @@ describe("cmd-add", () => {
   });
 
   it("should fail if manifest could not be saved", async () => {
-    const expected = new FsError();
+    const expected = new FsError("", FsErrorReason.Other);
     const { addCmd, writeProjectManifest } = makeDependencies();
     mockProjectManifestWriteResult(writeProjectManifest, expected);
 
@@ -694,7 +694,10 @@ describe("cmd-add", () => {
 
   it("should notify if manifest could not be saved", async () => {
     const { addCmd, writeProjectManifest, log } = makeDependencies();
-    mockProjectManifestWriteResult(writeProjectManifest, new FsError());
+    mockProjectManifestWriteResult(
+      writeProjectManifest,
+      new FsError("", FsErrorReason.Other)
+    );
 
     await addCmd(somePackage, { _global: {} });
 

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -3,7 +3,7 @@ import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { Err, Ok } from "ts-results-es";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { FsError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
 import { makeMockLogger } from "./log.mock";
@@ -54,7 +54,7 @@ function makeDependencies() {
 
 describe("cmd-deps", () => {
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError();
+    const expected = new FsError("", FsErrorReason.Other);
     const { depsCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -1,4 +1,4 @@
-import { FsError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import { makeLoginCmd } from "../../src/cli/cmd-login";
 import { mockService } from "../services/service.mock";
@@ -44,7 +44,7 @@ describe("cmd-login", () => {
   }
 
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError();
+    const expected = new FsError("", FsErrorReason.Other);
     const { loginCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -2,7 +2,7 @@ import { makeViewCmd } from "../../src/cli/cmd-view";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { FsError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
@@ -71,7 +71,7 @@ function makeDependencies() {
 
 describe("cmd-view", () => {
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError();
+    const expected = new FsError("", FsErrorReason.Other);
     const { viewCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 

--- a/test/io/builtin-packages.test.ts
+++ b/test/io/builtin-packages.test.ts
@@ -1,7 +1,7 @@
 import * as specialPaths from "../../src/io/special-paths";
 import { OSNotSupportedError } from "../../src/io/special-paths";
 import * as fileIo from "../../src/io/file-io";
-import { NotFoundError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import {
   EditorNotInstalledError,
@@ -34,7 +34,9 @@ describe("builtin-packages", () => {
     const { getBuiltInPackages } = makeDependencies();
     jest
       .spyOn(fileIo, "tryGetDirectoriesIn")
-      .mockReturnValue(Err(new NotFoundError("")).toAsyncResult());
+      .mockReturnValue(
+        Err(new FsError("", FsErrorReason.Missing)).toAsyncResult()
+      );
 
     const result = await getBuiltInPackages(version).promise;
 

--- a/test/io/file-io.test.ts
+++ b/test/io/file-io.test.ts
@@ -1,9 +1,9 @@
 import fs from "fs/promises";
 import {
   FsError,
+  FsErrorReason,
   makeTextReader,
   makeTextWriter,
-  NotFoundError,
   tryGetDirectoriesIn,
 } from "../../src/io/file-io";
 import fse from "fs-extra";
@@ -39,8 +39,8 @@ describe("file-io", () => {
 
       const result = await readFile("path/to/file.txt").promise;
 
-      expect(result).toBeError((error) =>
-        expect(error).toBeInstanceOf(NotFoundError)
+      expect(result).toBeError((error: FsError) =>
+        expect(error.reason).toEqual(FsErrorReason.Missing)
       );
     });
 
@@ -51,8 +51,8 @@ describe("file-io", () => {
 
       const result = await readFile("path/to/file.txt").promise;
 
-      expect(result).toBeError((error) =>
-        expect(error).toBeInstanceOf(FsError)
+      expect(result).toBeError((error: FsError) =>
+        expect(error.reason).toEqual(FsErrorReason.Other)
       );
     });
   });
@@ -139,8 +139,8 @@ describe("file-io", () => {
 
       const result = await tryGetDirectoriesIn("/bad/path/").promise;
 
-      expect(result).toBeError((actual) =>
-        expect(actual).toBeInstanceOf(NotFoundError)
+      expect(result).toBeError((actual: FsError) =>
+        expect(actual.reason).toEqual(FsErrorReason.Missing)
       );
     });
 
@@ -149,8 +149,8 @@ describe("file-io", () => {
 
       const result = await tryGetDirectoriesIn("/good/path/").promise;
 
-      expect(result).toBeError((actual) =>
-        expect(actual).toBeInstanceOf(FsError)
+      expect(result).toBeError((actual: FsError) =>
+        expect(actual.reason).toEqual(FsErrorReason.Other)
       );
     });
 

--- a/test/io/npmrc-io.test.ts
+++ b/test/io/npmrc-io.test.ts
@@ -1,6 +1,6 @@
 import {
   FsError,
-  NotFoundError,
+  FsErrorReason,
   ReadTextFile,
   WriteTextFile,
 } from "../../src/io/file-io";
@@ -70,7 +70,7 @@ describe("npmrc-io", () => {
     it("should be null for missing file", async () => {
       const { loadNpmrc, readText } = makeDependencies();
       const path = "/invalid/path/.npmrc";
-      const expected = new NotFoundError(path);
+      const expected = new FsError(path, FsErrorReason.Missing);
       readText.mockReturnValue(new AsyncResult(Err(expected)));
 
       const result = await loadNpmrc(path).promise;
@@ -99,8 +99,8 @@ describe("npmrc-io", () => {
 
     it("should fail when write fails", async () => {
       const { saveNpmrc, writeFile } = makeDependencies();
-      const expected = new FsError();
       const path = "/invalid/path/.npmrc";
+      const expected = new FsError(path, FsErrorReason.Other);
       writeFile.mockReturnValue(new AsyncResult(Err(expected)));
 
       const result = await saveNpmrc(path, ["key=value"]).promise;

--- a/test/io/project-manifest-io.mock.ts
+++ b/test/io/project-manifest-io.mock.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src/io/project-manifest-io";
 import { UnityProjectManifest } from "../../src/domain/project-manifest";
 import { Err, Ok } from "ts-results-es";
-import { NotFoundError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 
 /**
  * Mocks results for a {@link LoadProjectManifest} function.
@@ -21,7 +21,7 @@ export function mockProjectManifest(
   return loadProjectManifest.mockImplementation((projectPath) => {
     const manifestPath = manifestPathFor(projectPath);
     return manifest === null
-      ? Err(new NotFoundError(manifestPath)).toAsyncResult()
+      ? Err(new FsError(manifestPath, FsErrorReason.Missing)).toAsyncResult()
       : Ok(manifest).toAsyncResult();
   });
 }

--- a/test/io/project-version-io.test.ts
+++ b/test/io/project-version-io.test.ts
@@ -1,4 +1,4 @@
-import { NotFoundError, ReadTextFile } from "../../src/io/file-io";
+import { FsError, FsErrorReason, ReadTextFile } from "../../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import { FileParseError } from "../../src/common-errors";
 import { StringFormatError } from "../../src/utils/string-parsing";
@@ -17,7 +17,10 @@ describe("project-version-io", () => {
 
     it("should fail if file could not be read", async () => {
       const { loadProjectVersion, readFile } = makeDependencies();
-      const expected = new NotFoundError("/some/path/ProjectVersion.txt");
+      const expected = new FsError(
+        "/some/path/ProjectVersion.txt",
+        FsErrorReason.Other
+      );
       readFile.mockReturnValue(Err(expected).toAsyncResult());
 
       const result = await loadProjectVersion("/some/bad/path").promise;

--- a/test/io/upm-config-io.test.ts
+++ b/test/io/upm-config-io.test.ts
@@ -4,7 +4,7 @@ import {
   RequiredEnvMissingError,
 } from "../../src/io/upm-config-io";
 import { Err, Ok } from "ts-results-es";
-import { FsError, NotFoundError, ReadTextFile } from "../../src/io/file-io";
+import { FsError, FsErrorReason, ReadTextFile } from "../../src/io/file-io";
 import { mockService } from "../services/service.mock";
 import { StringFormatError } from "../../src/utils/string-parsing";
 import { GetHomePath } from "../../src/io/special-paths";
@@ -55,7 +55,9 @@ describe("upm-config-io", () => {
     it("should be null if file is not found", async () => {
       const { loadUpmConfig, readFile } = makeDependencies();
       const path = "/home/user/.upmconfig.toml";
-      readFile.mockReturnValue(Err(new NotFoundError(path)).toAsyncResult());
+      readFile.mockReturnValue(
+        Err(new FsError(path, FsErrorReason.Missing)).toAsyncResult()
+      );
 
       const result = await loadUpmConfig(path).promise;
 
@@ -74,7 +76,7 @@ describe("upm-config-io", () => {
     it("should fail if file could not be read", async () => {
       const { loadUpmConfig, readFile } = makeDependencies();
       const path = "/home/user/.upmconfig.toml";
-      const expected = new FsError();
+      const expected = new FsError(path, FsErrorReason.Other);
       readFile.mockReturnValue(Err(expected).toAsyncResult());
 
       const result = await loadUpmConfig(path).promise;

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -8,7 +8,7 @@ import {
 import { AuthNpmrcService } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
-import { FsError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 
 const exampleUser = "user";
 const examplePassword = "pass";
@@ -60,7 +60,7 @@ describe("login", () => {
     });
 
     it("should fail if config write fails", async () => {
-      const expected = new FsError();
+      const expected = new FsError("", FsErrorReason.Other);
       const { login, saveAuthToUpmConfig } = makeDependencies();
       saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
 
@@ -121,7 +121,7 @@ describe("login", () => {
     });
 
     it("should fail if npmrc auth fails", async () => {
-      const expected = new FsError();
+      const expected = new FsError("", FsErrorReason.Other);
       const { login, authNpmrc } = makeDependencies();
       authNpmrc.mockReturnValue(Err(expected).toAsyncResult());
 
@@ -186,7 +186,7 @@ describe("login", () => {
     });
 
     it("should fail if config write fails", async () => {
-      const expected = new FsError();
+      const expected = new FsError("", FsErrorReason.Other);
       const { login, saveAuthToUpmConfig } = makeDependencies();
       saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
 

--- a/test/services/npmrc-auth.test.ts
+++ b/test/services/npmrc-auth.test.ts
@@ -3,7 +3,7 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import { RequiredEnvMissingError } from "../../src/io/upm-config-io";
 import { emptyNpmrc, setToken } from "../../src/domain/npmrc";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { FsError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { makeAuthNpmrcService } from "../../src/services/npmrc-auth";
 import { mockService } from "./service.mock";
 
@@ -36,7 +36,7 @@ describe("npmrc-auth", () => {
     });
 
     it("should fail if npmrc load failed", async () => {
-      const expected = new FsError();
+      const expected = new FsError("", FsErrorReason.Other);
       const { authNpmrc, loadNpmrc } = makeDependencies();
       loadNpmrc.mockReturnValue(new AsyncResult(Err(expected)));
 
@@ -46,7 +46,7 @@ describe("npmrc-auth", () => {
     });
 
     it("should fail if npmrc save failed", async () => {
-      const expected = new FsError();
+      const expected = new FsError("", FsErrorReason.Other);
       const { authNpmrc, saveNpmrc } = makeDependencies();
       saveNpmrc.mockReturnValue(new AsyncResult(Err(expected)));
 

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -3,7 +3,7 @@ import { NpmAuth } from "another-npm-registry-client";
 import { Env, makeParseEnvService } from "../../src/services/parse-env";
 import { Err, Ok } from "ts-results-es";
 import { GetUpmConfigPath, LoadUpmConfig } from "../../src/io/upm-config-io";
-import { FsError, NotFoundError } from "../../src/io/file-io";
+import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { FileParseError } from "../../src/common-errors";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { NoWslError } from "../../src/io/wsl";
@@ -512,7 +512,7 @@ describe("env", () => {
 
     it("should fail if ProjectVersion.txt could not be loaded", async () => {
       const { parseEnv, loadProjectVersion } = makeDependencies();
-      const expected = new FsError();
+      const expected = new FsError("", FsErrorReason.Other);
       loadProjectVersion.mockReturnValue(Err(expected).toAsyncResult());
 
       const result = await parseEnv({
@@ -525,7 +525,9 @@ describe("env", () => {
     it("should notify of missing ProjectVersion.txt", async () => {
       const { parseEnv, log, loadProjectVersion } = makeDependencies();
       loadProjectVersion.mockReturnValue(
-        Err(new NotFoundError("/some/path/ProjectVersion.txt")).toAsyncResult()
+        Err(
+          new FsError("/some/path/ProjectVersion.txt", FsErrorReason.Missing)
+        ).toAsyncResult()
       );
 
       await parseEnv({


### PR DESCRIPTION
Merge FsError and NotFoundError. This simplifies handling logic. Also remove references to node error from FsError in order to avoid leaking low-level information when not necessary.