### PR TITLE
refactor: improve file-io errors

### DIFF
--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -7,18 +7,18 @@ import { PackumentVersionResolveError } from "../packument-version-resolving";
 import { FileParseError, PackumentNotFoundError } from "../common-errors";
 import { DomainName } from "../domain/domain-name";
 import { VersionNotFoundError } from "../domain/packument";
-import { FsError, FsErrorReason } from "../io/file-io";
 import { EnvParseError } from "../services/parse-env";
 import { NoWslError } from "../io/wsl";
 import { ChildProcessError } from "../utils/process";
 import { RequiredEnvMissingError } from "../io/upm-config-io";
+import { FileMissingError, GenericIOError } from "../io/common-errors";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.
  */
 export function logManifestLoadError(log: Logger, error: ManifestLoadError) {
   const prefix = "manifest";
-  if (error instanceof FsError && error.reason === FsErrorReason.Missing)
+  if (error instanceof FileMissingError)
     log.error(prefix, `manifest at ${error.path} does not exist`);
   else if (error instanceof FileParseError) {
     log.error(prefix, `failed to parse manifest at ${error.path}`);
@@ -62,10 +62,10 @@ export function logEnvParseError(log: Logger, error: EnvParseError) {
   const reason =
     error instanceof NoWslError
       ? "you attempted to use wsl even though you are not running openupm inside wsl"
-      : error instanceof FsError
-      ? error.reason === FsErrorReason.Missing
-        ? `the file or directory at "${error.path}" does not exist`
-        : `the file or directory at "${error.path}" could not be read`
+      : error instanceof FileMissingError
+      ? `the projects version file (ProjectVersion.txt) could not be found at "${error.path}"`
+      : error instanceof GenericIOError
+      ? `a file-system interaction failed`
       : error instanceof ChildProcessError
       ? "a required child process failed"
       : error instanceof FileParseError

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,7 +33,7 @@ import {
   makeUpmConfigLoader,
   makeUpmConfigPathGetter,
 } from "../io/upm-config-io";
-import { makeTextReader, makeTextWriter } from "../io/file-io";
+import { makeTextReader, makeTextWriter } from "../io/fs-result";
 import {
   makeNpmrcLoader,
   makeNpmrcPathFinder,

--- a/src/io/builtin-packages.ts
+++ b/src/io/builtin-packages.ts
@@ -7,8 +7,9 @@ import {
 import { DomainName } from "../domain/domain-name";
 import { CustomError } from "ts-custom-error";
 import path from "path";
-import { FsError, FsErrorReason, tryGetDirectoriesIn } from "./file-io";
+import { tryGetDirectoriesIn } from "./fs-result";
 import { DebugLog } from "../logging";
+import { GenericIOError } from "./common-errors";
 
 /**
  * Error for when an editor-version is not installed.
@@ -31,7 +32,7 @@ export class EditorNotInstalledError extends CustomError {
 export type FindBuiltInPackagesError =
   | GetEditorInstallPathError
   | EditorNotInstalledError
-  | FsError;
+  | GenericIOError;
 
 /**
  * Function for loading all built-in packages for an installed editor.
@@ -62,9 +63,9 @@ export function makeBuiltInPackagesFinder(
           // We can assume correct format
           .map((names) => names as DomainName[])
           .mapErr((error) =>
-            error.reason === FsErrorReason.Missing
+            error.code === "ENOENT"
               ? new EditorNotInstalledError(editorVersion)
-              : error
+              : new GenericIOError()
           )
       );
     }

--- a/src/io/common-errors.ts
+++ b/src/io/common-errors.ts
@@ -1,0 +1,31 @@
+import { CustomError } from "ts-custom-error";
+
+/**
+ * Generic error for when some non-specific IO operation failed.
+ */
+export class GenericIOError extends CustomError {
+  // noinspection JSUnusedLocalSymbols
+  private readonly _class = "GenericIOError";
+}
+
+/**
+ * Error for when a required file or directory is missing.
+ */
+export class FileMissingError<const TName extends string> extends CustomError {
+  // noinspection JSUnusedLocalSymbols
+  private readonly _class = "FileMissingError";
+
+  public constructor(
+    /**
+     * Name of the file. This is a constant string that can be used in
+     * ifs and switches to identify the file that was missing.
+     */
+    public readonly fileName: TName,
+    /**
+     * The path where the file was searched but not found.
+     */
+    public readonly path: string
+  ) {
+    super();
+  }
+}

--- a/src/io/file-io.ts
+++ b/src/io/file-io.ts
@@ -52,16 +52,11 @@ function fsOperation<T>(debugLog: DebugLog, op: () => Promise<T>) {
 }
 
 /**
- * Error for when a file-read failed.
- */
-export type FileReadError = FsError;
-
-/**
  * Function for loading the content of a text file.
  * @param path The path to the file.
  * @returns The files text content.
  */
-export type ReadTextFile = (path: string) => AsyncResult<string, FileReadError>;
+export type ReadTextFile = (path: string) => AsyncResult<string, FsError>;
 
 /**
  * Makes a {@link ReadTextFile} function.
@@ -72,11 +67,6 @@ export function makeTextReader(debugLog: DebugLog): ReadTextFile {
 }
 
 /**
- * Error for when a file-write failed.
- */
-export type FileWriteError = FsError;
-
-/**
  * Function for overwriting the content of a text file. Creates the file
  * if it does not exist.
  * @param filePath The path to the file.
@@ -85,7 +75,7 @@ export type FileWriteError = FsError;
 export type WriteTextFile = (
   filePath: string,
   content: string
-) => AsyncResult<void, FileWriteError>;
+) => AsyncResult<void, FsError>;
 
 /**
  * Makes a {@link WriteTextFile} function.
@@ -100,11 +90,6 @@ export function makeTextWriter(debugLog: DebugLog): WriteTextFile {
 }
 
 /**
- * Error which may occur when getting all directory names in a directory.
- */
-export type GetDirectoriesError = FsError;
-
-/**
  * Attempts to get the names of all directories in a directory.
  * @param directoryPath The directories name.
  * @param debugLog Debug-log function.
@@ -113,7 +98,7 @@ export type GetDirectoriesError = FsError;
 export function tryGetDirectoriesIn(
   directoryPath: string,
   debugLog: DebugLog
-): AsyncResult<ReadonlyArray<string>, GetDirectoriesError> {
+): AsyncResult<ReadonlyArray<string>, FsError> {
   return fsOperation(debugLog, () =>
     fs.readdir(directoryPath, { withFileTypes: true })
   )

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -1,11 +1,5 @@
 import { AsyncResult, Err, Ok, Result } from "ts-results-es";
-import {
-  FileWriteError,
-  FsError,
-  FsErrorReason,
-  ReadTextFile,
-  WriteTextFile,
-} from "./file-io";
+import { FsError, FsErrorReason, ReadTextFile, WriteTextFile } from "./file-io";
 import { EOL } from "node:os";
 import { Npmrc } from "../domain/npmrc";
 import path from "path";
@@ -59,7 +53,7 @@ export function makeNpmrcLoader(readFile: ReadTextFile): LoadNpmrc {
 /**
  * Error that might occur when saving a npmrc.
  */
-export type NpmrcSaveError = FileWriteError;
+export type NpmrcSaveError = FsError;
 
 /**
  * Function for saving npmrc files. Overwrites the content of the file.

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -4,9 +4,10 @@ import {
 } from "../domain/project-manifest";
 import path from "path";
 import { AsyncResult } from "ts-results-es";
-import { FsError, ReadTextFile, WriteTextFile } from "./file-io";
+import { ReadTextFile, WriteTextFile } from "./fs-result";
 import { StringFormatError, tryParseJson } from "../utils/string-parsing";
 import { FileParseError } from "../common-errors";
+import { FileMissingError, GenericIOError } from "./common-errors";
 
 /**
  * Determines the path to the package manifest based on the project
@@ -18,9 +19,27 @@ export function manifestPathFor(projectPath: string): string {
 }
 
 /**
+ * Error for when the project manifest is missing.
+ */
+export type ProjectManifestMissingError = FileMissingError<"ProjectManifest">;
+
+/**
+ * Makes a new {@link ProjectManifestMissingError}.
+ * @param filePath The path that was searched.
+ */
+export function makeProjectManifestMissingError(
+  filePath: string
+): ProjectManifestMissingError {
+  return new FileMissingError("ProjectManifest", filePath);
+}
+
+/**
  * Error which may occur when loading a project manifest.
  */
-export type ManifestLoadError = FsError | FileParseError;
+export type ManifestLoadError =
+  | ProjectManifestMissingError
+  | GenericIOError
+  | FileParseError;
 
 /**
  * Function for loading the project manifest for a Unity project.
@@ -40,6 +59,11 @@ export function makeProjectManifestLoader(
     const manifestPath = manifestPathFor(projectPath);
     return (
       readFile(manifestPath)
+        .mapErr((error) =>
+          error.code === "ENOENT"
+            ? makeProjectManifestMissingError(manifestPath)
+            : new GenericIOError()
+        )
         .andThen(tryParseJson)
         // TODO: Actually validate the json structure
         .map((json) => json as unknown as UnityProjectManifest)
@@ -55,7 +79,7 @@ export function makeProjectManifestLoader(
 /**
  * Error which may occur when saving a project manifest.
  */
-export type ManifestWriteError = FsError;
+export type ManifestWriteError = GenericIOError;
 
 /**
  * Function for replacing the project manifest for a Unity project.
@@ -78,6 +102,6 @@ export function makeProjectManifestWriter(
     manifest = pruneManifest(manifest);
     const json = JSON.stringify(manifest, null, 2);
 
-    return writeFile(manifestPath, json);
+    return writeFile(manifestPath, json).mapErr(() => new GenericIOError());
   };
 }

--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { FileParseError } from "../common-errors";
-import { FileReadError, ReadTextFile } from "./file-io";
+import { FsError, ReadTextFile } from "./file-io";
 import { StringFormatError, tryParseYaml } from "../utils/string-parsing";
 
 function projectVersionTxtPathFor(projectDirPath: string) {
@@ -12,7 +12,7 @@ function projectVersionTxtPathFor(projectDirPath: string) {
  * Error which may occur when loading a project-version.
  */
 export type ProjectVersionLoadError =
-  | FileReadError
+  | FsError
   | StringFormatError
   | FileParseError;
 

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -24,7 +24,6 @@ import {
 import { Registry } from "../domain/registry";
 import { Logger } from "npmlog";
 import { GetCwd } from "../io/special-paths";
-import { FileMissingError } from "../io/common-errors";
 
 export type Env = Readonly<{
   cwd: string;

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -24,7 +24,7 @@ import {
 import { Registry } from "../domain/registry";
 import { Logger } from "npmlog";
 import { GetCwd } from "../io/special-paths";
-import { FsError, FsErrorReason } from "../io/file-io";
+import { FileMissingError } from "../io/common-errors";
 
 export type Env = Readonly<{
   cwd: string;
@@ -162,12 +162,7 @@ export function makeParseEnvService(
     const projectVersionLoadResult = await loadProjectVersion(cwd).promise;
     if (projectVersionLoadResult.isErr()) {
       const error = projectVersionLoadResult.error;
-      if (error instanceof FsError && error.reason === FsErrorReason.Missing)
-        log.warn(
-          "ProjectVersion",
-          `can not locate ProjectVersion.text at path ${error.path}`
-        );
-      else if (error instanceof FileParseError)
+      if (error instanceof FileParseError)
         log.error(
           "ProjectVersion",
           "ProjectVersion.txt could not be parsed for editor-version!"

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -5,7 +5,7 @@ import { SemanticVersion } from "../domain/semantic-version";
 import { PackumentNotFoundError } from "../common-errors";
 import { NoVersionsError, tryGetLatestVersion } from "../domain/packument";
 import { recordKeys } from "../utils/record-utils";
-import { FetchPackumentError, FetchPackument } from "../io/packument-io";
+import { FetchPackument, FetchPackumentError } from "../io/packument-io";
 
 /**
  * Error which may occur when resolving the latest version for a package.

--- a/src/services/upm-auth.ts
+++ b/src/services/upm-auth.ts
@@ -1,4 +1,4 @@
-import { FsError, WriteTextFile } from "../io/file-io";
+import { WriteTextFile } from "../io/fs-result";
 import { RegistryUrl } from "../domain/registry-url";
 import { addAuth, UpmAuth } from "../domain/upm-config";
 import { AsyncResult } from "ts-results-es";
@@ -7,11 +7,12 @@ import {
   trySaveUpmConfig,
   UpmConfigLoadError,
 } from "../io/upm-config-io";
+import { GenericIOError } from "../io/common-errors";
 
 /**
  * Errors which may occur when storing an {@link UpmAuth} to the file-system.
  */
-export type UpmAuthStoreError = UpmConfigLoadError | FsError;
+export type UpmAuthStoreError = UpmConfigLoadError | GenericIOError;
 
 /**
  * Service function for storing authentication information in an upmconfig file.

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -3,7 +3,6 @@ import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { Err, Ok } from "ts-results-es";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
 import { makeMockLogger } from "./log.mock";
@@ -12,8 +11,8 @@ import { PackumentNotFoundError } from "../../src/common-errors";
 import { ResolveDependenciesService } from "../../src/services/dependency-resolving";
 import { mockService } from "../services/service.mock";
 import { VersionNotFoundError } from "../../src/domain/packument";
-import { DebugLogger } from "node:util";
 import { noopLogger } from "../../src/logging";
+import { GenericIOError } from "../../src/io/common-errors";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -56,7 +55,7 @@ function makeDependencies() {
 
 describe("cmd-deps", () => {
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError("", FsErrorReason.Other);
+    const expected = new GenericIOError();
     const { depsCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -1,4 +1,3 @@
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import { makeLoginCmd } from "../../src/cli/cmd-login";
 import { mockService } from "../services/service.mock";
@@ -13,6 +12,7 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { AuthenticationError } from "../../src/services/npm-login";
+import { GenericIOError } from "../../src/io/common-errors";
 
 const defaultEnv = {
   cwd: "/users/some-user/projects/SomeProject",
@@ -44,7 +44,7 @@ describe("cmd-login", () => {
   }
 
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError("", FsErrorReason.Other);
+    const expected = new GenericIOError();
     const { loginCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -9,7 +9,7 @@ import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { DebugLog, noopLogger } from "../../src/logging";
+import { noopLogger } from "../../src/logging";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -2,7 +2,6 @@ import { makeViewCmd } from "../../src/cli/cmd-view";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { Err, Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
@@ -16,6 +15,7 @@ import { buildPackument } from "../domain/data-packument";
 import { mockService } from "../services/service.mock";
 import { ResolveRemotePackument } from "../../src/services/resolve-remote-packument";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+import { GenericIOError } from "../../src/io/common-errors";
 
 const somePackage = makeDomainName("com.some.package");
 const somePackument = buildPackument(somePackage, (packument) =>
@@ -71,7 +71,7 @@ function makeDependencies() {
 
 describe("cmd-view", () => {
   it("should fail if env could not be parsed", async () => {
-    const expected = new FsError("", FsErrorReason.Other);
+    const expected = new GenericIOError();
     const { viewCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 

--- a/test/io/builtin-packages.test.ts
+++ b/test/io/builtin-packages.test.ts
@@ -1,7 +1,6 @@
 import * as specialPaths from "../../src/io/special-paths";
 import { OSNotSupportedError } from "../../src/io/special-paths";
-import * as fileIo from "../../src/io/file-io";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
+import * as fileIo from "../../src/io/fs-result";
 import { Err, Ok } from "ts-results-es";
 import {
   EditorNotInstalledError,
@@ -9,6 +8,7 @@ import {
 } from "../../src/io/builtin-packages";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { noopLogger } from "../../src/logging";
+import { enoentError } from "./node-error.mock";
 
 function makeDependencies() {
   const getBuiltInPackages = makeBuiltInPackagesFinder(noopLogger);
@@ -35,9 +35,7 @@ describe("builtin-packages", () => {
     const { getBuiltInPackages } = makeDependencies();
     jest
       .spyOn(fileIo, "tryGetDirectoriesIn")
-      .mockReturnValue(
-        Err(new FsError("", FsErrorReason.Missing)).toAsyncResult()
-      );
+      .mockReturnValue(Err(enoentError).toAsyncResult());
 
     const result = await getBuiltInPackages(version).promise;
 

--- a/test/io/node-error.mock.ts
+++ b/test/io/node-error.mock.ts
@@ -1,0 +1,13 @@
+/**
+ * Makes a NodeJS error for testing.
+ * @param code The errors error code.
+ */
+export function makeNodeError(code: string): NodeJS.ErrnoException {
+  const error = new Error() as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+export const eaccesError = makeNodeError("EACCES");
+
+export const enoentError = makeNodeError("ENOENT");

--- a/test/io/project-manifest-io.mock.ts
+++ b/test/io/project-manifest-io.mock.ts
@@ -1,12 +1,12 @@
 import {
   LoadProjectManifest,
+  makeProjectManifestMissingError,
   manifestPathFor,
   ManifestWriteError,
   WriteProjectManifest,
 } from "../../src/io/project-manifest-io";
 import { UnityProjectManifest } from "../../src/domain/project-manifest";
 import { Err, Ok } from "ts-results-es";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 
 /**
  * Mocks results for a {@link LoadProjectManifest} function.
@@ -21,7 +21,7 @@ export function mockProjectManifest(
   return loadProjectManifest.mockImplementation((projectPath) => {
     const manifestPath = manifestPathFor(projectPath);
     return manifest === null
-      ? Err(new FsError(manifestPath, FsErrorReason.Missing)).toAsyncResult()
+      ? Err(makeProjectManifestMissingError(manifestPath)).toAsyncResult()
       : Ok(manifest).toAsyncResult();
   });
 }

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -8,8 +8,8 @@ import {
 import { AuthNpmrcService } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { noopLogger } from "../../src/logging";
+import { GenericIOError } from "../../src/io/common-errors";
 
 const exampleUser = "user";
 const examplePassword = "pass";
@@ -64,7 +64,7 @@ describe("login", () => {
     });
 
     it("should fail if config write fails", async () => {
-      const expected = new FsError("", FsErrorReason.Other);
+      const expected = new GenericIOError();
       const { login, saveAuthToUpmConfig } = makeDependencies();
       saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
 
@@ -102,7 +102,7 @@ describe("login", () => {
     });
 
     it("should fail if npmrc auth fails", async () => {
-      const expected = new FsError("", FsErrorReason.Other);
+      const expected = new GenericIOError();
       const { login, authNpmrc } = makeDependencies();
       authNpmrc.mockReturnValue(Err(expected).toAsyncResult());
 
@@ -144,7 +144,7 @@ describe("login", () => {
     });
 
     it("should fail if config write fails", async () => {
-      const expected = new FsError("", FsErrorReason.Other);
+      const expected = new GenericIOError();
       const { login, saveAuthToUpmConfig } = makeDependencies();
       saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
 

--- a/test/services/npmrc-auth.test.ts
+++ b/test/services/npmrc-auth.test.ts
@@ -3,9 +3,9 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import { RequiredEnvMissingError } from "../../src/io/upm-config-io";
 import { emptyNpmrc, setToken } from "../../src/domain/npmrc";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { makeAuthNpmrcService } from "../../src/services/npmrc-auth";
 import { mockService } from "./service.mock";
+import { GenericIOError } from "../../src/io/common-errors";
 
 const exampleNpmrcPath = "/users/someuser/.npmrc";
 
@@ -36,7 +36,7 @@ describe("npmrc-auth", () => {
     });
 
     it("should fail if npmrc load failed", async () => {
-      const expected = new FsError("", FsErrorReason.Other);
+      const expected = new GenericIOError();
       const { authNpmrc, loadNpmrc } = makeDependencies();
       loadNpmrc.mockReturnValue(new AsyncResult(Err(expected)));
 
@@ -46,7 +46,7 @@ describe("npmrc-auth", () => {
     });
 
     it("should fail if npmrc save failed", async () => {
-      const expected = new FsError("", FsErrorReason.Other);
+      const expected = new GenericIOError();
       const { authNpmrc, saveNpmrc } = makeDependencies();
       saveNpmrc.mockReturnValue(new AsyncResult(Err(expected)));
 

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -13,7 +13,7 @@ import { makeMockLogger } from "../cli/log.mock";
 import { mockService } from "./service.mock";
 import { GetCwd } from "../../src/io/special-paths";
 import { LoadProjectVersion } from "../../src/io/project-version-io";
-import { FileMissingError, GenericIOError } from "../../src/io/common-errors";
+import { GenericIOError } from "../../src/io/common-errors";
 
 const testRootPath = "/users/some-user/projects/MyUnityProject";
 
@@ -520,27 +520,6 @@ describe("env", () => {
       });
 
       expect(result).toBeError((error) => expect(error).toEqual(expected));
-    });
-
-    it("should notify of missing ProjectVersion.txt", async () => {
-      const { parseEnv, log, loadProjectVersion } = makeDependencies();
-      loadProjectVersion.mockReturnValue(
-        Err(
-          new FileMissingError(
-            "ProjectVersion.txt",
-            "/some/path/ProjectVersion.txt"
-          )
-        ).toAsyncResult()
-      );
-
-      await parseEnv({
-        _global: {},
-      });
-
-      expect(log.warn).toHaveBeenCalledWith(
-        "ProjectVersion",
-        expect.stringContaining("can not locate")
-      );
     });
 
     it("should notify of parsing issue", async () => {

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -3,7 +3,6 @@ import { NpmAuth } from "another-npm-registry-client";
 import { Env, makeParseEnvService } from "../../src/services/parse-env";
 import { Err, Ok } from "ts-results-es";
 import { GetUpmConfigPath, LoadUpmConfig } from "../../src/io/upm-config-io";
-import { FsError, FsErrorReason } from "../../src/io/file-io";
 import { FileParseError } from "../../src/common-errors";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { NoWslError } from "../../src/io/wsl";
@@ -14,6 +13,7 @@ import { makeMockLogger } from "../cli/log.mock";
 import { mockService } from "./service.mock";
 import { GetCwd } from "../../src/io/special-paths";
 import { LoadProjectVersion } from "../../src/io/project-version-io";
+import { FileMissingError, GenericIOError } from "../../src/io/common-errors";
 
 const testRootPath = "/users/some-user/projects/MyUnityProject";
 
@@ -512,7 +512,7 @@ describe("env", () => {
 
     it("should fail if ProjectVersion.txt could not be loaded", async () => {
       const { parseEnv, loadProjectVersion } = makeDependencies();
-      const expected = new FsError("", FsErrorReason.Other);
+      const expected = new GenericIOError();
       loadProjectVersion.mockReturnValue(Err(expected).toAsyncResult());
 
       const result = await parseEnv({
@@ -526,7 +526,10 @@ describe("env", () => {
       const { parseEnv, log, loadProjectVersion } = makeDependencies();
       loadProjectVersion.mockReturnValue(
         Err(
-          new FsError("/some/path/ProjectVersion.txt", FsErrorReason.Missing)
+          new FileMissingError(
+            "ProjectVersion.txt",
+            "/some/path/ProjectVersion.txt"
+          )
         ).toAsyncResult()
       );
 


### PR DESCRIPTION
Refactor logic for file-system related io errors. The main changes are:

- We now log all file-system errors when they happen using the debug logger. This way we don't need to bubble the errors all the way up to the cli layer.
- There are now two file-system error types as part of the domain. One for when a file is missing and one for everything else.
- The `FileMissingError` allows to pass a constant string which identifies the missing file ("ProjectVersion.txt", "ProjectManifest", ...). This way the error can be reused for different files but still be differentiated for better logging.