### PR TITLE
feat: improve error messages

### DIFF
--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -62,9 +62,10 @@ export function makeDepsCmd(
 
     const [name, version] = splitPackageReference(pkg);
 
-    if (version !== undefined && isPackageUrl(version))
-      // TODO: Convert to result
-      throw new Error("Cannot get dependencies for url-version");
+    if (version !== undefined && isPackageUrl(version)) {
+      log.error("", "cannot get dependencies for url-version");
+      return ResultCodes.Error;
+    }
 
     const deep = options.deep || false;
     debugLog(`fetch: ${makePackageReference(name, version)}, deep=${deep}`);

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -12,9 +12,12 @@ import { ResolveDependenciesService } from "../services/dependency-resolving";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
 import { VersionNotFoundError } from "../domain/packument";
-import { logEnvParseError, logPackumentResolveError } from "./error-logging";
 import { DebugLog } from "../logging";
 import { ResultCodes } from "./result-codes";
+import {
+  notifyEnvParsingFailed,
+  notifyRemotePackumentVersionResolvingFailed,
+} from "./error-logging";
 
 export type DepsOptions = CmdOptions<{
   deep?: boolean;
@@ -55,7 +58,7 @@ export function makeDepsCmd(
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
-      logEnvParseError(log, envResult.error);
+      notifyEnvParsingFailed(log, envResult.error);
       return ResultCodes.Error;
     }
     const env = envResult.value;
@@ -76,7 +79,11 @@ export function makeDepsCmd(
       deep
     );
     if (resolveResult.isErr()) {
-      logPackumentResolveError(log, name, resolveResult.error);
+      notifyRemotePackumentVersionResolvingFailed(
+        log,
+        name,
+        resolveResult.error
+      );
       return ResultCodes.Error;
     }
 

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -10,9 +10,9 @@ import {
 import { CmdOptions } from "./options";
 import { Logger } from "npmlog";
 import { LoginService } from "../services/login";
-import { logEnvParseError } from "./error-logging";
 import { ResultCodes } from "./result-codes";
 import { RegistryAuthenticationError } from "../io/common-errors";
+import { notifyEnvParsingFailed } from "./error-logging";
 
 /**
  * Options for logging in a user. These come from the CLI.
@@ -51,7 +51,7 @@ export function makeLoginCmd(
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
-      logEnvParseError(log, envResult.error);
+      notifyEnvParsingFailed(log, envResult.error);
       return ResultCodes.Error;
     }
     const env = envResult.value;

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,4 +1,3 @@
-import { AuthenticationError } from "../services/npm-login";
 import { GetUpmConfigPath } from "../io/upm-config-io";
 import { ParseEnvService } from "../services/parse-env";
 import { coerceRegistryUrl } from "../domain/registry-url";
@@ -13,6 +12,7 @@ import { Logger } from "npmlog";
 import { LoginService } from "../services/login";
 import { logEnvParseError } from "./error-logging";
 import { ResultCodes } from "./result-codes";
+import { RegistryAuthenticationError } from "../io/common-errors";
 
 /**
  * Options for logging in a user. These come from the CLI.
@@ -88,11 +88,8 @@ export function makeLoginCmd(
 
     if (loginResult.isErr()) {
       const loginError = loginResult.error;
-      if (loginError instanceof AuthenticationError) {
-        if (loginError.status === 401)
-          log.warn("401", "Incorrect username or password");
-        else log.error(loginError.status.toString(), loginError.message);
-      }
+      if (loginError instanceof RegistryAuthenticationError)
+        log.warn("401", "Incorrect username or password");
 
       // TODO: Log all errors
       return ResultCodes.Error;

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,6 +1,6 @@
 import { AuthenticationError } from "../services/npm-login";
-import { GetUpmConfigPath, GetUpmConfigPathError } from "../io/upm-config-io";
-import { EnvParseError, ParseEnvService } from "../services/parse-env";
+import { GetUpmConfigPath } from "../io/upm-config-io";
+import { ParseEnvService } from "../services/parse-env";
 import { coerceRegistryUrl } from "../domain/registry-url";
 import {
   promptEmail,
@@ -9,23 +9,10 @@ import {
   promptUsername,
 } from "./prompts";
 import { CmdOptions } from "./options";
-import { Ok, Result } from "ts-results-es";
-import { NpmrcLoadError, NpmrcSaveError } from "../io/npmrc-io";
 import { Logger } from "npmlog";
-import { UpmAuthStoreError } from "../services/upm-auth";
 import { LoginService } from "../services/login";
 import { logEnvParseError } from "./error-logging";
-
-/**
- * Errors which may occur when logging in.
- */
-export type LoginError =
-  | EnvParseError
-  | GetUpmConfigPathError
-  | AuthenticationError
-  | NpmrcLoadError
-  | NpmrcSaveError
-  | UpmAuthStoreError;
+import { ResultCodes } from "./result-codes";
 
 /**
  * Options for logging in a user. These come from the CLI.
@@ -41,12 +28,15 @@ export type LoginOptions = CmdOptions<{
 }>;
 
 /**
+ * The possible result codes with which the login command can exit.
+ */
+export type LoginResultCode = ResultCodes.Ok | ResultCodes.Error;
+
+/**
  * Cmd-handler for logging in users.
  * @param options Options for logging in.
  */
-export type LoginCmd = (
-  options: LoginOptions
-) => Promise<Result<void, LoginError>>;
+export type LoginCmd = (options: LoginOptions) => Promise<LoginResultCode>;
 
 /**
  * Makes a {@link LoginCmd} function.
@@ -62,7 +52,7 @@ export function makeLoginCmd(
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
       logEnvParseError(log, envResult.error);
-      return envResult;
+      return ResultCodes.Error;
     }
     const env = envResult.value;
 
@@ -80,7 +70,10 @@ export function makeLoginCmd(
 
     const configPathResult = await getUpmConfigPath(env.wsl, env.systemUser)
       .promise;
-    if (configPathResult.isErr()) return configPathResult;
+    if (configPathResult.isErr()) {
+      // TODO: Log error
+      return ResultCodes.Error;
+    }
     const configPath = configPathResult.value;
 
     const loginResult = await login(
@@ -101,11 +94,12 @@ export function makeLoginCmd(
         else log.error(loginError.status.toString(), loginError.message);
       }
 
-      return loginResult;
+      // TODO: Log all errors
+      return ResultCodes.Error;
     }
 
     log.notice("auth", `you are authenticated as '${username}'`);
     log.notice("config", "saved unity config at " + configPath);
-    return Ok(undefined);
+    return ResultCodes.Ok;
   };
 }

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -24,13 +24,13 @@ import {
   PackageWithVersionError,
   PackumentNotFoundError,
 } from "../common-errors";
-import {
-  logEnvParseError,
-  logManifestLoadError,
-  logManifestSaveError,
-} from "./error-logging";
 import { Logger } from "npmlog";
 import { ResultCodes } from "./result-codes";
+import {
+  notifyEnvParsingFailed,
+  notifyManifestLoadFailed,
+  notifyManifestWriteFailed,
+} from "./error-logging";
 
 /**
  * The possible result codes with which the remove command can exit.
@@ -70,7 +70,7 @@ export function makeRemoveCmd(
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
-      logEnvParseError(log, envResult.error);
+      notifyEnvParsingFailed(log, envResult.error);
       return ResultCodes.Error;
     }
     const env = envResult.value;
@@ -110,7 +110,7 @@ export function makeRemoveCmd(
     // load manifest
     const manifestResult = await loadProjectManifest(env.cwd).promise;
     if (manifestResult.isErr()) {
-      logManifestLoadError(log, manifestResult.error);
+      notifyManifestLoadFailed(log, manifestResult.error);
       return ResultCodes.Error;
     }
     let manifest = manifestResult.value;
@@ -125,7 +125,7 @@ export function makeRemoveCmd(
     // save manifest
     const saveResult = await writeProjectManifest(env.cwd, manifest).promise;
     if (saveResult.isErr()) {
-      logManifestSaveError(log, saveResult.error);
+      notifyManifestWriteFailed(log);
       return ResultCodes.Error;
     }
 

--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -4,9 +4,9 @@ import { CmdOptions } from "./options";
 import { formatAsTable } from "./output-formatting";
 import { Logger } from "npmlog";
 import { SearchPackages } from "../services/search-packages";
-import { logEnvParseError } from "./error-logging";
 import { DebugLog } from "../logging";
 import { ResultCodes } from "./result-codes";
+import { notifyEnvParsingFailed } from "./error-logging";
 
 /**
  * The possible result codes with which the search command can exit.
@@ -38,7 +38,7 @@ export function makeSearchCmd(
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
-      logEnvParseError(log, envResult.error);
+      notifyEnvParsingFailed(log, envResult.error);
       return ResultCodes.Error;
     }
     const env = envResult.value;

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -11,8 +11,8 @@ import { CmdOptions } from "./options";
 import { recordKeys } from "../utils/record-utils";
 import { Logger } from "npmlog";
 import { ResolveRemotePackument } from "../services/resolve-remote-packument";
-import { logEnvParseError } from "./error-logging";
 import { ResultCodes } from "./result-codes";
+import { notifyEnvParsingFailed } from "./error-logging";
 
 export type ViewOptions = CmdOptions;
 
@@ -112,7 +112,7 @@ export function makeViewCmd(
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
-      logEnvParseError(log, envResult.error);
+      notifyEnvParsingFailed(log, envResult.error);
       return ResultCodes.Error;
     }
     const env = envResult.value;

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import assert from "assert";
 import { tryGetLatestVersion, UnityPackument } from "../domain/packument";
-import { EnvParseError, ParseEnvService } from "../services/parse-env";
+import { ParseEnvService } from "../services/parse-env";
 import {
   hasVersion,
   PackageReference,
@@ -9,18 +9,17 @@ import {
 } from "../domain/package-reference";
 import { CmdOptions } from "./options";
 import { recordKeys } from "../utils/record-utils";
-import { Err, Ok, Result } from "ts-results-es";
-import {
-  PackageWithVersionError,
-  PackumentNotFoundError,
-} from "../common-errors";
 import { Logger } from "npmlog";
 import { ResolveRemotePackument } from "../services/resolve-remote-packument";
 import { logEnvParseError } from "./error-logging";
+import { ResultCodes } from "./result-codes";
 
 export type ViewOptions = CmdOptions;
 
-export type ViewError = EnvParseError | PackageWithVersionError;
+/**
+ * The possible result codes with which the view command can exit.
+ */
+export type ViewResultCode = ResultCodes.Ok | ResultCodes.Error;
 
 /**
  * Cmd-handler for viewing package information.
@@ -30,7 +29,7 @@ export type ViewError = EnvParseError | PackageWithVersionError;
 export type ViewCmd = (
   pkg: PackageReference,
   options: ViewOptions
-) => Promise<Result<void, ViewError>>;
+) => Promise<ViewResultCode>;
 
 const printInfo = function (packument: UnityPackument) {
   const versionCount = recordKeys(packument.versions).length;
@@ -114,7 +113,7 @@ export function makeViewCmd(
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
       logEnvParseError(log, envResult.error);
-      return envResult;
+      return ResultCodes.Error;
     }
     const env = envResult.value;
 
@@ -122,7 +121,7 @@ export function makeViewCmd(
     if (hasVersion(pkg)) {
       const [name] = splitPackageReference(pkg);
       log.warn("", `please do not specify a version (Write only '${name}').`);
-      return Err(new PackageWithVersionError());
+      return ResultCodes.Error;
     }
 
     // verify name
@@ -131,15 +130,18 @@ export function makeViewCmd(
       ...(env.upstream ? [env.upstreamRegistry] : []),
     ];
     const resolveResult = await resolveRemotePackument(pkg, sources).promise;
-    if (!resolveResult.isOk()) return resolveResult;
+    if (!resolveResult.isOk()) {
+      // TODO: Print error
+      return ResultCodes.Error;
+    }
 
     const packument = resolveResult.value?.packument ?? null;
     if (packument === null) {
       log.error("404", `package not found: ${pkg}`);
-      return Err(new PackumentNotFoundError());
+      return ResultCodes.Error;
     }
 
     printInfo(packument);
-    return Ok(undefined);
+    return ResultCodes.Ok;
   };
 }

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -1,110 +1,242 @@
-import {
-  ManifestLoadError,
-  ManifestWriteError,
-} from "../io/project-manifest-io";
 import { Logger } from "npmlog";
-import { PackumentVersionResolveError } from "../packument-version-resolving";
-import { FileParseError, PackumentNotFoundError } from "../common-errors";
-import { DomainName } from "../domain/domain-name";
-import { VersionNotFoundError } from "../domain/packument";
 import { EnvParseError } from "../services/parse-env";
 import { NoWslError } from "../io/wsl";
 import { ChildProcessError } from "../utils/process";
 import { RequiredEnvMissingError } from "../io/upm-config-io";
-import { FileMissingError, GenericIOError } from "../io/common-errors";
+import {
+  FileMissingError,
+  GenericIOError,
+  GenericNetworkError,
+  RegistryAuthenticationError,
+} from "../io/common-errors";
 import { StringFormatError } from "../utils/string-parsing";
-import { DetermineEditorVersionError } from "../services/determine-editor-version";
+import { ProjectVersionLoadError } from "../io/project-version-io";
+import { FileParseError, PackumentNotFoundError } from "../common-errors";
+import { DomainName } from "../domain/domain-name";
+import { NoVersionsError, VersionNotFoundError } from "../domain/packument";
+import { SemanticVersion } from "../domain/semantic-version";
+import { EOL } from "node:os";
 import { ResolveRemotePackumentVersionError } from "../services/resolve-remote-packument-version";
+import { ManifestLoadError } from "../io/project-manifest-io";
 
-/**
- * Logs a {@link ManifestLoadError} to the console.
- */
-export function logManifestLoadError(log: Logger, error: ManifestLoadError) {
-  const reason =
-    error instanceof FileMissingError
-      ? `it could not be found at "${error.path}"`
-      : error instanceof GenericIOError
-      ? "a file-system interaction failed"
-      : error instanceof StringFormatError
-      ? "the manifest file did not contain valid json"
-      : "the manifest file did not contain a valid project manifest";
-
-  const prefix = "manifest";
-  const errorMessage = `could not load project manifest because ${reason}.`;
-  log.error(prefix, errorMessage);
-
-  // TODO: Print fix suggestions
+export function suggestCheckingWorkingDirectory(log: Logger) {
+  log.notice("", "Are you in the correct working directory?");
 }
 
-/**
- * Logs a {@link ManifestWriteError} to the console.
- */
-export function logManifestSaveError(log: Logger, error: ManifestWriteError) {
-  const prefix = "manifest";
-  log.error(prefix, "can not write manifest json file");
-  log.error(prefix, error.message);
+export function notifyManifestMissing(log: Logger, filePath: string) {
+  log.error("", `Could not locate your project manifest at "${filePath}".`);
+  suggestCheckingWorkingDirectory(log);
 }
 
-/**
- * Logs a {@link PackumentVersionResolveError} to the console.
- */
-export function logPackumentResolveError(
+export function suggestFixErrorsInProjectManifest(log: Logger) {
+  log.notice(
+    "",
+    "Please fix the errors in your project manifest and try again."
+  );
+}
+
+export function notifySyntacticallyMalformedProjectManifest(log: Logger) {
+  log.error("", "Project manifest file contained json syntax errors.");
+  suggestFixErrorsInProjectManifest(log);
+}
+
+export function notifySemanticallyMalformedProjectManifest(log: Logger) {
+  log.error(
+    "",
+    "Project manifest is valid json but was not of the correct shape."
+  );
+  suggestFixErrorsInProjectManifest(log);
+}
+
+export function notifyManifestLoadFailedBecauseIO(log: Logger) {
+  log.error(
+    "",
+    "Could not load project manifest because of a file-system error."
+  );
+}
+
+export function notifyManifestLoadFailed(
+  log: Logger,
+  error: ManifestLoadError
+) {
+  if (error instanceof FileMissingError) notifyManifestMissing(log, error.path);
+  else if (error instanceof StringFormatError)
+    notifySyntacticallyMalformedProjectManifest(log);
+  else if (error instanceof FileParseError)
+    notifySemanticallyMalformedProjectManifest(log);
+  else if (error instanceof GenericIOError)
+    notifyManifestLoadFailedBecauseIO(log);
+}
+
+export function notifyManifestWriteFailed(log: Logger) {
+  log.error(
+    "",
+    "Could not save project manifest because of a file-system error."
+  );
+}
+
+export function notifyNotUsingWsl(log: Logger) {
+  log.error("", "No wsl detected.");
+  log.notice("", "Please make sure you are actually running openupm in wsl.");
+}
+
+export function notifyChildProcessError(log: Logger) {
+  log.error("", "A child process encountered an error.");
+}
+
+export function notifyMissingEnvForUpmConfigPath(
+  log: Logger,
+  variableNames: string[]
+) {
+  const nameList = variableNames.map((name) => `"${name}"`).join(", ");
+  log.error(
+    "",
+    "Could not determine upm-config path because of missing home environment variables."
+  );
+  log.notice(
+    "",
+    `Please make sure that you set one of the following environment variables: ${nameList}.`
+  );
+}
+
+export function notifySyntacticallyMalformedUpmConfig(log: Logger) {
+  log.error("", "Upm-config file contained toml syntax errors.");
+  log.notice("", "Please fix the errors in your upm-config and try again.");
+}
+
+function notifyUpmConfigLoadFailedBecauseIO(log: Logger) {
+  log.error("", "Could not load upm-config because of a file-system error.");
+}
+
+export function notifyEnvParsingFailed(log: Logger, error: EnvParseError) {
+  if (error instanceof NoWslError) notifyNotUsingWsl(log);
+  else if (error instanceof ChildProcessError) notifyChildProcessError(log);
+  else if (error instanceof RequiredEnvMissingError)
+    notifyMissingEnvForUpmConfigPath(log, error.keyNames);
+  else if (error instanceof GenericIOError)
+    notifyUpmConfigLoadFailedBecauseIO(log);
+  else if (error instanceof StringFormatError)
+    notifySyntacticallyMalformedUpmConfig(log);
+}
+
+export function notifyProjectVersionMissing(log: Logger, filePath: string) {
+  log.error(
+    "",
+    `Could not locate your projects version file (ProjectVersion.txt) at "${filePath}".`
+  );
+  suggestCheckingWorkingDirectory(log);
+}
+
+export function suggestFixErrorsInProjectVersionFile(log: Logger) {
+  log.notice(
+    "",
+    "Please fix the errors in your project version file and try again."
+  );
+}
+
+export function notifySyntacticallyMalformedProjectVersion(log: Logger) {
+  log.error(
+    "",
+    "Project version file (ProjectVersion.txt) file contained yaml syntax errors."
+  );
+  suggestFixErrorsInProjectVersionFile(log);
+}
+
+export function notifySemanticallyMalformedProjectVersion(log: Logger) {
+  log.error(
+    "",
+    "Project version file (ProjectVersion.txt) file is valid yaml but was not of the correct shape."
+  );
+  suggestFixErrorsInProjectVersionFile(log);
+}
+
+export function notifyProjectVersionLoadFailed(
+  log: Logger,
+  error: ProjectVersionLoadError
+) {
+  if (error instanceof FileMissingError)
+    notifyProjectVersionMissing(log, error.path);
+  else if (error instanceof GenericIOError)
+    log.error(
+      "",
+      "Could not load project version file (ProjectVersion.txt) because of a file-system error."
+    );
+  else if (error instanceof StringFormatError)
+    notifySyntacticallyMalformedProjectVersion(log);
+  else if (error instanceof FileParseError)
+    notifySemanticallyMalformedProjectVersion(log);
+}
+
+export function notifyPackumentNotFoundInAnyRegistry(
+  log: Logger,
+  packageName: DomainName
+) {
+  log.error(
+    "",
+    `The package "${packageName}" was not found in any of the provided registries.`
+  );
+  log.notice(
+    "",
+    "Please make sure you have spelled the name and registry urls correctly."
+  );
+}
+
+export function notifyNoVersions(log: Logger, packageName: DomainName) {
+  log.error("", `The package ${packageName} has no versions.`);
+}
+
+export function notifyOfMissingVersion(
+  log: Logger,
+  packageName: DomainName,
+  requestedVersion: SemanticVersion,
+  availableVersions: ReadonlyArray<SemanticVersion>
+) {
+  const versionList = availableVersions
+    .map((version) => `\t- ${version}`)
+    .join(EOL);
+
+  log.error(
+    "",
+    `The package "${packageName}" has no published version "${requestedVersion}".`
+  );
+  log.notice("", `Maybe you meant one of the following:${EOL}${versionList}`);
+}
+
+export function notifyRegistryCallFailedBecauseHttp(log: Logger) {
+  log.error(
+    "",
+    "Could not communicate with registry because of an http error."
+  );
+}
+
+export function notifyRegistryCallFailedBecauseUnauthorized(log: Logger) {
+  log.error(
+    "",
+    "An npm registry rejected your request, because you are unauthorized."
+  );
+  log.notice(
+    "",
+    "Please make sure you are correctly authenticated for the registry."
+  );
+}
+
+export function notifyRemotePackumentVersionResolvingFailed(
   log: Logger,
   packageName: DomainName,
   error: ResolveRemotePackumentVersionError
 ) {
   if (error instanceof PackumentNotFoundError)
-    log.error("404", `package not found: ${packageName}`);
-  else if (error instanceof VersionNotFoundError) {
-    const versionList = [...error.availableVersions].reverse().join(", ");
-    log.warn(
-      "404",
-      `version ${error.requestedVersion} is not a valid choice of: ${versionList}`
+    notifyPackumentNotFoundInAnyRegistry(log, packageName);
+  else if (error instanceof NoVersionsError) notifyNoVersions(log, packageName);
+  else if (error instanceof VersionNotFoundError)
+    notifyOfMissingVersion(
+      log,
+      packageName,
+      error.requestedVersion,
+      error.availableVersions
     );
-  }
-}
-
-/**
- * Logs a {@link EnvParseError} to a logger.
- */
-export function logEnvParseError(log: Logger, error: EnvParseError) {
-  // TODO: Formulate more specific error messages.
-  const reason =
-    error instanceof NoWslError
-      ? "you attempted to use wsl even though you are not running openupm inside wsl"
-      : error instanceof GenericIOError
-      ? `a file-system interaction failed`
-      : error instanceof ChildProcessError
-      ? "a required child process failed"
-      : error instanceof RequiredEnvMissingError
-      ? `none of the following environment variables were set: ${error.keyNames.join(
-          ", "
-        )}`
-      : `a string was malformed. Expected to be ${error.formatName}`;
-  const errorMessage = `environment information could not be parsed because ${reason}.`;
-  log.error("", errorMessage);
-
-  // TODO: Suggest actions user might take in order to fix the problem.
-}
-
-/**
- * Logs a {@link DetermineEditorVersionError} to a logger.
- */
-export function logDetermineEditorError(
-  log: Logger,
-  error: DetermineEditorVersionError
-) {
-  const reason =
-    error instanceof FileMissingError
-      ? `the projects version file (ProjectVersion.txt) could not be found at "${error.path}"`
-      : error instanceof GenericIOError
-      ? `a file-system interaction failed`
-      : error instanceof FileParseError
-      ? `the project version file (ProjectVersion.txt) has an invalid structure`
-      : `the project versions file (ProjectVersion.txt) did not contain valid yaml`;
-
-  const errorMessage = `editor version could be determined because ${reason}.`;
-  log.error("", errorMessage);
-
-  // TODO: Suggest actions user might take in order to fix the problem.
+  else if (error instanceof GenericNetworkError)
+    notifyRegistryCallFailedBecauseHttp(log);
+  else if (error instanceof RegistryAuthenticationError)
+    notifyRegistryCallFailedBecauseUnauthorized(log);
 }

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -29,7 +29,7 @@ export function logManifestLoadError(log: Logger, error: ManifestLoadError) {
       : "the manifest file did not contain a valid project manifest";
 
   const prefix = "manifest";
-  const errorMessage = `Could not load project manifest because ${reason}.`;
+  const errorMessage = `could not load project manifest because ${reason}.`;
   log.error(prefix, errorMessage);
 
   // TODO: Print fix suggestions

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -14,6 +14,7 @@ import { RequiredEnvMissingError } from "../io/upm-config-io";
 import { FileMissingError, GenericIOError } from "../io/common-errors";
 import { StringFormatError } from "../utils/string-parsing";
 import { DetermineEditorVersionError } from "../services/determine-editor-version";
+import { ResolveRemotePackumentVersionError } from "../services/resolve-remote-packument-version";
 
 /**
  * Logs a {@link ManifestLoadError} to the console.
@@ -50,7 +51,7 @@ export function logManifestSaveError(log: Logger, error: ManifestWriteError) {
 export function logPackumentResolveError(
   log: Logger,
   packageName: DomainName,
-  error: PackumentVersionResolveError
+  error: ResolveRemotePackumentVersionError
 ) {
   if (error instanceof PackumentNotFoundError)
     log.error("404", `package not found: ${packageName}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -73,8 +73,8 @@ const loadNpmrc = makeNpmrcLoader(readFile);
 const saveNpmrc = makeNpmrcSaver(writeFile);
 const loadProjectVersion = makeProjectVersionLoader(readFile);
 const fetchPackument = makePackumentFetcher(regClient);
-const fetchAllPackuments = makeAllPackumentsFetcher();
-const searchRegistry = makeRegistrySearcher();
+const fetchAllPackuments = makeAllPackumentsFetcher(debugLog);
+const searchRegistry = makeRegistrySearcher(debugLog);
 const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
 
 const parseEnv = makeParseEnvService(
@@ -85,7 +85,7 @@ const parseEnv = makeParseEnvService(
 );
 const determineEditorVersion = makeEditorVersionDeterminer(loadProjectVersion);
 const authNpmrc = makeAuthNpmrcService(findNpmrcPath, loadNpmrc, saveNpmrc);
-const npmLogin = makeNpmLoginService(regClient);
+const npmLogin = makeNpmLoginService(regClient, debugLog);
 const resolveRemovePackumentVersion =
   makeResolveRemotePackumentVersionService(fetchPackument);
 const resolveLatestVersion = makeResolveLatestVersionService(fetchPackument);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -230,8 +230,8 @@ openupm deps <pkg>
 openupm deps <pkg>@<version>`
   )
   .action(async function (pkg, options) {
-    const depsResult = await depsCmd(pkg, makeCmdOptions(options));
-    if (depsResult.isErr()) process.exit(1);
+    const resultCode = await depsCmd(pkg, makeCmdOptions(options));
+    process.exit(resultCode);
   });
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -215,8 +215,8 @@ program
   .aliases(["v", "info", "show"])
   .description("view package information")
   .action(async function (pkg, options) {
-    const result = await viewCmd(pkg, makeCmdOptions(options));
-    if (result.isErr()) process.exit(1);
+    const resultCode = await viewCmd(pkg, makeCmdOptions(options));
+    process.exit(resultCode);
   });
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -247,8 +247,8 @@ program
   )
   .description("authenticate with a scoped registry")
   .action(async function (options) {
-    const loginResult = await loginCmd(makeCmdOptions(options));
-    if (loginResult.isErr()) process.exit(1);
+    const resultCode = await loginCmd(makeCmdOptions(options));
+    process.exit(resultCode);
   });
 
 // prompt for invalid command

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -195,8 +195,8 @@ program
   .description("remove package from manifest json")
   .action(async function (pkg, otherPkgs, options) {
     const pkgs = [pkg].concat(otherPkgs);
-    const removeResult = await removeCmd(pkgs, makeCmdOptions(options));
-    if (removeResult.isErr()) process.exit(1);
+    const resultCode = await removeCmd(pkgs, makeCmdOptions(options));
+    process.exit(resultCode);
   });
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -179,8 +179,8 @@ openupm add <pkg>@<version> [otherPkgs...]`
   )
   .action(async function (pkg, otherPkgs, options) {
     const pkgs = [pkg].concat(otherPkgs);
-    const addResult = await addCmd(pkgs, makeCmdOptions(options));
-    if (addResult.isErr()) process.exit(1);
+    const resultCode = await addCmd(pkgs, makeCmdOptions(options));
+    process.exit(resultCode);
   });
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -205,8 +205,8 @@ program
   .aliases(["s", "se", "find"])
   .description("Search package by keyword")
   .action(async function (keyword, options) {
-    const searchResult = await searchCmd(keyword, makeCmdOptions(options));
-    if (searchResult.isErr()) process.exit(1);
+    const resultCode = await searchCmd(keyword, makeCmdOptions(options));
+    process.exit(resultCode);
   });
 
 program

--- a/src/cli/result-codes.ts
+++ b/src/cli/result-codes.ts
@@ -1,0 +1,14 @@
+/**
+ * The set of all result-codes with which openupm can exit.
+ */
+export enum ResultCodes {
+  // TODO: Add more differentiated error codes
+  /**
+   * The operation completed successfully.
+   */
+  Ok = 0,
+  /**
+   * The operation failed.
+   */
+  Error = 1,
+}

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -5,6 +5,8 @@ import { EditorVersion } from "./domain/editor-version";
  * Error for when the packument was not found.
  */
 export class PackumentNotFoundError extends CustomError {
+  // noinspection JSUnusedLocalSymbols
+  private readonly _class = "PackumentNotFoundError";
   constructor() {
     super("A packument was not found.");
   }
@@ -16,6 +18,8 @@ export class PackumentNotFoundError extends CustomError {
  * "com.my-package@1.2.3".
  */
 export class PackageWithVersionError extends CustomError {
+  // noinspection JSUnusedLocalSymbols
+  private readonly _class = "PackageWithVersionError";
   constructor() {
     super(
       "A package-reference including a version was specified when only a name was expected."
@@ -27,6 +31,8 @@ export class PackageWithVersionError extends CustomError {
  * Error for when a file could not be parsed into a specific target type.
  */
 export class FileParseError<const TTarget extends string> extends CustomError {
+  // noinspection JSUnusedLocalSymbols
+  private readonly _class = "FileParseError";
   constructor(
     /**
      * The path to the file that could not be parsed.

--- a/src/io/all-packuments-io.ts
+++ b/src/io/all-packuments-io.ts
@@ -4,7 +4,11 @@ import npmFetch from "npm-registry-fetch";
 import { assertIsHttpError } from "../utils/error-type-guards";
 import { getNpmFetchOptions, SearchedPackument } from "./npm-search";
 import { DomainName } from "../domain/domain-name";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+import {
+  GenericNetworkError,
+  RegistryAuthenticationError,
+} from "./common-errors";
+import { DebugLog } from "../logging";
 
 /**
  * The result of querying the /-/all endpoint.
@@ -15,17 +19,26 @@ export type AllPackuments = Readonly<{
 }>;
 
 /**
+ * Error for when the request to get all packuments failed.
+ */
+export type FetchAllPackumentsError =
+  | GenericNetworkError
+  | RegistryAuthenticationError;
+
+/**
  * Function for getting fetching packuments from a npm registry.
  * @param registry The registry to get packuments for.
  */
 export type FetchAllPackuments = (
   registry: Registry
-) => AsyncResult<AllPackuments, HttpErrorBase>;
+) => AsyncResult<AllPackuments, FetchAllPackumentsError>;
 
 /**
  * Makes a {@link FetchAllPackuments} function.
  */
-export function makeAllPackumentsFetcher(): FetchAllPackuments {
+export function makeAllPackumentsFetcher(
+  debugLog: DebugLog
+): FetchAllPackuments {
   return (registry) => {
     return new AsyncResult(
       npmFetch
@@ -33,7 +46,12 @@ export function makeAllPackumentsFetcher(): FetchAllPackuments {
         .then((result) => Ok(result as AllPackuments))
         .catch((error) => {
           assertIsHttpError(error);
-          return Err(error);
+          debugLog("A http request failed.", error);
+          return Err(
+            error.statusCode === 401
+              ? new RegistryAuthenticationError()
+              : new GenericNetworkError()
+          );
         })
     );
   };

--- a/src/io/common-errors.ts
+++ b/src/io/common-errors.ts
@@ -29,3 +29,21 @@ export class FileMissingError<const TName extends string> extends CustomError {
     super();
   }
 }
+
+/**
+ * Generic error for when some non-specific network operation failed.
+ */
+export class GenericNetworkError extends CustomError {
+  private readonly _class = "GenericNetworkError";
+}
+
+/**
+ * Error for when authentication with a registry failed.
+ */
+export class RegistryAuthenticationError extends CustomError {
+  private readonly _class = "RegistryAuthenticationError";
+
+  constructor() {
+    super();
+  }
+}

--- a/src/packument-version-resolving.ts
+++ b/src/packument-version-resolving.ts
@@ -12,6 +12,7 @@ import { PackumentCache, tryGetFromCache } from "./packument-cache";
 import { RegistryUrl } from "./domain/registry-url";
 import { Err, Result } from "ts-results-es";
 import { PackumentNotFoundError } from "./common-errors";
+import { ResolveRemotePackumentVersionError } from "./services/resolve-remote-packument-version";
 
 /**
  * A version-reference that is resolvable.
@@ -79,9 +80,9 @@ export function tryResolveFromCache(
  * @returns The more fixable failure.
  */
 export function pickMostFixable(
-  a: Err<PackumentVersionResolveError>,
-  b: Err<PackumentVersionResolveError>
-): Err<PackumentVersionResolveError> {
+  a: Err<ResolveRemotePackumentVersionError>,
+  b: Err<ResolveRemotePackumentVersionError>
+): Err<ResolveRemotePackumentVersionError> {
   // Anything is more fixable than packument-not-found
   if (
     a.error instanceof PackumentNotFoundError &&

--- a/src/services/search-packages.ts
+++ b/src/services/search-packages.ts
@@ -1,13 +1,21 @@
 import { Registry } from "../domain/registry";
 import { AsyncResult } from "ts-results-es";
 import { SearchedPackument, SearchRegistry } from "../io/npm-search";
-import { FetchAllPackuments } from "../io/all-packuments-io";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+import {
+  FetchAllPackuments,
+  FetchAllPackumentsError,
+} from "../io/all-packuments-io";
+import {
+  GenericNetworkError,
+  RegistryAuthenticationError,
+} from "../io/common-errors";
 
 /**
  * Error which may occur when searching for packages.
  */
-export type SearchPackagesError = HttpErrorBase;
+export type SearchPackagesError =
+  | RegistryAuthenticationError
+  | GenericNetworkError;
 
 /**
  * A function for searching packages in a registry.
@@ -32,7 +40,7 @@ export function makePackagesSearcher(
   function searchInAll(
     registry: Registry,
     keyword: string
-  ): AsyncResult<SearchedPackument[], HttpErrorBase> {
+  ): AsyncResult<SearchedPackument[], FetchAllPackumentsError> {
     return fetchAllPackuments(registry).map((allPackuments) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { _updated, ...packumentEntries } = allPackuments;

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -188,7 +188,7 @@ describe("cmd-add", () => {
 
     await addCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike(
+    expect(log.error).toHaveBeenCalledWith(
       expect.any(String),
       expect.stringContaining("could not load project manifest")
     );
@@ -209,7 +209,7 @@ describe("cmd-add", () => {
 
     await addCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike(
+    expect(log.error).toHaveBeenCalledWith(
       "404",
       expect.stringContaining("not found")
     );
@@ -235,7 +235,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "404",
       expect.stringContaining("is not a valid choice")
     );
@@ -249,7 +249,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "editor.version",
       expect.stringContaining("unknown")
     );
@@ -266,7 +266,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "package.unity",
       expect.stringContaining("not valid")
     );
@@ -283,7 +283,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "suggest",
       expect.stringContaining("run with option -f")
     );
@@ -329,7 +329,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "editor.version",
       expect.stringContaining("requires")
     );
@@ -346,7 +346,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "suggest",
       expect.stringContaining("run with option -f")
     );
@@ -400,7 +400,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "404",
       expect.stringContaining("is not a valid choice")
     );
@@ -440,7 +440,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "suggest",
       expect.stringContaining("manually")
     );
@@ -465,7 +465,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.error).toHaveLogLike(
+    expect(log.error).toHaveBeenCalledWith(
       "missing dependencies",
       expect.stringContaining("run with option -f")
     );
@@ -538,7 +538,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "manifest",
       expect.stringContaining("added")
     );
@@ -579,7 +579,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "manifest",
       expect.stringContaining("modified")
     );
@@ -598,7 +598,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "manifest",
       expect.stringContaining("existed")
     );
@@ -680,7 +680,7 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike("", expect.stringContaining("open Unity"));
+    expect(log.notice).toHaveBeenCalledWith("", expect.stringContaining("open Unity"));
   });
 
   it("should fail if manifest could not be saved", async () => {
@@ -699,6 +699,6 @@ describe("cmd-add", () => {
 
     await addCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike("manifest", expect.stringContaining(""));
+    expect(log.error).toHaveBeenCalledWith("manifest", expect.stringContaining(""));
   });
 });

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -144,7 +144,7 @@ describe("cmd-add", () => {
 
     expect(log.error).toHaveBeenCalledWith(
       expect.any(String),
-      expect.stringContaining("environment information could not be parsed")
+      expect.stringContaining("file-system error")
     );
   });
 
@@ -169,7 +169,7 @@ describe("cmd-add", () => {
 
     expect(log.error).toHaveBeenCalledWith(
       expect.any(String),
-      expect.stringContaining("editor version could be determined")
+      expect.stringContaining("file-system error")
     );
   });
 
@@ -190,7 +190,7 @@ describe("cmd-add", () => {
 
     expect(log.error).toHaveBeenCalledWith(
       expect.any(String),
-      expect.stringContaining("could not load project manifest")
+      expect.stringContaining("Could not locate")
     );
   });
 
@@ -210,7 +210,7 @@ describe("cmd-add", () => {
     await addCmd(somePackage, { _global: {} });
 
     expect(log.error).toHaveBeenCalledWith(
-      "404",
+      expect.any(String),
       expect.stringContaining("not found")
     );
   });
@@ -235,9 +235,9 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
-      "404",
-      expect.stringContaining("is not a valid choice")
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("has no published version")
     );
   });
 
@@ -400,9 +400,9 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
-      "404",
-      expect.stringContaining("is not a valid choice")
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("has no published version")
     );
   });
 
@@ -680,7 +680,10 @@ describe("cmd-add", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveBeenCalledWith("", expect.stringContaining("open Unity"));
+    expect(log.notice).toHaveBeenCalledWith(
+      "",
+      expect.stringContaining("open Unity")
+    );
   });
 
   it("should fail if manifest could not be saved", async () => {
@@ -699,6 +702,9 @@ describe("cmd-add", () => {
 
     await addCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveBeenCalledWith("manifest", expect.stringContaining(""));
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("file-system error")
+    );
   });
 });

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -13,7 +13,7 @@ import { mockService } from "../services/service.mock";
 import { VersionNotFoundError } from "../../src/domain/packument";
 import { noopLogger } from "../../src/logging";
 import { GenericIOError } from "../../src/io/common-errors";
-import {ResultCodes} from "../../src/cli/result-codes";
+import { ResultCodes } from "../../src/cli/result-codes";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -60,9 +60,9 @@ describe("cmd-deps", () => {
     const { depsCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
-    const result = await depsCmd(somePackage, { _global: {} });
+    const resultCode = await depsCmd(somePackage, { _global: {} });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should fail if package-reference has url-version", async () => {

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -13,6 +13,7 @@ import { mockService } from "../services/service.mock";
 import { VersionNotFoundError } from "../../src/domain/packument";
 import { noopLogger } from "../../src/logging";
 import { GenericIOError } from "../../src/io/common-errors";
+import {ResultCodes} from "../../src/cli/result-codes";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -61,7 +62,7 @@ describe("cmd-deps", () => {
 
     const result = await depsCmd(somePackage, { _global: {} });
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should fail if package-reference has url-version", async () => {

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -68,16 +68,30 @@ describe("cmd-deps", () => {
   it("should fail if package-reference has url-version", async () => {
     const { depsCmd } = makeDependencies();
 
-    const operation = depsCmd(
+    const resultCode = await depsCmd(
       makePackageReference(somePackage, "https://some.registry.com"),
       {
         _global: {},
       }
     );
 
-    await expect(operation).rejects.toMatchObject({
-      message: "Cannot get dependencies for url-version",
-    });
+    expect(resultCode).toEqual(ResultCodes.Error);
+  });
+
+  it("should notify if package-reference has url-version", async () => {
+    const { depsCmd, log } = makeDependencies();
+
+    await depsCmd(
+      makePackageReference(somePackage, "https://some.registry.com"),
+      {
+        _global: {},
+      }
+    );
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("url-version")
+    );
   });
 
   it("should log valid dependencies", async () => {

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -101,7 +101,7 @@ describe("cmd-deps", () => {
       _global: {},
     });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "dependency",
       expect.stringContaining(otherPackage)
     );
@@ -126,7 +126,7 @@ describe("cmd-deps", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "missing dependency",
       expect.stringContaining(otherPackage)
     );
@@ -151,7 +151,7 @@ describe("cmd-deps", () => {
       _global: {},
     });
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "missing dependency version",
       expect.stringContaining(otherPackage)
     );

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -12,6 +12,7 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { AuthenticationError } from "../../src/services/npm-login";
 import { GenericIOError } from "../../src/io/common-errors";
+import { ResultCodes } from "../../src/cli/result-codes";
 
 const defaultEnv = {
   cwd: "/users/some-user/projects/SomeProject",
@@ -48,7 +49,7 @@ describe("cmd-login", () => {
 
     const result = await loginCmd({ _global: {} });
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   // TODO: Add tests for prompting logic
@@ -65,7 +66,7 @@ describe("cmd-login", () => {
       _global: { registry: exampleRegistryUrl },
     });
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should fail if login failed", async () => {
@@ -80,7 +81,7 @@ describe("cmd-login", () => {
       _global: { registry: exampleRegistryUrl },
     });
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should notify if unauthorized", async () => {

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -10,8 +10,10 @@ import { LoginService } from "../../src/services/login";
 import { makeMockLogger } from "./log.mock";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { AuthenticationError } from "../../src/services/npm-login";
-import { GenericIOError } from "../../src/io/common-errors";
+import {
+  GenericIOError,
+  RegistryAuthenticationError,
+} from "../../src/io/common-errors";
 import { ResultCodes } from "../../src/cli/result-codes";
 
 const defaultEnv = {
@@ -87,7 +89,7 @@ describe("cmd-login", () => {
   it("should notify if unauthorized", async () => {
     const { loginCmd, login, log } = makeDependencies();
     login.mockReturnValue(
-      Err(new AuthenticationError(401, "oof")).toAsyncResult()
+      Err(new RegistryAuthenticationError()).toAsyncResult()
     );
 
     await loginCmd({
@@ -101,22 +103,6 @@ describe("cmd-login", () => {
       "401",
       "Incorrect username or password"
     );
-  });
-
-  it("should notify of other login errors", async () => {
-    const { loginCmd, login, log } = makeDependencies();
-    login.mockReturnValue(
-      Err(new AuthenticationError(500, "oof")).toAsyncResult()
-    );
-
-    await loginCmd({
-      username: exampleUser,
-      password: examplePassword,
-      email: exampleEmail,
-      _global: { registry: exampleRegistryUrl },
-    });
-
-    expect(log.error).toHaveBeenCalledWith("500", "oof");
   });
 
   it("should notify of success", async () => {

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -47,9 +47,9 @@ describe("cmd-login", () => {
     const { loginCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
-    const result = await loginCmd({ _global: {} });
+    const resultCode = await loginCmd({ _global: {} });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   // TODO: Add tests for prompting logic
@@ -59,14 +59,14 @@ describe("cmd-login", () => {
     const { loginCmd, getUpmConfigPath } = makeDependencies();
     getUpmConfigPath.mockReturnValue(Err(expected).toAsyncResult());
 
-    const result = await loginCmd({
+    const resultCode = await loginCmd({
       username: exampleUser,
       password: examplePassword,
       email: exampleEmail,
       _global: { registry: exampleRegistryUrl },
     });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should fail if login failed", async () => {
@@ -74,14 +74,14 @@ describe("cmd-login", () => {
     const { loginCmd, login } = makeDependencies();
     login.mockReturnValue(Err(expected).toAsyncResult());
 
-    const result = await loginCmd({
+    const resultCode = await loginCmd({
       username: exampleUser,
       password: examplePassword,
       email: exampleEmail,
       _global: { registry: exampleRegistryUrl },
     });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should notify if unauthorized", async () => {

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -62,18 +62,18 @@ describe("cmd-remove", () => {
     const { removeCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
-    const result = await removeCmd(somePackage, { _global: {} });
+    const resultCode = await removeCmd(somePackage, { _global: {} });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should fail if manifest could not be loaded", async () => {
     const { removeCmd, loadProjectManifest } = makeDependencies();
     mockProjectManifest(loadProjectManifest, null);
 
-    const result = await removeCmd(somePackage, { _global: {} });
+    const resultCode = await removeCmd(somePackage, { _global: {} });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should notify if manifest could not be loaded", async () => {
@@ -88,12 +88,12 @@ describe("cmd-remove", () => {
   it("should fail if package version was specified", async () => {
     const { removeCmd } = makeDependencies();
 
-    const result = await removeCmd(
+    const resultCode = await removeCmd(
       makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
       { _global: {} }
     );
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should notify if package version was specified", async () => {
@@ -113,9 +113,9 @@ describe("cmd-remove", () => {
   it("should fail if package is not in manifest", async () => {
     const { removeCmd } = makeDependencies();
 
-    const result = await removeCmd(otherPackage, { _global: {} });
+    const resultCode = await removeCmd(otherPackage, { _global: {} });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should notify if package is not in manifest", async () => {
@@ -182,9 +182,9 @@ describe("cmd-remove", () => {
     const { removeCmd, writeProjectManifest } = makeDependencies();
     mockProjectManifestWriteResult(writeProjectManifest, expected);
 
-    const result = await removeCmd(somePackage, { _global: {} });
+    const resultCode = await removeCmd(somePackage, { _global: {} });
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should notify if manifest could not be saved", async () => {

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -82,7 +82,7 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike("manifest", expect.any(String));
+    expect(log.error).toHaveBeenCalledWith("manifest", expect.any(String));
   });
 
   it("should fail if package version was specified", async () => {
@@ -104,7 +104,7 @@ describe("cmd-remove", () => {
       { _global: {} }
     );
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "",
       expect.stringContaining("please do not specify")
     );
@@ -123,7 +123,7 @@ describe("cmd-remove", () => {
 
     await removeCmd(otherPackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike(
+    expect(log.error).toHaveBeenCalledWith(
       "404",
       expect.stringContaining("not found")
     );
@@ -134,7 +134,7 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "manifest",
       expect.stringContaining("removed")
     );
@@ -193,7 +193,7 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike("manifest", expect.stringContaining(""));
+    expect(log.error).toHaveBeenCalledWith("manifest", expect.stringContaining(""));
   });
 
   it("should suggest to open Unity after save", async () => {
@@ -201,6 +201,6 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.notice).toHaveLogLike("", expect.stringContaining("open Unity"));
+    expect(log.notice).toHaveBeenCalledWith("", expect.stringContaining("open Unity"));
   });
 });

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -82,7 +82,10 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveBeenCalledWith("manifest", expect.any(String));
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("Could not locate")
+    );
   });
 
   it("should fail if package version was specified", async () => {
@@ -193,7 +196,10 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveBeenCalledWith("manifest", expect.stringContaining(""));
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("file-system error")
+    );
   });
 
   it("should suggest to open Unity after save", async () => {
@@ -201,6 +207,9 @@ describe("cmd-remove", () => {
 
     await removeCmd(somePackage, { _global: {} });
 
-    expect(log.notice).toHaveBeenCalledWith("", expect.stringContaining("open Unity"));
+    expect(log.notice).toHaveBeenCalledWith(
+      "",
+      expect.stringContaining("open Unity")
+    );
   });
 });

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -1,6 +1,6 @@
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
-import { makeRemoveCmd, RemoveError } from "../../src/cli/cmd-remove";
+import { makeRemoveCmd } from "../../src/cli/cmd-remove";
 import { Err, Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import {
@@ -10,17 +10,14 @@ import {
 import { buildProjectManifest } from "../domain/data-project-manifest";
 import { makePackageReference } from "../../src/domain/package-reference";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
-import {
-  PackageWithVersionError,
-  PackumentNotFoundError,
-} from "../../src/common-errors";
 import { makeMockLogger } from "./log.mock";
 import { mockService } from "../services/service.mock";
 import {
   LoadProjectManifest,
   WriteProjectManifest,
 } from "../../src/io/project-manifest-io";
-import { FileMissingError, GenericIOError } from "../../src/io/common-errors";
+import { GenericIOError } from "../../src/io/common-errors";
+import { ResultCodes } from "../../src/cli/result-codes";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -67,7 +64,7 @@ describe("cmd-remove", () => {
 
     const result = await removeCmd(somePackage, { _global: {} });
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should fail if manifest could not be loaded", async () => {
@@ -76,9 +73,7 @@ describe("cmd-remove", () => {
 
     const result = await removeCmd(somePackage, { _global: {} });
 
-    expect(result).toBeError((actual: RemoveError) =>
-      expect(actual).toBeInstanceOf(FileMissingError)
-    );
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should notify if manifest could not be loaded", async () => {
@@ -98,9 +93,7 @@ describe("cmd-remove", () => {
       { _global: {} }
     );
 
-    expect(result).toBeError((actual) =>
-      expect(actual).toBeInstanceOf(PackageWithVersionError)
-    );
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should notify if package version was specified", async () => {
@@ -122,9 +115,7 @@ describe("cmd-remove", () => {
 
     const result = await removeCmd(otherPackage, { _global: {} });
 
-    expect(result).toBeError((actual) =>
-      expect(actual).toBeInstanceOf(PackumentNotFoundError)
-    );
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should notify if package is not in manifest", async () => {
@@ -193,7 +184,7 @@ describe("cmd-remove", () => {
 
     const result = await removeCmd(somePackage, { _global: {} });
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should notify if manifest could not be saved", async () => {

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -66,9 +66,9 @@ describe("cmd-search", () => {
   it("should be ok if no network error occurred", async () => {
     const { searchCmd } = makeDependencies();
 
-    const result = await searchCmd("pkg-not-exist", options);
+    const resultCode = await searchCmd("pkg-not-exist", options);
 
-    expect(result).toEqual(ResultCodes.Ok);
+    expect(resultCode).toEqual(ResultCodes.Ok);
   });
 
   it("should notify of unknown packument", async () => {
@@ -88,9 +88,9 @@ describe("cmd-search", () => {
     const { searchCmd, searchPackages } = makeDependencies();
     searchPackages.mockReturnValue(Err(expected).toAsyncResult());
 
-    const result = await searchCmd("package-a", options);
+    const resultCode = await searchCmd("package-a", options);
 
-    expect(result).toEqual(ResultCodes.Error);
+    expect(resultCode).toEqual(ResultCodes.Error);
   });
 
   it("should notify if packuments could not be searched", async () => {

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -8,9 +8,9 @@ import { Err, Ok } from "ts-results-es";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { noopLogger } from "../../src/logging";
 import { ResultCodes } from "../../src/cli/result-codes";
+import { GenericNetworkError } from "../../src/io/common-errors";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -84,7 +84,7 @@ describe("cmd-search", () => {
   });
 
   it("should fail if packuments could not be searched", async () => {
-    const expected = { statusCode: 500 } as HttpErrorBase;
+    const expected = new GenericNetworkError();
     const { searchCmd, searchPackages } = makeDependencies();
     searchPackages.mockReturnValue(Err(expected).toAsyncResult());
 
@@ -94,7 +94,7 @@ describe("cmd-search", () => {
   });
 
   it("should notify if packuments could not be searched", async () => {
-    const expected = { statusCode: 500 } as HttpErrorBase;
+    const expected = new GenericNetworkError();
     const { searchCmd, searchPackages, log } = makeDependencies();
     searchPackages.mockReturnValue(Err(expected).toAsyncResult());
 

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -77,7 +77,7 @@ describe("cmd-search", () => {
 
     await searchCmd("pkg-not-exist", options);
 
-    expect(log.notice).toHaveLogLike(
+    expect(log.notice).toHaveBeenCalledWith(
       "",
       expect.stringContaining("No matches found")
     );

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -10,6 +10,7 @@ import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { noopLogger } from "../../src/logging";
+import { ResultCodes } from "../../src/cli/result-codes";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -67,7 +68,7 @@ describe("cmd-search", () => {
 
     const result = await searchCmd("pkg-not-exist", options);
 
-    expect(result).toBeOk();
+    expect(result).toEqual(ResultCodes.Ok);
   });
 
   it("should notify of unknown packument", async () => {
@@ -89,7 +90,7 @@ describe("cmd-search", () => {
 
     const result = await searchCmd("package-a", options);
 
-    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+    expect(result).toEqual(ResultCodes.Error);
   });
 
   it("should notify if packuments could not be searched", async () => {

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -10,8 +10,10 @@ import { makeMockLogger } from "./log.mock";
 import { buildPackument } from "../domain/data-packument";
 import { mockService } from "../services/service.mock";
 import { ResolveRemotePackument } from "../../src/services/resolve-remote-packument";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { GenericIOError } from "../../src/io/common-errors";
+import {
+  GenericIOError,
+  GenericNetworkError,
+} from "../../src/io/common-errors";
 import { ResultCodes } from "../../src/cli/result-codes";
 
 const somePackage = makeDomainName("com.some.package");
@@ -112,7 +114,7 @@ describe("cmd-view", () => {
   });
 
   it("should fail if package could not be resolved", async () => {
-    const expected = { statusCode: 500 } as HttpErrorBase;
+    const expected = new GenericNetworkError();
     const { viewCmd, resolveRemotePackument } = makeDependencies();
     resolveRemotePackument.mockReturnValue(Err(expected).toAsyncResult());
 

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -96,7 +96,7 @@ describe("cmd-view", () => {
       { _global: {} }
     );
 
-    expect(log.warn).toHaveLogLike(
+    expect(log.warn).toHaveBeenCalledWith(
       "",
       expect.stringContaining("please do not specify")
     );
@@ -127,7 +127,7 @@ describe("cmd-view", () => {
 
     await viewCmd(somePackage, { _global: {} });
 
-    expect(log.error).toHaveLogLike(
+    expect(log.error).toHaveBeenCalledWith(
       "404",
       expect.stringContaining("not found")
     );

--- a/test/cli/log.mock.ts
+++ b/test/cli/log.mock.ts
@@ -1,45 +1,4 @@
-import { Logger, LogLevels } from "npmlog";
-import AsymmetricMatcher = jest.AsymmetricMatcher;
-
-type LogSpy = jest.MockedFunctionDeep<Logger[LogLevels]>;
-
-expect.extend({
-  toHaveLogLike(
-    spy: LogSpy,
-    prefix: string | AsymmetricMatcher,
-    expected: string | AsymmetricMatcher,
-    count: number = 1
-  ) {
-    const stringMatches = (s: string, expected: string | AsymmetricMatcher) =>
-      typeof expected === "string"
-        ? s === expected
-        : expected.asymmetricMatch(s);
-
-    const calls = spy.mock.calls;
-    const callsWithPrefix = calls.filter(([actualPrefix]) =>
-      stringMatches(actualPrefix, prefix)
-    );
-    const matchingCalls = callsWithPrefix.filter(([, actualMessage]) =>
-      stringMatches(actualMessage, expected)
-    );
-    const hasMatch = matchingCalls.length >= count;
-    return {
-      pass: hasMatch,
-      message: () => `Logs failed expectation
-      Criteria:
-        Prefix: "${prefix}"
-        Message: "${expected}"
-        Min-count: ${count}
-      Issue: ${
-        callsWithPrefix.length === 0
-          ? "No logs had the correct prefix"
-          : matchingCalls.length === 0
-          ? "At least one log had the correct prefix, but none had a matching message"
-          : `There were logs matching the criteria, but not enough (${matchingCalls.length})`
-      }`,
-    };
-  },
-});
+import { Logger } from "npmlog";
 
 /**
  * Creates mock logger.

--- a/test/cli/log.mock.ts
+++ b/test/cli/log.mock.ts
@@ -6,21 +6,21 @@ type LogSpy = jest.MockedFunctionDeep<Logger[LogLevels]>;
 expect.extend({
   toHaveLogLike(
     spy: LogSpy,
-    prefix: string,
+    prefix: string | AsymmetricMatcher,
     expected: string | AsymmetricMatcher,
     count: number = 1
   ) {
-    const matches = (s: string) =>
+    const stringMatches = (s: string, expected: string | AsymmetricMatcher) =>
       typeof expected === "string"
         ? s === expected
         : expected.asymmetricMatch(s);
 
     const calls = spy.mock.calls;
-    const callsWithPrefix = calls.filter(
-      ([actualPrefix]) => actualPrefix === prefix
+    const callsWithPrefix = calls.filter(([actualPrefix]) =>
+      stringMatches(actualPrefix, prefix)
     );
     const matchingCalls = callsWithPrefix.filter(([, actualMessage]) =>
-      matches(actualMessage)
+      stringMatches(actualMessage, expected)
     );
     const hasMatch = matchingCalls.length >= count;
     return {

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -1,15 +1,15 @@
 import { makeLoginService } from "../../src/services/login";
 import { mockService } from "./service.mock";
 import { SaveAuthToUpmConfig } from "../../src/services/upm-auth";
-import {
-  AuthenticationError,
-  NpmLoginService,
-} from "../../src/services/npm-login";
+import { NpmLoginService } from "../../src/services/npm-login";
 import { AuthNpmrcService } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err, Ok } from "ts-results-es";
 import { noopLogger } from "../../src/logging";
-import { GenericIOError } from "../../src/io/common-errors";
+import {
+  RegistryAuthenticationError,
+  GenericIOError,
+} from "../../src/io/common-errors";
 
 const exampleUser = "user";
 const examplePassword = "pass";
@@ -84,7 +84,7 @@ describe("login", () => {
 
   describe("token auth", () => {
     it("should fail if npm login fails", async () => {
-      const expected = new AuthenticationError(401, "uh oh");
+      const expected = new RegistryAuthenticationError();
       const { login, npmLogin } = makeDependencies();
       npmLogin.mockReturnValue(Err(expected).toAsyncResult());
 

--- a/test/services/npm-login.test.ts
+++ b/test/services/npm-login.test.ts
@@ -1,13 +1,11 @@
 import "assert";
-import {
-  makeNpmLoginService,
-} from "../../src/services/npm-login";
+import { makeNpmLoginService } from "../../src/services/npm-login";
 import RegClient from "another-npm-registry-client";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { mockRegClientAddUserResult } from "./registry-client.mock";
-import {RegistryAuthenticationError} from "../../src/io/common-errors";
-import {noopLogger} from "../../src/logging";
+import { RegistryAuthenticationError } from "../../src/io/common-errors";
+import { noopLogger } from "../../src/logging";
 
 function makeDependencies() {
   const registryClient: jest.Mocked<RegClient.Instance> = {

--- a/test/services/npm-login.test.ts
+++ b/test/services/npm-login.test.ts
@@ -1,12 +1,13 @@
 import "assert";
 import {
-  AuthenticationError,
   makeNpmLoginService,
 } from "../../src/services/npm-login";
 import RegClient from "another-npm-registry-client";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { mockRegClientAddUserResult } from "./registry-client.mock";
+import {RegistryAuthenticationError} from "../../src/io/common-errors";
+import {noopLogger} from "../../src/logging";
 
 function makeDependencies() {
   const registryClient: jest.Mocked<RegClient.Instance> = {
@@ -14,7 +15,7 @@ function makeDependencies() {
     get: jest.fn(),
   };
 
-  const addUser = makeNpmLoginService(registryClient);
+  const addUser = makeNpmLoginService(registryClient, noopLogger);
   return { addUser, registryClient } as const;
 }
 
@@ -64,7 +65,7 @@ describe("npm-login service", () => {
     ).promise;
 
     expect(result).toBeError((error) =>
-      expect(error).toBeInstanceOf(AuthenticationError)
+      expect(error).toBeInstanceOf(RegistryAuthenticationError)
     );
   });
 
@@ -88,7 +89,7 @@ describe("npm-login service", () => {
     ).promise;
 
     expect(result).toBeError((error) =>
-      expect(error).toBeInstanceOf(AuthenticationError)
+      expect(error).toBeInstanceOf(RegistryAuthenticationError)
     );
   });
 });

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -370,7 +370,7 @@ describe("env", () => {
         },
       });
 
-      expect(log.warn).toHaveLogLike(
+      expect(log.warn).toHaveBeenCalledWith(
         "env.auth",
         expect.stringContaining("failed to parse auth info")
       );

--- a/test/services/resolve-remote-packument.test.ts
+++ b/test/services/resolve-remote-packument.test.ts
@@ -7,7 +7,7 @@ import { buildPackument } from "../domain/data-packument";
 import { mockService } from "./service.mock";
 import { FetchPackument } from "../../src/io/packument-io";
 import { Err, Ok } from "ts-results-es";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
+import { GenericNetworkError } from "../../src/io/common-errors";
 
 describe("resolve remove packument", () => {
   const exampleName = makeDomainName("com.some.package");
@@ -84,7 +84,7 @@ describe("resolve remove packument", () => {
   });
 
   it("should fail if any packument fetch failed", async () => {
-    const expected = { statusCode: 500 } as HttpErrorBase;
+    const expected = new GenericNetworkError();
     const { resolveRemotePackument, fetchPackument } = makeDependencies();
     fetchPackument.mockReturnValue(Err(expected).toAsyncResult());
 

--- a/test/services/search-packages.test.ts
+++ b/test/services/search-packages.test.ts
@@ -7,10 +7,10 @@ import {
 import { makePackagesSearcher } from "../../src/services/search-packages";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { Err, Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { GenericNetworkError } from "../../src/io/common-errors";
 
 describe("search packages", () => {
   const exampleRegistry: Registry = {
@@ -19,8 +19,6 @@ describe("search packages", () => {
   };
 
   const exampleKeyword = "package-a";
-
-  const exampleHttpError = { statusCode: 500 } as HttpErrorBase;
 
   const exampleSearchResult: SearchedPackument = {
     name: makeDomainName("com.example.package-a"),
@@ -73,7 +71,9 @@ describe("search packages", () => {
 
   it("should search using old search if search api is not available", async () => {
     const { searchPackages, searchRegistry } = makeDependencies();
-    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+    searchRegistry.mockReturnValue(
+      Err(new GenericNetworkError()).toAsyncResult()
+    );
 
     const result = await searchPackages(exampleRegistry, exampleKeyword)
       .promise;
@@ -85,7 +85,9 @@ describe("search packages", () => {
 
   it("should notify of using old search", async () => {
     const { searchPackages, searchRegistry } = makeDependencies();
-    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+    searchRegistry.mockReturnValue(
+      Err(new GenericNetworkError()).toAsyncResult()
+    );
 
     const fallback = jest.fn();
     await searchPackages(exampleRegistry, exampleKeyword, fallback).promise;
@@ -95,7 +97,9 @@ describe("search packages", () => {
 
   it("should not find packages not matching the keyword using old search", async () => {
     const { searchPackages, searchRegistry } = makeDependencies();
-    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+    searchRegistry.mockReturnValue(
+      Err(new GenericNetworkError()).toAsyncResult()
+    );
 
     const result = await searchPackages(exampleRegistry, "some other keyword")
       .promise;
@@ -106,8 +110,12 @@ describe("search packages", () => {
   it("should fail if both search strategies fail", async () => {
     const { searchPackages, searchRegistry, fetchAllPackument } =
       makeDependencies();
-    searchRegistry.mockReturnValue(Err(exampleHttpError).toAsyncResult());
-    fetchAllPackument.mockReturnValue(Err(exampleHttpError).toAsyncResult());
+    searchRegistry.mockReturnValue(
+      Err(new GenericNetworkError()).toAsyncResult()
+    );
+    fetchAllPackument.mockReturnValue(
+      Err(new GenericNetworkError()).toAsyncResult()
+    );
 
     const result = await searchPackages(exampleRegistry, exampleKeyword)
       .promise;

--- a/test/types/jest.d.ts
+++ b/test/types/jest.d.ts
@@ -31,7 +31,7 @@ declare global {
        * should have been logged. Defaults to 1 if omitted.
        */
       toHaveLogLike(
-        prefix: string,
+        prefix: string | AsymmetricMatcher,
         expected: string | AsymmetricMatcher,
         count?: number
       ): R;

--- a/test/types/jest.d.ts
+++ b/test/types/jest.d.ts
@@ -19,22 +19,6 @@ declare global {
       toBeOk<T>(valueAsserter?: (value: T) => void): R;
 
       toBeError<T>(errorAsserter?: (error: T) => void): R;
-
-      // Log
-
-      /**
-       * Tests if a specific log was made to this spy.
-       * @param prefix The prefix. This is matched exactly.
-       * @param expected The expected value. Either an exact string that a log
-       * needs to match or a matcher.
-       * @param count The minimum number of times a message matching the given criteria
-       * should have been logged. Defaults to 1 if omitted.
-       */
-      toHaveLogLike(
-        prefix: string | AsymmetricMatcher,
-        expected: string | AsymmetricMatcher,
-        count?: number
-      ): R;
     }
   }
 }


### PR DESCRIPTION
This PR adds a bunch of new error messages and fix suggestions for the various things that can go wrong when using openupm.

It also makes some improvements to error types. 

Also also cmd functions now simply return a numeric result code that is used for the process exit code. They should log all possible errors before returning.