### PR TITLE
refactor: extract service

### DIFF
--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -13,6 +13,7 @@ import { ChildProcessError } from "../utils/process";
 import { RequiredEnvMissingError } from "../io/upm-config-io";
 import { FileMissingError, GenericIOError } from "../io/common-errors";
 import { StringFormatError } from "../utils/string-parsing";
+import { DetermineEditorVersionError } from "../services/determine-editor-version";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.
@@ -70,20 +71,38 @@ export function logEnvParseError(log: Logger, error: EnvParseError) {
   const reason =
     error instanceof NoWslError
       ? "you attempted to use wsl even though you are not running openupm inside wsl"
-      : error instanceof FileMissingError
-      ? `the projects version file (ProjectVersion.txt) could not be found at "${error.path}"`
       : error instanceof GenericIOError
       ? `a file-system interaction failed`
       : error instanceof ChildProcessError
       ? "a required child process failed"
-      : error instanceof FileParseError
-      ? `the project version file (ProjectVersion.txt) has an invalid structure`
       : error instanceof RequiredEnvMissingError
       ? `none of the following environment variables were set: ${error.keyNames.join(
           ", "
         )}`
       : `a string was malformed. Expected to be ${error.formatName}`;
   const errorMessage = `environment information could not be parsed because ${reason}.`;
+  log.error("", errorMessage);
+
+  // TODO: Suggest actions user might take in order to fix the problem.
+}
+
+/**
+ * Logs a {@link DetermineEditorVersionError} to a logger.
+ */
+export function logDetermineEditorError(
+  log: Logger,
+  error: DetermineEditorVersionError
+) {
+  const reason =
+    error instanceof FileMissingError
+      ? `the projects version file (ProjectVersion.txt) could not be found at "${error.path}"`
+      : error instanceof GenericIOError
+      ? `a file-system interaction failed`
+      : error instanceof FileParseError
+      ? `the project version file (ProjectVersion.txt) has an invalid structure`
+      : `the project versions file (ProjectVersion.txt) did not contain valid yaml`;
+
+  const errorMessage = `editor version could be determined because ${reason}.`;
   log.error("", errorMessage);
 
   // TODO: Suggest actions user might take in order to fix the problem.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,6 +47,7 @@ import { makePackagesSearcher } from "../services/search-packages";
 import { makeRemotePackumentResolver } from "../services/resolve-remote-packument";
 import { makeLoginService } from "../services/login";
 import { DebugLog } from "../logging";
+import { makeEditorVersionDeterminer } from "../services/determine-editor-version";
 
 // Composition root
 
@@ -80,9 +81,9 @@ const parseEnv = makeParseEnvService(
   log,
   getUpmConfigPath,
   loadUpmConfig,
-  getCwd,
-  loadProjectVersion
+  getCwd
 );
+const determineEditorVersion = makeEditorVersionDeterminer(loadProjectVersion);
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);
 const npmLogin = makeNpmLoginService(regClient);
 const resolveRemovePackumentVersion =
@@ -110,6 +111,7 @@ const addCmd = makeAddCmd(
   resolveDependencies,
   loadProjectManifest,
   writeProjectManifest,
+  determineEditorVersion,
   log,
   debugLog
 );

--- a/src/services/determine-editor-version.ts
+++ b/src/services/determine-editor-version.ts
@@ -1,0 +1,41 @@
+import { AsyncResult } from "ts-results-es";
+import {
+  isRelease,
+  ReleaseVersion,
+  tryParseEditorVersion,
+} from "../domain/editor-version";
+import {
+  LoadProjectVersion,
+  ProjectVersionLoadError,
+} from "../io/project-version-io";
+
+/**
+ * Error which may occur when determining the editor-version.
+ */
+export type DetermineEditorVersionError = ProjectVersionLoadError;
+
+/**
+ * Function for determining the editor-version for a Unity project.
+ * @param projectPath The path to the projects root directory.
+ * @returns The editor-version. Either a parsed version object or the raw
+ * version string if it could not be parsed.
+ */
+export type DetermineEditorVersion = (
+  projectPath: string
+) => AsyncResult<ReleaseVersion | string, DetermineEditorVersionError>;
+
+/**
+ * Makes a {@link DetermineEditorVersion} function.
+ */
+export function makeEditorVersionDeterminer(
+  loadProjectVersion: LoadProjectVersion
+): DetermineEditorVersion {
+  return (projectPath) => {
+    return loadProjectVersion(projectPath).map((unparsedEditorVersion) => {
+      const parsedEditorVersion = tryParseEditorVersion(unparsedEditorVersion);
+      return parsedEditorVersion !== null && isRelease(parsedEditorVersion)
+        ? parsedEditorVersion
+        : unparsedEditorVersion;
+    });
+  };
+}

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -10,7 +10,6 @@ import { LoginService } from "../../src/services/login";
 import { makeMockLogger } from "./log.mock";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { makeEditorVersion } from "../../src/domain/editor-version";
 import { AuthenticationError } from "../../src/services/npm-login";
 import { GenericIOError } from "../../src/io/common-errors";
 
