### PR TITLE
test: make os independent

### DIFF
--- a/test/io/upm-config-io.test.ts
+++ b/test/io/upm-config-io.test.ts
@@ -25,7 +25,7 @@ describe("upm-config-io", () => {
     describe("no wsl and no system-user", () => {
       it("should be in home path", async () => {
         const { getUpmConfigPath, getHomePath } = makeDependencies();
-        const expected = "/some/home/dir/.upmconfig.toml";
+        const expected = path.resolve("/some/home/dir/.upmconfig.toml");
         getHomePath.mockReturnValue(Ok(path.dirname(expected)));
 
         const result = await getUpmConfigPath(false, false).promise;

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -14,6 +14,7 @@ import { mockService } from "./service.mock";
 import { GetCwd } from "../../src/io/special-paths";
 import { LoadProjectVersion } from "../../src/io/project-version-io";
 import { GenericIOError } from "../../src/io/common-errors";
+import path from "path";
 
 const testRootPath = "/users/some-user/projects/MyUnityProject";
 
@@ -457,7 +458,7 @@ describe("env", () => {
     it("should be specified path if overridden", async () => {
       const { parseEnv } = makeDependencies();
 
-      const expected = "/some/other/path";
+      const expected = path.resolve("/some/other/path");
 
       const result = await parseEnv({
         _global: {


### PR DESCRIPTION
Some tests failed when running on windows, specifically because of different path separators. This is now fixed.