### PR TITLE
refactor: separate user and debug logs

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -53,6 +53,7 @@ import { unityRegistryUrl } from "../domain/registry-url";
 import { tryGetTargetEditorVersionFor } from "../domain/package-manifest";
 import { VersionNotFoundError } from "../domain/packument";
 import { FetchPackumentError } from "../io/packument-io";
+import { DebugLog } from "../logging";
 
 export class InvalidPackumentDataError extends CustomError {
   private readonly _class = "InvalidPackumentDataError";
@@ -112,7 +113,8 @@ export function makeAddCmd(
   resolveDependencies: ResolveDependenciesService,
   loadProjectManifest: LoadProjectManifest,
   writeProjectManifest: WriteProjectManifest,
-  log: Logger
+  log: Logger,
+  debugLog: DebugLog
 ): AddCmd {
   return async (pkgs, options) => {
     if (!Array.isArray(pkgs)) pkgs = [pkgs];
@@ -213,10 +215,7 @@ export function makeAddCmd(
 
         // pkgsInScope
         if (!isUpstreamPackage) {
-          log.verbose(
-            "dependency",
-            `fetch: ${makePackageReference(name, requestedVersion)}`
-          );
+          debugLog(`fetch: ${makePackageReference(name, requestedVersion)}`);
           const resolveResult = await resolveDependencies(
             [env.registry, env.upstreamRegistry],
             name,
@@ -231,7 +230,7 @@ export function makeAddCmd(
 
           // add depsValid to pkgsInScope.
           depsValid.forEach((dependency) =>
-            logValidDependency(log, dependency)
+            logValidDependency(debugLog, dependency)
           );
           depsValid
             .filter((x) => {

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -17,6 +17,7 @@ import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
 import { VersionNotFoundError } from "../domain/packument";
 import { logEnvParseError } from "./error-logging";
+import { DebugLog } from "../logging";
 
 export type DepsError = EnvParseError | DependencyResolveError;
 
@@ -47,7 +48,8 @@ function errorPrefixForError(error: PackumentVersionResolveError): string {
 export function makeDepsCmd(
   parseEnv: ParseEnvService,
   resolveDependencies: ResolveDependenciesService,
-  log: Logger
+  log: Logger,
+  debugLog: DebugLog
 ): DepsCmd {
   return async (pkg, options) => {
     // parse env
@@ -65,10 +67,7 @@ export function makeDepsCmd(
       throw new Error("Cannot get dependencies for url-version");
 
     const deep = options.deep || false;
-    log.verbose(
-      "dependency",
-      `fetch: ${makePackageReference(name, version)}, deep=${deep}`
-    );
+    debugLog(`fetch: ${makePackageReference(name, version)}, deep=${deep}`);
     const resolveResult = await resolveDependencies(
       [env.registry, env.upstreamRegistry],
       name,
@@ -81,7 +80,7 @@ export function makeDepsCmd(
       return resolveResult;
     const [depsValid, depsInvalid] = resolveResult.value;
 
-    depsValid.forEach((dependency) => logValidDependency(log, dependency));
+    depsValid.forEach((dependency) => logValidDependency(debugLog, dependency));
     depsValid
       .filter((x) => !x.self)
       .forEach((x) =>

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -90,9 +90,7 @@ export function makeLoginCmd(
       alwaysAuth,
       loginRegistry,
       configPath,
-      options.basicAuth ? "basic" : "token",
-      () => log.notice("auth", `you are authenticated as '${username}'`),
-      (npmrcPath) => log.notice("config", `saved to npm config: ${npmrcPath}`)
+      options.basicAuth ? "basic" : "token"
     ).promise;
 
     if (loginResult.isErr()) {
@@ -106,6 +104,7 @@ export function makeLoginCmd(
       return loginResult;
     }
 
+    log.notice("auth", `you are authenticated as '${username}'`);
     log.notice("config", "saved unity config at " + configPath);
     return Ok(undefined);
   };

--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -7,6 +7,7 @@ import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { Logger } from "npmlog";
 import { SearchPackages } from "../services/search-packages";
 import { logEnvParseError } from "./error-logging";
+import { DebugLog } from "../logging";
 
 export type SearchError = EnvParseError | HttpErrorBase;
 
@@ -28,7 +29,8 @@ export type SearchCmd = (
 export function makeSearchCmd(
   parseEnv: ParseEnvService,
   searchPackages: SearchPackages,
-  log: Logger
+  log: Logger,
+  debugLog: DebugLog
 ): SearchCmd {
   return async (keyword, options) => {
     // parse env
@@ -56,7 +58,7 @@ export function makeSearchCmd(
       return Ok(undefined);
     }
 
-    log.verbose(usedEndpoint, results.map((it) => it.name).join(os.EOL));
+    debugLog(`${usedEndpoint}: ${results.map((it) => it.name).join(os.EOL)}`);
     console.log(formatAsTable(results));
     return Ok(undefined);
   };

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -1,12 +1,15 @@
 import { ValidDependency } from "../services/dependency-resolving";
 import { makePackageReference } from "../domain/package-reference";
-import { Logger } from "npmlog";
 import { unityRegistryUrl } from "../domain/registry-url";
+import { DebugLog } from "../logging";
 
 /**
  * Logs information about a valid dependency to a logger.
  */
-export function logValidDependency(log: Logger, dependency: ValidDependency) {
+export function logValidDependency(
+  debugLog: DebugLog,
+  dependency: ValidDependency
+) {
   const packageRef = makePackageReference(dependency.name, dependency.version);
   const tag =
     dependency.source === "built-in"
@@ -15,5 +18,5 @@ export function logValidDependency(log: Logger, dependency: ValidDependency) {
       ? "[upstream]"
       : "";
   const message = `${packageRef} ${tag}`;
-  log.verbose("dependency", message);
+  debugLog(message);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,10 +46,12 @@ import { makePackumentFetcher } from "../io/packument-io";
 import { makePackagesSearcher } from "../services/search-packages";
 import { makeRemotePackumentResolver } from "../services/resolve-remote-packument";
 import { makeLoginService } from "../services/login";
+import { DebugLog } from "../logging";
 
 // Composition root
 
 const log = npmlog;
+const debugLog: DebugLog = (message) => log.verbose("openupm-cli", message);
 const regClient = new RegClient({ log });
 const getCwd = makeCwdGetter();
 const getHomePath = makeHomePathGetter();
@@ -89,7 +91,12 @@ const saveAuthToUpmConfig = makeSaveAuthToUpmConfigService(
   writeFile
 );
 const searchPackages = makePackagesSearcher(searchRegistry, fetchAllPackuments);
-const login = makeLoginService(saveAuthToUpmConfig, npmLogin, authNpmrc);
+const login = makeLoginService(
+  saveAuthToUpmConfig,
+  npmLogin,
+  authNpmrc,
+  debugLog
+);
 
 const addCmd = makeAddCmd(
   parseEnv,
@@ -97,11 +104,12 @@ const addCmd = makeAddCmd(
   resolveDependencies,
   loadProjectManifest,
   writeProjectManifest,
-  log
+  log,
+  debugLog
 );
 const loginCmd = makeLoginCmd(parseEnv, getUpmConfigPath, login, log);
-const searchCmd = makeSearchCmd(parseEnv, searchPackages, log);
-const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log);
+const searchCmd = makeSearchCmd(parseEnv, searchPackages, log, debugLog);
+const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log, debugLog);
 const removeCmd = makeRemoveCmd(
   parseEnv,
   loadProjectManifest,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -61,8 +61,8 @@ const debugLog: DebugLog = (message, context) =>
 const regClient = new RegClient({ log });
 const getCwd = makeCwdGetter();
 const getHomePath = makeHomePathGetter();
-const readFile = makeTextReader();
-const writeFile = makeTextWriter();
+const readFile = makeTextReader(debugLog);
+const writeFile = makeTextWriter(debugLog);
 const loadProjectManifest = makeProjectManifestLoader(readFile);
 const writeProjectManifest = makeProjectManifestWriter(writeFile);
 const getUpmConfigPath = makeUpmConfigPathGetter(getHomePath);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -51,7 +51,13 @@ import { DebugLog } from "../logging";
 // Composition root
 
 const log = npmlog;
-const debugLog: DebugLog = (message) => log.verbose("openupm-cli", message);
+const debugLog: DebugLog = (message, context) =>
+  log.verbose(
+    "openupm-cli",
+    `${message}${
+      context !== undefined ? ` context: ${JSON.stringify(context)}` : ""
+    }`
+  );
 const regClient = new RegClient({ log });
 const getCwd = makeCwdGetter();
 const getHomePath = makeHomePathGetter();

--- a/src/io/builtin-packages.ts
+++ b/src/io/builtin-packages.ts
@@ -8,6 +8,7 @@ import { DomainName } from "../domain/domain-name";
 import { CustomError } from "ts-custom-error";
 import path from "path";
 import { FsError, FsErrorReason, tryGetDirectoriesIn } from "./file-io";
+import { DebugLog } from "../logging";
 
 /**
  * Error for when an editor-version is not installed.
@@ -43,7 +44,9 @@ export type FindBuiltInPackages = (
 /**
  * Makes a {@link FindBuiltInPackages} function.
  */
-export function makeBuiltInPackagesFinder(): FindBuiltInPackages {
+export function makeBuiltInPackagesFinder(
+  debugLog: DebugLog
+): FindBuiltInPackages {
   return (editorVersion) => {
     {
       const pathResult = tryGetEditorInstallPath(editorVersion);
@@ -55,7 +58,7 @@ export function makeBuiltInPackagesFinder(): FindBuiltInPackages {
       );
 
       return (
-        tryGetDirectoriesIn(packagesDir)
+        tryGetDirectoriesIn(packagesDir, debugLog)
           // We can assume correct format
           .map((names) => names as DomainName[])
           .mapErr((error) =>

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,9 @@
+/**
+ * Function that logs a message to some external system. This interface is
+ * output-agnostic meaning that the logs could go to a console, file or other.
+ * This interface is supposed to be only used for debug logs, not for
+ * user-facing logs.
+ * @param message The message to be logged.
+ * @returns Nothing. Could be asynchronous.
+ */
+export type DebugLog = (message: string) => void | Promise<void>;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -4,6 +4,11 @@
  * This interface is supposed to be only used for debug logs, not for
  * user-facing logs.
  * @param message The message to be logged.
+ * @param context Optional context object. Will be stringified and appended
+ * to the message.
  * @returns Nothing. Could be asynchronous.
  */
-export type DebugLog = (message: string) => void | Promise<void>;
+export type DebugLog = (
+  message: string,
+  context?: object
+) => void | Promise<void>;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -12,3 +12,5 @@ export type DebugLog = (
   message: string,
   context?: object
 ) => void | Promise<void>;
+
+export const noopLogger: DebugLog = () => {};

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -32,6 +32,7 @@ import {
 import { makePackageReference } from "../../src/domain/package-reference";
 import { VersionNotFoundError } from "../../src/domain/packument";
 import { DebugLogger } from "node:util";
+import { noopLogger } from "../../src/logging";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -103,8 +104,6 @@ function makeDependencies() {
 
   const log = makeMockLogger();
 
-  const debugLog = mockService<DebugLogger>();
-
   const addCmd = makeAddCmd(
     parseEnv,
     resolveRemovePackumentVersion,
@@ -112,7 +111,7 @@ function makeDependencies() {
     loadProjectManifest,
     writeProjectManifest,
     log,
-    debugLog
+    noopLogger
   );
   return {
     addCmd,

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -12,6 +12,7 @@ import { PackumentNotFoundError } from "../../src/common-errors";
 import { ResolveDependenciesService } from "../../src/services/dependency-resolving";
 import { mockService } from "../services/service.mock";
 import { VersionNotFoundError } from "../../src/domain/packument";
+import { DebugLogger } from "node:util";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -48,7 +49,9 @@ function makeDependencies() {
 
   const log = makeMockLogger();
 
-  const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log);
+  const debugLog = mockService<DebugLogger>();
+
+  const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log, debugLog);
   return { depsCmd, parseEnv, resolveDependencies, log } as const;
 }
 
@@ -76,50 +79,6 @@ describe("cmd-deps", () => {
     await expect(operation).rejects.toMatchObject({
       message: "Cannot get dependencies for url-version",
     });
-  });
-
-  it("should notify of shallow operation start", async () => {
-    const { depsCmd, log } = makeDependencies();
-
-    await depsCmd(somePackage, {
-      _global: {},
-    });
-
-    expect(log.verbose).toHaveLogLike(
-      "dependency",
-      expect.stringContaining("deep=false")
-    );
-  });
-
-  it("should notify of deep operation start", async () => {
-    const { depsCmd, log } = makeDependencies();
-
-    await depsCmd(somePackage, {
-      _global: {},
-      deep: true,
-    });
-
-    expect(log.verbose).toHaveLogLike(
-      "dependency",
-      expect.stringContaining("deep=true")
-    );
-  });
-
-  it("should print verbose information about valid dependencies", async () => {
-    const { depsCmd, log } = makeDependencies();
-
-    await depsCmd(somePackage, {
-      _global: {},
-    });
-
-    expect(log.verbose).toHaveLogLike(
-      "dependency",
-      expect.stringContaining(somePackage)
-    );
-    expect(log.verbose).toHaveLogLike(
-      "dependency",
-      expect.stringContaining(otherPackage)
-    );
   });
 
   it("should log valid dependencies", async () => {

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -13,6 +13,7 @@ import { ResolveDependenciesService } from "../../src/services/dependency-resolv
 import { mockService } from "../services/service.mock";
 import { VersionNotFoundError } from "../../src/domain/packument";
 import { DebugLogger } from "node:util";
+import { noopLogger } from "../../src/logging";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -49,9 +50,7 @@ function makeDependencies() {
 
   const log = makeMockLogger();
 
-  const debugLog = mockService<DebugLogger>();
-
-  const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log, debugLog);
+  const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log, noopLogger);
   return { depsCmd, parseEnv, resolveDependencies, log } as const;
 }
 

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -9,7 +9,7 @@ import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { DebugLog } from "../../src/logging";
+import { DebugLog, noopLogger } from "../../src/logging";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -30,9 +30,7 @@ function makeDependencies() {
 
   const log = makeMockLogger();
 
-  const debugLog = mockService<DebugLog>();
-
-  const searchCmd = makeSearchCmd(parseEnv, searchPackages, log, debugLog);
+  const searchCmd = makeSearchCmd(parseEnv, searchPackages, log, noopLogger);
   return {
     searchCmd,
     parseEnv,

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -9,6 +9,7 @@ import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+import { DebugLog } from "../../src/logging";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -29,7 +30,9 @@ function makeDependencies() {
 
   const log = makeMockLogger();
 
-  const searchCmd = makeSearchCmd(parseEnv, searchPackages, log);
+  const debugLog = mockService<DebugLog>();
+
+  const searchCmd = makeSearchCmd(parseEnv, searchPackages, log, debugLog);
   return {
     searchCmd,
     parseEnv,
@@ -58,17 +61,6 @@ describe("cmd-search", () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1.0.0"));
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("2019-10-02")
-    );
-  });
-
-  it("should print all found packument names when using new search", async () => {
-    const { searchCmd, log } = makeDependencies();
-
-    await searchCmd("package-a", options);
-
-    expect(log.verbose).toHaveBeenCalledWith(
-      "npmsearch",
-      expect.stringContaining("package-a")
     );
   });
 
@@ -129,23 +121,6 @@ describe("cmd-search", () => {
     expect(log.warn).toHaveBeenCalledWith(
       "",
       expect.stringContaining("using old search")
-    );
-  });
-
-  it("should print all found packument names when using old search", async () => {
-    const { searchCmd, searchPackages, log } = makeDependencies();
-    searchPackages.mockImplementation(
-      (_registry, _keyword, onUseAllFallback) => {
-        onUseAllFallback && onUseAllFallback();
-        return Ok([exampleSearchResult]).toAsyncResult();
-      }
-    );
-
-    await searchCmd("package-a", options);
-
-    expect(log.verbose).toHaveBeenCalledWith(
-      "endpoint.all",
-      expect.stringContaining("package-a")
     );
   });
 });

--- a/test/io/builtin-packages.test.ts
+++ b/test/io/builtin-packages.test.ts
@@ -8,9 +8,10 @@ import {
   makeBuiltInPackagesFinder,
 } from "../../src/io/builtin-packages";
 import { makeEditorVersion } from "../../src/domain/editor-version";
+import { noopLogger } from "../../src/logging";
 
 function makeDependencies() {
-  const getBuiltInPackages = makeBuiltInPackagesFinder();
+  const getBuiltInPackages = makeBuiltInPackagesFinder(noopLogger);
   return { getBuiltInPackages } as const;
 }
 

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -9,7 +9,7 @@ import { AuthNpmrcService } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
 import { FsError, FsErrorReason } from "../../src/io/file-io";
-import { DebugLogger } from "node:util";
+import { noopLogger } from "../../src/logging";
 
 const exampleUser = "user";
 const examplePassword = "pass";
@@ -29,13 +29,11 @@ describe("login", () => {
     const authNpmrc = mockService<AuthNpmrcService>();
     authNpmrc.mockReturnValue(Ok(exampleNpmrcPath).toAsyncResult());
 
-    const debugLog = mockService<DebugLogger>();
-
     const login = makeLoginService(
       saveAuthToUpmConfig,
       npmLogin,
       authNpmrc,
-      debugLog
+      noopLogger
     );
     return { login, saveAuthToUpmConfig, npmLogin, authNpmrc } as const;
   }

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -9,6 +9,7 @@ import { AuthNpmrcService } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
 import { FsError, FsErrorReason } from "../../src/io/file-io";
+import { DebugLogger } from "node:util";
 
 const exampleUser = "user";
 const examplePassword = "pass";
@@ -28,7 +29,14 @@ describe("login", () => {
     const authNpmrc = mockService<AuthNpmrcService>();
     authNpmrc.mockReturnValue(Ok(exampleNpmrcPath).toAsyncResult());
 
-    const login = makeLoginService(saveAuthToUpmConfig, npmLogin, authNpmrc);
+    const debugLog = mockService<DebugLogger>();
+
+    const login = makeLoginService(
+      saveAuthToUpmConfig,
+      npmLogin,
+      authNpmrc,
+      debugLog
+    );
     return { login, saveAuthToUpmConfig, npmLogin, authNpmrc } as const;
   }
 
@@ -43,9 +51,7 @@ describe("login", () => {
         true,
         exampleRegistryUrl,
         exampleConfigPath,
-        "basic",
-        () => {},
-        () => {}
+        "basic"
       ).promise;
 
       expect(saveAuthToUpmConfig).toHaveBeenCalledWith(
@@ -71,9 +77,7 @@ describe("login", () => {
         true,
         exampleRegistryUrl,
         exampleConfigPath,
-        "basic",
-        () => {},
-        () => {}
+        "basic"
       ).promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
@@ -93,31 +97,10 @@ describe("login", () => {
         true,
         exampleRegistryUrl,
         exampleConfigPath,
-        "token",
-        () => {},
-        () => {}
+        "token"
       ).promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
-    });
-
-    it("should notify of npm login success", async () => {
-      const { login } = makeDependencies();
-      const onNpmAuthSuccess = jest.fn();
-
-      await login(
-        exampleUser,
-        examplePassword,
-        exampleEmail,
-        true,
-        exampleRegistryUrl,
-        exampleConfigPath,
-        "token",
-        onNpmAuthSuccess,
-        () => {}
-      ).promise;
-
-      expect(onNpmAuthSuccess).toHaveBeenCalled();
     });
 
     it("should fail if npmrc auth fails", async () => {
@@ -132,31 +115,10 @@ describe("login", () => {
         true,
         exampleRegistryUrl,
         exampleConfigPath,
-        "token",
-        () => {},
-        () => {}
+        "token"
       ).promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));
-    });
-
-    it("should notify of npmrc auth success", async () => {
-      const { login } = makeDependencies();
-      const onNpmrcUpdated = jest.fn();
-
-      await login(
-        exampleUser,
-        examplePassword,
-        exampleEmail,
-        true,
-        exampleRegistryUrl,
-        exampleConfigPath,
-        "token",
-        () => {},
-        onNpmrcUpdated
-      ).promise;
-
-      expect(onNpmrcUpdated).toHaveBeenCalledWith(exampleNpmrcPath);
     });
 
     it("should save token", async () => {
@@ -169,9 +131,7 @@ describe("login", () => {
         true,
         exampleRegistryUrl,
         exampleConfigPath,
-        "token",
-        () => {},
-        () => {}
+        "token"
       ).promise;
 
       expect(saveAuthToUpmConfig).toHaveBeenCalledWith(
@@ -197,9 +157,7 @@ describe("login", () => {
         true,
         exampleRegistryUrl,
         exampleConfigPath,
-        "token",
-        () => {},
-        () => {}
+        "token"
       ).promise;
 
       expect(result).toBeError((actual) => expect(actual).toEqual(expected));


### PR DESCRIPTION
This PR separates the logging functions for user-facing and debug logs. User-facing logs should only be made on the CLI layer while debug logs can be made everywhere. This way low-level errors which only get logged to the debug log don't need to be bubbled all the way up to the CLI layer.