### PR TITLE
feat: extract remove service

### DIFF
--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -1,24 +1,10 @@
 import {
-  LoadProjectManifest,
   ManifestLoadError,
   ManifestWriteError,
-  WriteProjectManifest,
 } from "../io/project-manifest-io";
 import { EnvParseError, ParseEnvService } from "../services/parse-env";
-import {
-  hasVersion,
-  makePackageReference,
-  PackageReference,
-  splitPackageReference,
-} from "../domain/package-reference";
-import { removeScope } from "../domain/scoped-registry";
-import {
-  mapScopedRegistry,
-  removeDependency,
-  UnityProjectManifest,
-} from "../domain/project-manifest";
+import { makePackageReference } from "../domain/package-reference";
 import { CmdOptions } from "./options";
-import { Err, Ok, Result } from "ts-results-es";
 
 import {
   PackageWithVersionError,
@@ -28,8 +14,6 @@ import { Logger } from "npmlog";
 import { ResultCodes } from "./result-codes";
 import {
   notifyEnvParsingFailed,
-  notifyManifestLoadFailed,
-  notifyManifestWriteFailed,
   notifyPackageRemoveFailed,
 } from "./error-logging";
 import { DomainName } from "../domain/domain-name";

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -30,7 +30,10 @@ import {
   notifyEnvParsingFailed,
   notifyManifestLoadFailed,
   notifyManifestWriteFailed,
+  notifyPackageRemoveFailed,
 } from "./error-logging";
+import { DomainName } from "../domain/domain-name";
+import { RemovePackages } from "../services/remove-packages";
 
 /**
  * The possible result codes with which the remove command can exit.
@@ -48,11 +51,11 @@ export type RemoveOptions = CmdOptions;
 
 /**
  * Cmd-handler for removing packages.
- * @param pkgs One or multiple package-references to remove.
+ * @param pkgs One or multiple packages to remove.
  * @param options Command options.
  */
 export type RemoveCmd = (
-  pkgs: PackageReference[] | PackageReference,
+  pkgs: ReadonlyArray<DomainName>,
   options: RemoveOptions
 ) => Promise<RemoveResultCode>;
 
@@ -61,12 +64,10 @@ export type RemoveCmd = (
  */
 export function makeRemoveCmd(
   parseEnv: ParseEnvService,
-  loadProjectManifest: LoadProjectManifest,
-  writeProjectManifest: WriteProjectManifest,
+  removePackages: RemovePackages,
   log: Logger
 ): RemoveCmd {
   return async (pkgs, options) => {
-    if (!Array.isArray(pkgs)) pkgs = [pkgs];
     // parse env
     const envResult = await parseEnv(options);
     if (envResult.isErr()) {
@@ -75,59 +76,22 @@ export function makeRemoveCmd(
     }
     const env = envResult.value;
 
-    const tryRemoveFromManifest = async function (
-      manifest: UnityProjectManifest,
-      pkg: PackageReference
-    ): Promise<Result<UnityProjectManifest, RemoveError>> {
-      // parse name
-      if (hasVersion(pkg)) {
-        const [name] = splitPackageReference(pkg);
-        log.warn("", `please do not specify a version (Write only '${name}').`);
-        return Err(new PackageWithVersionError());
-      }
+    const removeResult = await removePackages(env.cwd, pkgs).promise;
+    if (removeResult.isErr()) {
+      notifyPackageRemoveFailed(log, removeResult.error);
+      return ResultCodes.Error;
+    }
+    const removedPackages = removeResult.value;
 
-      // not found array
-      const versionInManifest = manifest.dependencies[pkg];
-      if (versionInManifest === undefined) {
-        log.error("404", `package not found: ${pkg}`);
-        return Err(new PackumentNotFoundError());
-      }
-
-      manifest = removeDependency(manifest, pkg);
-
-      manifest = mapScopedRegistry(manifest, env.registry.url, (initial) => {
-        if (initial === null) return null;
-        return removeScope(initial, pkg);
-      });
-
+    removedPackages.forEach((removedPackage) => {
       log.notice(
-        "manifest",
-        `removed ${makePackageReference(pkg, versionInManifest)}`
+        "",
+        `Removed "${makePackageReference(
+          removedPackage.name,
+          removedPackage.version
+        )}".`
       );
-      return Ok(manifest);
-    };
-
-    // load manifest
-    const manifestResult = await loadProjectManifest(env.cwd).promise;
-    if (manifestResult.isErr()) {
-      notifyManifestLoadFailed(log, manifestResult.error);
-      return ResultCodes.Error;
-    }
-    let manifest = manifestResult.value;
-
-    // remove
-    for (const pkg of pkgs) {
-      const result = await tryRemoveFromManifest(manifest, pkg);
-      if (result.isErr()) return ResultCodes.Error;
-      manifest = result.value;
-    }
-
-    // save manifest
-    const saveResult = await writeProjectManifest(env.cwd, manifest).promise;
-    if (saveResult.isErr()) {
-      notifyManifestWriteFailed(log);
-      return ResultCodes.Error;
-    }
+    });
 
     // print manifest notice
     log.notice("", "please open Unity project to apply changes");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,7 @@ import { makeRemotePackumentResolver } from "../services/resolve-remote-packumen
 import { makeLoginService } from "../services/login";
 import { DebugLog } from "../logging";
 import { makeEditorVersionDeterminer } from "../services/determine-editor-version";
+import { makePackageRemover } from "../services/remove-packages";
 
 // Composition root
 
@@ -76,6 +77,10 @@ const fetchPackument = makePackumentFetcher(regClient);
 const fetchAllPackuments = makeAllPackumentsFetcher(debugLog);
 const searchRegistry = makeRegistrySearcher(debugLog);
 const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
+const removePackages = makePackageRemover(
+  loadProjectManifest,
+  writeProjectManifest
+);
 
 const parseEnv = makeParseEnvService(
   log,
@@ -118,12 +123,7 @@ const addCmd = makeAddCmd(
 const loginCmd = makeLoginCmd(parseEnv, getUpmConfigPath, login, log);
 const searchCmd = makeSearchCmd(parseEnv, searchPackages, log, debugLog);
 const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log, debugLog);
-const removeCmd = makeRemoveCmd(
-  parseEnv,
-  loadProjectManifest,
-  writeProjectManifest,
-  log
-);
+const removeCmd = makeRemoveCmd(parseEnv, removePackages, log);
 const viewCmd = makeViewCmd(parseEnv, resolveRemotePackument, log);
 
 // update-notifier
@@ -193,9 +193,9 @@ program
   )
   .aliases(["rm", "uninstall"])
   .description("remove package from manifest json")
-  .action(async function (pkg, otherPkgs, options) {
-    const pkgs = [pkg].concat(otherPkgs);
-    const resultCode = await removeCmd(pkgs, makeCmdOptions(options));
+  .action(async function (packageName, otherPackageNames, options) {
+    const packageNames = [packageName].concat(otherPackageNames);
+    const resultCode = await removeCmd(packageNames, makeCmdOptions(options));
     process.exit(resultCode);
   });
 

--- a/src/common-errors.ts
+++ b/src/common-errors.ts
@@ -1,5 +1,6 @@
 import { CustomError } from "ts-custom-error";
 import { EditorVersion } from "./domain/editor-version";
+import { DomainName } from "./domain/domain-name";
 
 /**
  * Error for when the packument was not found.
@@ -7,7 +8,12 @@ import { EditorVersion } from "./domain/editor-version";
 export class PackumentNotFoundError extends CustomError {
   // noinspection JSUnusedLocalSymbols
   private readonly _class = "PackumentNotFoundError";
-  constructor() {
+  constructor(
+    /**
+     * The name of the missing package.
+     */
+    public packageName: DomainName
+  ) {
     super("A packument was not found.");
   }
 }

--- a/src/packument-version-resolving.ts
+++ b/src/packument-version-resolving.ts
@@ -62,7 +62,8 @@ export function tryResolveFromCache(
   requestedVersion: ResolvableVersion
 ): Result<ResolvedPackumentVersion, PackumentVersionResolveError> {
   const cachedPackument = tryGetFromCache(cache, source, packumentName);
-  if (cachedPackument === null) return Err(new PackumentNotFoundError());
+  if (cachedPackument === null)
+    return Err(new PackumentNotFoundError(packumentName));
 
   return tryResolvePackumentVersion(cachedPackument, requestedVersion).map(
     (packumentVersion) => ({

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -166,7 +166,7 @@ export function makeResolveDependenciesService(
         let resolveResult: Result<
           ResolvedPackumentVersion,
           ResolveRemotePackumentVersionError
-        > = Err(new PackumentNotFoundError());
+        > = Err(new PackumentNotFoundError(entryName));
         for (const source of sources) {
           const result = await tryResolveFromRegistry(
             source,

--- a/src/services/remove-packages.ts
+++ b/src/services/remove-packages.ts
@@ -1,0 +1,101 @@
+import { AsyncResult, Err, Ok, Result } from "ts-results-es";
+import {
+  removeDependency,
+  UnityProjectManifest,
+} from "../domain/project-manifest";
+import { PackumentNotFoundError } from "../common-errors";
+import { DomainName } from "../domain/domain-name";
+import {
+  LoadProjectManifest,
+  ManifestLoadError,
+  ManifestWriteError,
+  WriteProjectManifest,
+} from "../io/project-manifest-io";
+import { SemanticVersion } from "../domain/semantic-version";
+import { PackageUrl } from "../domain/package-url";
+
+export type RemovedPackage = {
+  name: DomainName;
+  version: SemanticVersion | PackageUrl;
+};
+
+export type RemovePackagesError =
+  | ManifestLoadError
+  | PackumentNotFoundError
+  | ManifestWriteError;
+
+export type RemovePackages = (
+  projectPath: string,
+  packageNames: ReadonlyArray<DomainName>
+) => AsyncResult<ReadonlyArray<RemovedPackage>, RemovePackagesError>;
+
+export function makePackageRemover(
+  loadProjectManifest: LoadProjectManifest,
+  writeProjectManifest: WriteProjectManifest
+): RemovePackages {
+  const tryRemoveSingle = function (
+    manifest: UnityProjectManifest,
+    packageName: DomainName
+  ): Result<[UnityProjectManifest, RemovedPackage], PackumentNotFoundError> {
+    // not found array
+    const versionInManifest = manifest.dependencies[packageName];
+    if (versionInManifest === undefined) {
+      return Err(new PackumentNotFoundError(packageName));
+    }
+
+    manifest = removeDependency(manifest, packageName);
+
+    manifest = {
+      ...manifest,
+      scopedRegistries: manifest.scopedRegistries
+        // Remove package scope from all scoped registries
+        ?.map((scopedRegistry) => ({
+          ...scopedRegistry,
+          scopes: scopedRegistry.scopes.filter(
+            (scope) => scope !== packageName
+          ),
+        })),
+    };
+
+    return Ok([manifest, { name: packageName, version: versionInManifest }]);
+  };
+
+  function tryRemoveAll(
+    manifest: UnityProjectManifest,
+    packageNames: ReadonlyArray<DomainName>
+  ): Result<
+    [UnityProjectManifest, ReadonlyArray<RemovedPackage>],
+    PackumentNotFoundError
+  > {
+    if (packageNames.length == 0) return Ok([manifest, []]);
+
+    const currentPackageName = packageNames[0]!;
+    const remainingPackageNames = packageNames.slice(1);
+
+    return tryRemoveSingle(manifest, currentPackageName).andThen(
+      ([updatedManifest, removedPackage]) =>
+        tryRemoveAll(updatedManifest, remainingPackageNames).map(
+          ([finalManifest, removedPackages]) => [
+            finalManifest,
+            [removedPackage, ...removedPackages],
+          ]
+        )
+    );
+  }
+
+  return (projectPath, packageNames) => {
+    // load manifest
+    const initialManifest = loadProjectManifest(projectPath);
+
+    // remove
+    const removeResult = initialManifest.andThen((it) =>
+      tryRemoveAll(it, packageNames)
+    );
+
+    return removeResult.andThen(([updatedManifest, removedPackages]) =>
+      writeProjectManifest(projectPath, updatedManifest).map(
+        () => removedPackages
+      )
+    );
+  };
+}

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -33,7 +33,7 @@ export function makeResolveLatestVersionService(
     packageName
   ) => {
     if (sources.length === 0)
-      return Err(new PackumentNotFoundError()).toAsyncResult();
+      return Err(new PackumentNotFoundError(packageName)).toAsyncResult();
 
     const sourceToCheck = sources[0]!;
     return fetchPackument(sourceToCheck, packageName).andThen(

--- a/src/services/resolve-remote-packument-version.ts
+++ b/src/services/resolve-remote-packument-version.ts
@@ -38,7 +38,8 @@ export function makeResolveRemotePackumentVersionService(
   return (packageName, requestedVersion, source) =>
     fetchPackument(source, packageName)
       .andThen((maybePackument) => {
-        if (maybePackument === null) return Err(new PackumentNotFoundError());
+        if (maybePackument === null)
+          return Err(new PackumentNotFoundError(packageName));
         return Ok(maybePackument);
       })
       .andThen((packument) =>

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -116,7 +116,7 @@ describe("cmd-deps", () => {
           {
             name: otherPackage,
             self: false,
-            reason: new PackumentNotFoundError(),
+            reason: new PackumentNotFoundError(otherPackage),
           },
         ],
       ])

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -3,55 +3,37 @@ import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { makeRemoveCmd } from "../../src/cli/cmd-remove";
 import { Err, Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
-import {
-  mockProjectManifest,
-  mockProjectManifestWriteResult,
-} from "../io/project-manifest-io.mock";
-import { buildProjectManifest } from "../domain/data-project-manifest";
-import { makePackageReference } from "../../src/domain/package-reference";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import { mockService } from "../services/service.mock";
-import {
-  LoadProjectManifest,
-  WriteProjectManifest,
-} from "../../src/io/project-manifest-io";
 import { GenericIOError } from "../../src/io/common-errors";
 import { ResultCodes } from "../../src/cli/result-codes";
+import { RemovePackages } from "../../src/services/remove-packages";
 
 const somePackage = makeDomainName("com.some.package");
-const otherPackage = makeDomainName("com.other.package");
 const defaultEnv = {
   cwd: "/users/some-user/projects/SomeProject",
   registry: { url: exampleRegistryUrl, auth: null },
 } as Env;
-const defaultManifest = buildProjectManifest((manifest) =>
-  manifest.addDependency(somePackage, "1.0.0", true, true)
-);
 
 function makeDependencies() {
   const parseEnv = mockService<ParseEnvService>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
-  const loadProjectManifest = mockService<LoadProjectManifest>();
-  mockProjectManifest(loadProjectManifest, defaultManifest);
-
-  const writeProjectManifest = mockService<WriteProjectManifest>();
-  mockProjectManifestWriteResult(writeProjectManifest);
+  const removePackages = mockService<RemovePackages>();
+  removePackages.mockReturnValue(
+    Ok([
+      { name: somePackage, version: "1.0.0" as SemanticVersion },
+    ]).toAsyncResult()
+  );
 
   const log = makeMockLogger();
 
-  const removeCmd = makeRemoveCmd(
-    parseEnv,
-    loadProjectManifest,
-    writeProjectManifest,
-    log
-  );
+  const removeCmd = makeRemoveCmd(parseEnv, removePackages, log);
   return {
     removeCmd,
     parseEnv,
-    loadProjectManifest,
-    writeProjectManifest,
+    removePackages,
     log,
   } as const;
 }
@@ -62,153 +44,37 @@ describe("cmd-remove", () => {
     const { removeCmd, parseEnv } = makeDependencies();
     parseEnv.mockResolvedValue(Err(expected));
 
-    const resultCode = await removeCmd(somePackage, { _global: {} });
+    const resultCode = await removeCmd([somePackage], { _global: {} });
 
     expect(resultCode).toEqual(ResultCodes.Error);
   });
 
-  it("should fail if manifest could not be loaded", async () => {
-    const { removeCmd, loadProjectManifest } = makeDependencies();
-    mockProjectManifest(loadProjectManifest, null);
-
-    const resultCode = await removeCmd(somePackage, { _global: {} });
-
-    expect(resultCode).toEqual(ResultCodes.Error);
-  });
-
-  it("should notify if manifest could not be loaded", async () => {
-    const { removeCmd, loadProjectManifest, log } = makeDependencies();
-    mockProjectManifest(loadProjectManifest, null);
-
-    await removeCmd(somePackage, { _global: {} });
-
-    expect(log.error).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.stringContaining("Could not locate")
-    );
-  });
-
-  it("should fail if package version was specified", async () => {
-    const { removeCmd } = makeDependencies();
-
-    const resultCode = await removeCmd(
-      makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
-      { _global: {} }
+  it("should fail if package could not be removed", async () => {
+    const { removeCmd, removePackages } = makeDependencies();
+    removePackages.mockReturnValue(
+      Err(new GenericIOError("Read")).toAsyncResult()
     );
 
+    const resultCode = await removeCmd([somePackage], { _global: {} });
+
     expect(resultCode).toEqual(ResultCodes.Error);
   });
 
-  it("should notify if package version was specified", async () => {
+  it("should print removed packages", async () => {
     const { removeCmd, log } = makeDependencies();
 
-    await removeCmd(
-      makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
-      { _global: {} }
-    );
-
-    expect(log.warn).toHaveBeenCalledWith(
-      "",
-      expect.stringContaining("please do not specify")
-    );
-  });
-
-  it("should fail if package is not in manifest", async () => {
-    const { removeCmd } = makeDependencies();
-
-    const resultCode = await removeCmd(otherPackage, { _global: {} });
-
-    expect(resultCode).toEqual(ResultCodes.Error);
-  });
-
-  it("should notify if package is not in manifest", async () => {
-    const { removeCmd, log } = makeDependencies();
-
-    await removeCmd(otherPackage, { _global: {} });
-
-    expect(log.error).toHaveBeenCalledWith(
-      "404",
-      expect.stringContaining("not found")
-    );
-  });
-
-  it("should notify of removed package", async () => {
-    const { removeCmd, log } = makeDependencies();
-
-    await removeCmd(somePackage, { _global: {} });
+    await removeCmd([somePackage], { _global: {} });
 
     expect(log.notice).toHaveBeenCalledWith(
-      "manifest",
-      expect.stringContaining("removed")
-    );
-  });
-
-  it("should be atomic for multiple packages", async () => {
-    const { removeCmd, writeProjectManifest } = makeDependencies();
-
-    // One of these packages can not be removed, so none should be removed.
-    await removeCmd([somePackage, otherPackage], { _global: {} });
-
-    expect(writeProjectManifest).not.toHaveBeenCalled();
-  });
-
-  it("should remove package from manifest", async () => {
-    const { removeCmd, writeProjectManifest } = makeDependencies();
-
-    await removeCmd(somePackage, { _global: {} });
-
-    expect(writeProjectManifest).toHaveBeenCalledWith(
       expect.any(String),
-      expect.not.objectContaining({
-        dependencies: {
-          [somePackage]: expect.anything(),
-        },
-      })
-    );
-  });
-
-  it("should remove scope from manifest", async () => {
-    const { removeCmd, writeProjectManifest } = makeDependencies();
-
-    await removeCmd(somePackage, { _global: {} });
-
-    expect(writeProjectManifest).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.not.objectContaining({
-        scopes: [somePackage],
-      })
-    );
-  });
-
-  it("should fail if manifest could not be saved", async () => {
-    const expected = new GenericIOError("Write");
-    const { removeCmd, writeProjectManifest } = makeDependencies();
-    mockProjectManifestWriteResult(writeProjectManifest, expected);
-
-    const resultCode = await removeCmd(somePackage, { _global: {} });
-
-    expect(resultCode).toEqual(ResultCodes.Error);
-  });
-
-  it("should notify if manifest could not be saved", async () => {
-    const { removeCmd, log, writeProjectManifest } = makeDependencies();
-    mockProjectManifestWriteResult(
-      writeProjectManifest,
-      new GenericIOError("Write")
-    );
-
-    await removeCmd(somePackage, { _global: {} });
-
-    expect(log.error).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.stringContaining("file-system error")
+      expect.stringContaining(`${somePackage}@1.0.0`)
     );
   });
 
   it("should suggest to open Unity after save", async () => {
     const { removeCmd, log } = makeDependencies();
 
-    await removeCmd(somePackage, { _global: {} });
+    await removeCmd([somePackage], { _global: {} });
 
     expect(log.notice).toHaveBeenCalledWith(
       "",

--- a/test/io/project-version-io.test.ts
+++ b/test/io/project-version-io.test.ts
@@ -7,7 +7,7 @@ import { eaccesError, enoentError } from "./node-error.mock";
 import {
   FileMissingError,
   FileParseError,
-  GenericIOError
+  GenericIOError,
 } from "../../src/io/common-errors";
 
 describe("project-version-io", () => {

--- a/test/services/packument-resolving.mock.ts
+++ b/test/services/packument-resolving.mock.ts
@@ -26,7 +26,7 @@ export function mockResolvedPackuments(
         (entry) => entry[0] === registry.url && entry[1].name === name
       );
       if (matchingEntry === undefined)
-        return Err(new PackumentNotFoundError()).toAsyncResult();
+        return Err(new PackumentNotFoundError(name)).toAsyncResult();
 
       const source = matchingEntry[0];
       const packument = matchingEntry[1];

--- a/test/services/remove-packages.test.ts
+++ b/test/services/remove-packages.test.ts
@@ -1,0 +1,126 @@
+import { FileMissingError, GenericIOError } from "../../src/io/common-errors";
+import { ResultCodes } from "../../src/cli/result-codes";
+import {
+  mockProjectManifest,
+  mockProjectManifestWriteResult,
+} from "../io/project-manifest-io.mock";
+import {
+  makePackageRemover,
+  RemovedPackage,
+} from "../../src/services/remove-packages";
+import { mockService } from "./service.mock";
+import {
+  LoadProjectManifest,
+  WriteProjectManifest,
+} from "../../src/io/project-manifest-io";
+import { makeDomainName } from "../../src/domain/domain-name";
+import { buildProjectManifest } from "../domain/data-project-manifest";
+import path from "path";
+import { PackumentNotFoundError } from "../../src/common-errors";
+
+describe("remove packages", () => {
+  const someProjectPath = path.resolve("/home/projects/MyUnityProject");
+  const somePackage = makeDomainName("com.some.package");
+  const otherPackage = makeDomainName("com.other.package");
+
+  const defaultManifest = buildProjectManifest((manifest) =>
+    manifest.addDependency(somePackage, "1.0.0", true, true)
+  );
+
+  function makeDependencies() {
+    const loadProjectManifest = mockService<LoadProjectManifest>();
+    mockProjectManifest(loadProjectManifest, defaultManifest);
+
+    const writeProjectManifest = mockService<WriteProjectManifest>();
+    mockProjectManifestWriteResult(writeProjectManifest);
+
+    const removePackages = makePackageRemover(
+      loadProjectManifest,
+      writeProjectManifest
+    );
+    return {
+      removePackages,
+      loadProjectManifest,
+      writeProjectManifest,
+    } as const;
+  }
+
+  it("should fail if manifest could not be loaded", async () => {
+    const { removePackages, loadProjectManifest } = makeDependencies();
+    mockProjectManifest(loadProjectManifest, null);
+
+    const result = await removePackages(someProjectPath, [somePackage]).promise;
+
+    expect(result).toBeError((actual) =>
+      expect(actual).toBeInstanceOf(FileMissingError)
+    );
+  });
+
+  it("should fail if package is not in manifest", async () => {
+    const { removePackages } = makeDependencies();
+
+    const result = await removePackages(someProjectPath, [otherPackage])
+      .promise;
+
+    expect(result).toBeError((actual) =>
+      expect(actual).toBeInstanceOf(PackumentNotFoundError)
+    );
+  });
+
+  it("should return removed version", async () => {
+    const { removePackages } = makeDependencies();
+
+    const result = await removePackages(someProjectPath, [somePackage]).promise;
+
+    expect(result).toBeOk((removedPackage: RemovedPackage) =>
+      expect(removedPackage).toEqual([{ name: somePackage, version: "1.0.0" }])
+    );
+  });
+
+  it("should be atomic for multiple packages", async () => {
+    const { removePackages, writeProjectManifest } = makeDependencies();
+
+    // One of these packages can not be removed, so none should be removed.
+    await removePackages(someProjectPath, [somePackage, otherPackage]).promise;
+
+    expect(writeProjectManifest).not.toHaveBeenCalled();
+  });
+
+  it("should remove package from manifest", async () => {
+    const { removePackages, writeProjectManifest } = makeDependencies();
+
+    await removePackages(someProjectPath, [somePackage]).promise;
+
+    expect(writeProjectManifest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.not.objectContaining({
+        dependencies: {
+          [somePackage]: expect.anything(),
+        },
+      })
+    );
+  });
+
+  it("should remove scope from manifest", async () => {
+    const { removePackages, writeProjectManifest } = makeDependencies();
+
+    await removePackages(someProjectPath, [somePackage]).promise;
+
+    expect(writeProjectManifest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.not.objectContaining({
+        scopes: [somePackage],
+      })
+    );
+  });
+
+  it("should fail if manifest could not be saved", async () => {
+    const expected = new GenericIOError("Write");
+    const { removePackages, writeProjectManifest } = makeDependencies();
+    mockProjectManifestWriteResult(writeProjectManifest, expected);
+
+    const result = await removePackages(someProjectPath, [somePackage]).promise;
+
+    expect(result).toBeError((actual) => expect(actual).toEqual(expected));
+  });
+});


### PR DESCRIPTION
This change extracts all business logic out of the remove command into its own service function. The cmd function is now only responsible for cli related logic.

This change also slightly changes the behavior of the remove command.
- Logs are rewritten
- Information about removed packages is printed all at once at the end when the atomic remove process is complete. Previously messages about removed packages were printed as soon as the in-memory manifest was modified. The command could still fail however and then these logs would be confusing.