@@ -19,7 +18,6 @@ const defaultEnv = {
   upstream: true,
   registry: { url: exampleRegistryUrl, auth: null },
   upstreamRegistry: { url: unityRegistryUrl, auth: null },
-  editorVersion: makeEditorVersion(2022, 2, 1, "f", 2),
 } as Env;
 const exampleUser = "user";
 const examplePassword = "pass";

--- a/test/services/determine-editor-version.test.ts
+++ b/test/services/determine-editor-version.test.ts
@@ -1,0 +1,60 @@
+import { makeEditorVersionDeterminer } from "../../src/services/determine-editor-version";
+import { mockService } from "./service.mock";
+import { LoadProjectVersion } from "../../src/io/project-version-io";
+import { makeEditorVersion } from "../../src/domain/editor-version";
+import { mockProjectVersion } from "../io/project-version-io.mock";
+import { GenericIOError } from "../../src/io/common-errors";
+import { Err } from "ts-results-es";
+
+describe("determine editor version", () => {
+  const exampleProjectPath = "/home/my-project/";
+
+  function makeDependencies() {
+    const loadProjectVersion = mockService<LoadProjectVersion>();
+
+    const determineEditorVersion =
+      makeEditorVersionDeterminer(loadProjectVersion);
+    return { determineEditorVersion, loadProjectVersion } as const;
+  }
+
+  it("should be parsed object for valid release versions", async () => {
+    const { determineEditorVersion, loadProjectVersion } = makeDependencies();
+    mockProjectVersion(loadProjectVersion, "2021.3.1f1");
+
+    const result = await determineEditorVersion(exampleProjectPath).promise;
+
+    expect(result).toBeOk((version) =>
+      expect(version).toEqual(makeEditorVersion(2021, 3, 1, "f", 1))
+    );
+  });
+
+  it("should be original string for non-release versions", async () => {
+    const { determineEditorVersion, loadProjectVersion } = makeDependencies();
+    const expected = "2022.3";
+    mockProjectVersion(loadProjectVersion, expected);
+
+    const result = await determineEditorVersion(exampleProjectPath).promise;
+
+    expect(result).toBeOk((version) => expect(version).toEqual(expected));
+  });
+
+  it("should be original string for non-version string", async () => {
+    const { determineEditorVersion, loadProjectVersion } = makeDependencies();
+    const expected = "Bad version";
+    mockProjectVersion(loadProjectVersion, expected);
+
+    const result = await determineEditorVersion(exampleProjectPath).promise;
+
+    expect(result).toBeOk((version) => expect(version).toEqual(expected));
+  });
+
+  it("should fail if ProjectVersion.txt could not be loaded", async () => {
+    const { determineEditorVersion, loadProjectVersion } = makeDependencies();
+    const expected = new GenericIOError();
+    loadProjectVersion.mockReturnValue(Err(expected).toAsyncResult());
+
+    const result = await determineEditorVersion(exampleProjectPath).promise;
+
+    expect(result).toBeError((error) => expect(error).toEqual(expected));
+  });
+});


### PR DESCRIPTION
Currently we always parse the projects editor version so that we can put it into the env object. But we only use the editor-version inside the add command. So there is no reason to load it for example for the search command.

This change extracts the logic for determining a projects editor-version into its own service which is now used by the add command. This way users can now use other commands outside of unity projects.