### PR TITLE
refactor: async result constructor

### DIFF
--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -1,9 +1,10 @@
-import { AsyncResult, Ok } from "ts-results-es";
+import { AsyncResult } from "ts-results-es";
 import { UnityPackument } from "../domain/packument";
 import { Registry } from "../domain/registry";
 import { DomainName } from "../domain/domain-name";
 import { FetchPackument, FetchPackumentError } from "../io/packument-io";
 import { RegistryUrl } from "../domain/registry-url";
+import { AsyncOk } from "../utils/result-utils";
 
 /**
  * A resolved remote Unity packument.
@@ -38,7 +39,7 @@ export type ResolveRemotePackument = (
 
 const noPackumentResult = <
   AsyncResult<ResolvedPackument | null, ResolveRemotePackumentError>
->Ok(null).toAsyncResult();
+>AsyncOk(null);
 
 function withSource(
   source: Registry,
@@ -77,7 +78,7 @@ export function makeRemotePackumentResolver(
         // If yes we can return it, otherwhise we enter the next level
         // of the recursion with the remaining registries.
         maybePackument !== null
-          ? Ok(maybePackument).toAsyncResult()
+          ? AsyncOk(maybePackument)
           : resolveRecursively(packageName, fallbackSources)
     );
   };

--- a/src/utils/result-utils.ts
+++ b/src/utils/result-utils.ts
@@ -5,7 +5,13 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
  * Shorthand for `Ok(value).toAsyncResult()`.
  * @param value The results value.
  */
-export function AsyncOk<T>(value: T): AsyncResult<T, never> {
+export function AsyncOk<T>(value: T): AsyncResult<T, never>;
+/**
+ * Creates an empty {@link AsyncResult}.
+ * Shorthand for `Ok(undefined).toAsyncResult()`.
+ */
+export function AsyncOk(): AsyncResult<void, never>;
+export function AsyncOk(value?: unknown) {
   return Ok(value).toAsyncResult();
 }
 

--- a/src/utils/result-utils.ts
+++ b/src/utils/result-utils.ts
@@ -1,13 +1,13 @@
 import { AsyncResult, Err, Ok } from "ts-results-es";
 
 /**
- * Creates an {@link AsyncResult} with a given value.
+ * Creates an ok {@link AsyncResult} with a given value.
  * Shorthand for `Ok(value).toAsyncResult()`.
  * @param value The results value.
  */
 export function AsyncOk<T>(value: T): AsyncResult<T, never>;
 /**
- * Creates an empty {@link AsyncResult}.
+ * Creates an empty ok {@link AsyncResult}.
  * Shorthand for `Ok(undefined).toAsyncResult()`.
  */
 export function AsyncOk(): AsyncResult<void, never>;
@@ -16,7 +16,7 @@ export function AsyncOk(value?: unknown) {
 }
 
 /**
- * Creates an {@link AsyncResult} with a given error.
+ * Creates an error {@link AsyncResult} with a given error.
  * Shorthand for `Err(value).toAsyncResult()`.
  * @param error The results error.
  */

--- a/src/utils/result-utils.ts
+++ b/src/utils/result-utils.ts
@@ -1,0 +1,19 @@
+import { AsyncResult, Err, Ok } from "ts-results-es";
+
+/**
+ * Creates an {@link AsyncResult} with a given value.
+ * Shorthand for `Ok(value).toAsyncResult()`.
+ * @param value The results value.
+ */
+export function AsyncOk<T>(value: T): AsyncResult<T, never> {
+  return Ok(value).toAsyncResult();
+}
+
+/**
+ * Creates an {@link AsyncResult} with a given error.
+ * Shorthand for `Err(value).toAsyncResult()`.
+ * @param error The results error.
+ */
+export function AsyncErr<T>(error: T): AsyncResult<never, T> {
+  return Err(error).toAsyncResult();
+}

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -28,6 +28,7 @@ import { GenericIOError } from "../../src/io/common-errors";
 import { DetermineEditorVersion } from "../../src/services/determine-editor-version";
 import { Err, Ok } from "ts-results-es";
 import { ResultCodes } from "../../src/cli/result-codes";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 const somePackage = makeDomainName("com.some.package");
 const otherPackage = makeDomainName("com.other.package");
@@ -243,7 +244,7 @@ describe("cmd-add", () => {
 
   it("should notify if editor-version is unknown", async () => {
     const { addCmd, determineEditorVersion, log } = makeDependencies();
-    determineEditorVersion.mockReturnValue(Ok("bad version").toAsyncResult());
+    determineEditorVersion.mockReturnValue(AsyncOk("bad version"));
 
     await addCmd(somePackage, {
       _global: {},

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -15,6 +15,7 @@ import {
   RegistryAuthenticationError,
 } from "../../src/io/common-errors";
 import { ResultCodes } from "../../src/cli/result-codes";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 const defaultEnv = {
   cwd: "/users/some-user/projects/SomeProject",
@@ -33,10 +34,10 @@ describe("cmd-login", () => {
     parseEnv.mockResolvedValue(Ok(defaultEnv));
 
     const getUpmConfigPath = mockService<GetUpmConfigPath>();
-    getUpmConfigPath.mockReturnValue(Ok(exampleUpmConfigPath).toAsyncResult());
+    getUpmConfigPath.mockReturnValue(AsyncOk(exampleUpmConfigPath));
 
     const login = mockService<LoginService>();
-    login.mockReturnValue(Ok(undefined).toAsyncResult());
+    login.mockReturnValue(AsyncOk(undefined));
 
     const log = makeMockLogger();
 
@@ -59,7 +60,7 @@ describe("cmd-login", () => {
   it("should fail if upm config path could not be determined", async () => {
     const expected = new RequiredEnvMissingError([]);
     const { loginCmd, getUpmConfigPath } = makeDependencies();
-    getUpmConfigPath.mockReturnValue(Err(expected).toAsyncResult());
+    getUpmConfigPath.mockReturnValue(AsyncErr(expected));
 
     const resultCode = await loginCmd({
       username: exampleUser,
@@ -74,7 +75,7 @@ describe("cmd-login", () => {
   it("should fail if login failed", async () => {
     const expected = new RequiredEnvMissingError([]);
     const { loginCmd, login } = makeDependencies();
-    login.mockReturnValue(Err(expected).toAsyncResult());
+    login.mockReturnValue(AsyncErr(expected));
 
     const resultCode = await loginCmd({
       username: exampleUser,

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -37,7 +37,7 @@ describe("cmd-login", () => {
     getUpmConfigPath.mockReturnValue(AsyncOk(exampleUpmConfigPath));
 
     const login = mockService<LoginService>();
-    login.mockReturnValue(AsyncOk(undefined));
+    login.mockReturnValue(AsyncOk());
 
     const log = makeMockLogger();
 

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -9,6 +9,7 @@ import { mockService } from "../services/service.mock";
 import { GenericIOError } from "../../src/io/common-errors";
 import { ResultCodes } from "../../src/cli/result-codes";
 import { RemovePackages } from "../../src/services/remove-packages";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 const somePackage = makeDomainName("com.some.package");
 const defaultEnv = {
@@ -22,9 +23,7 @@ function makeDependencies() {
 
   const removePackages = mockService<RemovePackages>();
   removePackages.mockReturnValue(
-    Ok([
-      { name: somePackage, version: "1.0.0" as SemanticVersion },
-    ]).toAsyncResult()
+    AsyncOk([{ name: somePackage, version: "1.0.0" as SemanticVersion }])
   );
 
   const log = makeMockLogger();

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -4,13 +4,14 @@ import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import { SearchedPackument } from "../../src/io/npm-search";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { Err, Ok } from "ts-results-es";
+import { Ok } from "ts-results-es";
 import { Env, ParseEnvService } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
 import { noopLogger } from "../../src/logging";
 import { ResultCodes } from "../../src/cli/result-codes";
 import { GenericNetworkError } from "../../src/io/common-errors";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 const exampleSearchResult: SearchedPackument = {
   name: makeDomainName("com.example.package-a"),
@@ -27,7 +28,7 @@ function makeDependencies() {
   );
 
   const searchPackages = mockService<SearchPackages>();
-  searchPackages.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
+  searchPackages.mockReturnValue(AsyncOk([exampleSearchResult]));
 
   const log = makeMockLogger();
 
@@ -73,7 +74,7 @@ describe("cmd-search", () => {
 
   it("should notify of unknown packument", async () => {
     const { searchCmd, searchPackages, log } = makeDependencies();
-    searchPackages.mockReturnValue(Ok([]).toAsyncResult());
+    searchPackages.mockReturnValue(AsyncOk([]));
 
     await searchCmd("pkg-not-exist", options);
 
@@ -86,7 +87,7 @@ describe("cmd-search", () => {
   it("should fail if packuments could not be searched", async () => {
     const expected = new GenericNetworkError();
     const { searchCmd, searchPackages } = makeDependencies();
-    searchPackages.mockReturnValue(Err(expected).toAsyncResult());
+    searchPackages.mockReturnValue(AsyncErr(expected));
 
     const resultCode = await searchCmd("package-a", options);
 
@@ -96,7 +97,7 @@ describe("cmd-search", () => {
   it("should notify if packuments could not be searched", async () => {
     const expected = new GenericNetworkError();
     const { searchCmd, searchPackages, log } = makeDependencies();
-    searchPackages.mockReturnValue(Err(expected).toAsyncResult());
+    searchPackages.mockReturnValue(AsyncErr(expected));
 
     await searchCmd("package-a", options);
 
@@ -111,7 +112,7 @@ describe("cmd-search", () => {
     searchPackages.mockImplementation(
       (_registry, _keyword, onUseAllFallback) => {
         onUseAllFallback && onUseAllFallback();
-        return Ok([]).toAsyncResult();
+        return AsyncOk([]);
       }
     );
 

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -15,6 +15,7 @@ import {
   GenericNetworkError,
 } from "../../src/io/common-errors";
 import { ResultCodes } from "../../src/cli/result-codes";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 const somePackage = makeDomainName("com.some.package");
 const somePackument = buildPackument(somePackage, (packument) =>
@@ -59,7 +60,7 @@ function makeDependencies() {
 
   const resolveRemotePackument = mockService<ResolveRemotePackument>();
   resolveRemotePackument.mockReturnValue(
-    Ok({ packument: somePackument, source: exampleRegistryUrl }).toAsyncResult()
+    AsyncOk({ packument: somePackument, source: exampleRegistryUrl })
   );
 
   const log = makeMockLogger();
@@ -106,7 +107,7 @@ describe("cmd-view", () => {
 
   it("should fail if package was not found", async () => {
     const { viewCmd, resolveRemotePackument } = makeDependencies();
-    resolveRemotePackument.mockReturnValue(Ok(null).toAsyncResult());
+    resolveRemotePackument.mockReturnValue(AsyncOk(null));
 
     const resultCode = await viewCmd(somePackage, { _global: {} });
 
@@ -116,7 +117,7 @@ describe("cmd-view", () => {
   it("should fail if package could not be resolved", async () => {
     const expected = new GenericNetworkError();
     const { viewCmd, resolveRemotePackument } = makeDependencies();
-    resolveRemotePackument.mockReturnValue(Err(expected).toAsyncResult());
+    resolveRemotePackument.mockReturnValue(AsyncErr(expected));
 
     const resultCode = await viewCmd(somePackage, { _global: {} });
 
@@ -125,7 +126,7 @@ describe("cmd-view", () => {
 
   it("should notify if package could not be resolved", async () => {
     const { viewCmd, resolveRemotePackument, log } = makeDependencies();
-    resolveRemotePackument.mockReturnValue(Ok(null).toAsyncResult());
+    resolveRemotePackument.mockReturnValue(AsyncOk(null));
 
     await viewCmd(somePackage, { _global: {} });
 

--- a/test/io/builtin-packages.test.ts
+++ b/test/io/builtin-packages.test.ts
@@ -9,6 +9,7 @@ import {
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { noopLogger } from "../../src/logging";
 import { enoentError } from "./node-error.mock";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 function makeDependencies() {
   const getBuiltInPackages = makeBuiltInPackagesFinder(noopLogger);
@@ -35,7 +36,7 @@ describe("builtin-packages", () => {
     const { getBuiltInPackages } = makeDependencies();
     jest
       .spyOn(fileIo, "tryGetDirectoriesIn")
-      .mockReturnValue(Err(enoentError).toAsyncResult());
+      .mockReturnValue(AsyncErr(enoentError));
 
     const result = await getBuiltInPackages(version).promise;
 
@@ -51,7 +52,7 @@ describe("builtin-packages", () => {
       .mockReturnValue(Ok("/some/path"));
     jest
       .spyOn(fileIo, "tryGetDirectoriesIn")
-      .mockReturnValue(Ok(expected).toAsyncResult());
+      .mockReturnValue(AsyncOk(expected));
 
     const result = await getBuiltInPackages(version).promise;
 

--- a/test/io/project-manifest-io.mock.ts
+++ b/test/io/project-manifest-io.mock.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/io/project-manifest-io";
 import { UnityProjectManifest } from "../../src/domain/project-manifest";
 import { Err, Ok } from "ts-results-es";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 /**
  * Mocks results for a {@link LoadProjectManifest} function.
@@ -22,7 +23,7 @@ export function mockProjectManifest(
     const manifestPath = manifestPathFor(projectPath);
     return manifest === null
       ? Err(makeProjectManifestMissingError(manifestPath)).toAsyncResult()
-      : Ok(manifest).toAsyncResult();
+      : AsyncOk(manifest);
   });
 }
 

--- a/test/io/project-manifest-io.test.ts
+++ b/test/io/project-manifest-io.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../../src/domain/project-manifest";
 import path from "path";
 import { ReadTextFile, WriteTextFile } from "../../src/io/fs-result";
-import { Err, Ok } from "ts-results-es";
 import { buildProjectManifest } from "../domain/data-project-manifest";
 import { DomainName } from "../../src/domain/domain-name";
 import { removeScope } from "../../src/domain/scoped-registry";
@@ -18,6 +17,7 @@ import { mockService } from "../services/service.mock";
 import { eaccesError, enoentError } from "./node-error.mock";
 import { FileMissingError, GenericIOError } from "../../src/io/common-errors";
 import { StringFormatError } from "../../src/utils/string-parsing";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 const exampleProjectPath = "/some/path";
 describe("project-manifest io", () => {
@@ -43,7 +43,7 @@ describe("project-manifest io", () => {
 
     it("should fail if file could not be read", async () => {
       const { loadProjectManifest, readFile } = makeDependencies();
-      readFile.mockReturnValue(Err(eaccesError).toAsyncResult());
+      readFile.mockReturnValue(AsyncErr(eaccesError));
 
       const result = await loadProjectManifest(exampleProjectPath).promise;
 
@@ -54,7 +54,7 @@ describe("project-manifest io", () => {
 
     it("should fail if file is missing", async () => {
       const { loadProjectManifest, readFile } = makeDependencies();
-      readFile.mockReturnValue(Err(enoentError).toAsyncResult());
+      readFile.mockReturnValue(AsyncErr(enoentError));
 
       const result = await loadProjectManifest(exampleProjectPath).promise;
 
@@ -65,9 +65,7 @@ describe("project-manifest io", () => {
 
     it("should fail if file does not contain json", async () => {
       const { loadProjectManifest, readFile } = makeDependencies();
-      readFile.mockReturnValue(
-        Ok("{} dang, this is not json []").toAsyncResult()
-      );
+      readFile.mockReturnValue(AsyncOk("{} dang, this is not json []"));
 
       const result = await loadProjectManifest(exampleProjectPath).promise;
 
@@ -79,7 +77,7 @@ describe("project-manifest io", () => {
     it("should load valid manifest", async () => {
       const { loadProjectManifest, readFile } = makeDependencies();
       readFile.mockReturnValue(
-        Ok(`{ "dependencies": { "com.package.a": "1.0.0"} }`).toAsyncResult()
+        AsyncOk(`{ "dependencies": { "com.package.a": "1.0.0"} }`)
       );
 
       const result = await loadProjectManifest(exampleProjectPath).promise;
@@ -97,7 +95,7 @@ describe("project-manifest io", () => {
   describe("write", () => {
     function makeDependencies() {
       const writeFile = mockService<WriteTextFile>();
-      writeFile.mockReturnValue(Ok(undefined).toAsyncResult());
+      writeFile.mockReturnValue(AsyncOk(undefined));
 
       const writeProjectManifest = makeProjectManifestWriter(writeFile);
       return { writeProjectManifest, writeFile } as const;
@@ -106,7 +104,7 @@ describe("project-manifest io", () => {
     it("should fail if file could not be written", async () => {
       const expected = eaccesError;
       const { writeProjectManifest, writeFile } = makeDependencies();
-      writeFile.mockReturnValue(Err(expected).toAsyncResult());
+      writeFile.mockReturnValue(AsyncErr(expected));
 
       const result = await writeProjectManifest(
         exampleProjectPath,

--- a/test/io/project-manifest-io.test.ts
+++ b/test/io/project-manifest-io.test.ts
@@ -95,7 +95,7 @@ describe("project-manifest io", () => {
   describe("write", () => {
     function makeDependencies() {
       const writeFile = mockService<WriteTextFile>();
-      writeFile.mockReturnValue(AsyncOk(undefined));
+      writeFile.mockReturnValue(AsyncOk());
 
       const writeProjectManifest = makeProjectManifestWriter(writeFile);
       return { writeProjectManifest, writeFile } as const;

--- a/test/io/project-version-io.mock.ts
+++ b/test/io/project-version-io.mock.ts
@@ -2,8 +2,8 @@ import {
   ReleaseVersion,
   stringifyEditorVersion,
 } from "../../src/domain/editor-version";
-import { Ok } from "ts-results-es";
 import { LoadProjectVersion } from "../../src/io/project-version-io";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 /**
  * Mocks return values for calls to a {@link LoadProjectVersion} function.
@@ -20,5 +20,5 @@ export function mockProjectVersion(
       ? editorVersion
       : stringifyEditorVersion(editorVersion);
 
-  loadProjectVersion.mockReturnValue(Ok(versionString).toAsyncResult());
+  loadProjectVersion.mockReturnValue(AsyncOk(versionString));
 }

--- a/test/io/project-version-io.test.ts
+++ b/test/io/project-version-io.test.ts
@@ -1,5 +1,4 @@
 import { ReadTextFile } from "../../src/io/fs-result";
-import { Err, Ok } from "ts-results-es";
 import { StringFormatError } from "../../src/utils/string-parsing";
 import { mockService } from "../services/service.mock";
 import { makeProjectVersionLoader } from "../../src/io/project-version-io";
@@ -9,6 +8,7 @@ import {
   FileParseError,
   GenericIOError,
 } from "../../src/io/common-errors";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 describe("project-version-io", () => {
   describe("load", () => {
@@ -22,7 +22,7 @@ describe("project-version-io", () => {
 
     it("should fail if file is missing", async () => {
       const { loadProjectVersion, readFile } = makeDependencies();
-      readFile.mockReturnValue(Err(enoentError).toAsyncResult());
+      readFile.mockReturnValue(AsyncErr(enoentError));
 
       const result = await loadProjectVersion("/some/bad/path").promise;
 
@@ -33,7 +33,7 @@ describe("project-version-io", () => {
 
     it("should fail if file could not be read", async () => {
       const { loadProjectVersion, readFile } = makeDependencies();
-      readFile.mockReturnValue(Err(eaccesError).toAsyncResult());
+      readFile.mockReturnValue(AsyncErr(eaccesError));
 
       const result = await loadProjectVersion("/some/bad/path").promise;
 
@@ -44,7 +44,7 @@ describe("project-version-io", () => {
 
     it("should fail if file does not contain valid yaml", async () => {
       const { loadProjectVersion, readFile } = makeDependencies();
-      readFile.mockReturnValue(Ok("{ this is not valid yaml").toAsyncResult());
+      readFile.mockReturnValue(AsyncOk("{ this is not valid yaml"));
 
       const result = await loadProjectVersion("/some/path").promise;
 
@@ -55,9 +55,7 @@ describe("project-version-io", () => {
 
     it("should fail if yaml does not contain editor-version", async () => {
       const { loadProjectVersion, readFile } = makeDependencies();
-      readFile.mockReturnValue(
-        Ok("thisIsYaml: but not what we want").toAsyncResult()
-      );
+      readFile.mockReturnValue(AsyncOk("thisIsYaml: but not what we want"));
 
       const result = await loadProjectVersion("/some/path").promise;
 
@@ -69,9 +67,7 @@ describe("project-version-io", () => {
     it("should load valid version strings", async () => {
       const { loadProjectVersion, readFile } = makeDependencies();
       const expected = "2022.1.2f1";
-      readFile.mockReturnValue(
-        Ok(`m_EditorVersion: ${expected}`).toAsyncResult()
-      );
+      readFile.mockReturnValue(AsyncOk(`m_EditorVersion: ${expected}`));
 
       const result = await loadProjectVersion("/some/path").promise;
 

--- a/test/io/upm-config-io.mock.ts
+++ b/test/io/upm-config-io.mock.ts
@@ -1,6 +1,6 @@
 import { UPMConfig } from "../../src/domain/upm-config";
 import { LoadUpmConfig } from "../../src/io/upm-config-io";
-import { Ok } from "ts-results-es";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 /**
  * Mocks return value for calls to {@link LoadUpmConfig} function.
@@ -11,5 +11,5 @@ export function mockUpmConfig(
   loadUpmConfig: jest.MockedFunction<LoadUpmConfig>,
   config: UPMConfig | null
 ) {
-  loadUpmConfig.mockReturnValue(Ok(config).toAsyncResult());
+  loadUpmConfig.mockReturnValue(AsyncOk(config));
 }

--- a/test/io/upm-config-io.test.ts
+++ b/test/io/upm-config-io.test.ts
@@ -11,6 +11,7 @@ import { GetHomePath } from "../../src/io/special-paths";
 import path from "path";
 import { eaccesError, enoentError } from "./node-error.mock";
 import { GenericIOError } from "../../src/io/common-errors";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 describe("upm-config-io", () => {
   describe("get path", () => {
@@ -48,7 +49,7 @@ describe("upm-config-io", () => {
   describe("load", () => {
     function makeDependencies() {
       const readFile = mockService<ReadTextFile>();
-      readFile.mockReturnValue(Ok("").toAsyncResult());
+      readFile.mockReturnValue(AsyncOk(""));
 
       const loadUpmConfig = makeUpmConfigLoader(readFile);
       return { loadUpmConfig, readFile } as const;
@@ -57,7 +58,7 @@ describe("upm-config-io", () => {
     it("should be null if file is not found", async () => {
       const { loadUpmConfig, readFile } = makeDependencies();
       const path = "/home/user/.upmconfig.toml";
-      readFile.mockReturnValue(Err(enoentError).toAsyncResult());
+      readFile.mockReturnValue(AsyncErr(enoentError));
 
       const result = await loadUpmConfig(path).promise;
 
@@ -76,7 +77,7 @@ describe("upm-config-io", () => {
     it("should fail if file could not be read", async () => {
       const { loadUpmConfig, readFile } = makeDependencies();
       const path = "/home/user/.upmconfig.toml";
-      readFile.mockReturnValue(Err(eaccesError).toAsyncResult());
+      readFile.mockReturnValue(AsyncErr(eaccesError));
 
       const result = await loadUpmConfig(path).promise;
 
@@ -87,9 +88,7 @@ describe("upm-config-io", () => {
 
     it("should fail if file has bad toml content", async () => {
       const { loadUpmConfig, readFile } = makeDependencies();
-      readFile.mockReturnValue(
-        Ok("This {\n is not]\n valid TOML").toAsyncResult()
-      );
+      readFile.mockReturnValue(AsyncOk("This {\n is not]\n valid TOML"));
       const path = "/home/user/.upmconfig.toml";
 
       const result = await loadUpmConfig(path).promise;

--- a/test/io/wsl.test.ts
+++ b/test/io/wsl.test.ts
@@ -1,7 +1,8 @@
 import * as processModule from "../../src/utils/process";
 import { ChildProcessError } from "../../src/utils/process";
 import { tryGetWslPath } from "../../src/io/wsl";
-import { Err, Ok } from "ts-results-es";
+import { Err } from "ts-results-es";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 jest.mock("is-wsl", () => ({
   __esModule: true,
@@ -12,9 +13,7 @@ describe("wsl", () => {
   describe("get path", () => {
     it("should be result of wslpath command", async () => {
       const expected = "/some/path";
-      jest
-        .spyOn(processModule, "default")
-        .mockReturnValue(Ok(expected).toAsyncResult());
+      jest.spyOn(processModule, "default").mockReturnValue(AsyncOk(expected));
 
       const result = await tryGetWslPath("SOMEVAR").promise;
 

--- a/test/services/determine-editor-version.test.ts
+++ b/test/services/determine-editor-version.test.ts
@@ -4,7 +4,7 @@ import { LoadProjectVersion } from "../../src/io/project-version-io";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { mockProjectVersion } from "../io/project-version-io.mock";
 import { GenericIOError } from "../../src/io/common-errors";
-import { Err } from "ts-results-es";
+import { AsyncErr } from "../../src/utils/result-utils";
 
 describe("determine editor version", () => {
   const exampleProjectPath = "/home/my-project/";
@@ -51,7 +51,7 @@ describe("determine editor version", () => {
   it("should fail if ProjectVersion.txt could not be loaded", async () => {
     const { determineEditorVersion, loadProjectVersion } = makeDependencies();
     const expected = new GenericIOError("Read");
-    loadProjectVersion.mockReturnValue(Err(expected).toAsyncResult());
+    loadProjectVersion.mockReturnValue(AsyncErr(expected));
 
     const result = await determineEditorVersion(exampleProjectPath).promise;
 

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -21,7 +21,7 @@ const exampleToken = "some token";
 describe("login", () => {
   function makeDependencies() {
     const saveAuthToUpmConfig = mockService<SaveAuthToUpmConfig>();
-    saveAuthToUpmConfig.mockReturnValue(AsyncOk(undefined));
+    saveAuthToUpmConfig.mockReturnValue(AsyncOk());
 
     const npmLogin = mockService<NpmLoginService>();
     npmLogin.mockReturnValue(AsyncOk(exampleToken));

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -4,12 +4,12 @@ import { SaveAuthToUpmConfig } from "../../src/services/upm-auth";
 import { NpmLoginService } from "../../src/services/npm-login";
 import { AuthNpmrcService } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { Err, Ok } from "ts-results-es";
 import { noopLogger } from "../../src/logging";
 import {
-  RegistryAuthenticationError,
   GenericIOError,
+  RegistryAuthenticationError,
 } from "../../src/io/common-errors";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 const exampleUser = "user";
 const examplePassword = "pass";
@@ -21,13 +21,13 @@ const exampleToken = "some token";
 describe("login", () => {
   function makeDependencies() {
     const saveAuthToUpmConfig = mockService<SaveAuthToUpmConfig>();
-    saveAuthToUpmConfig.mockReturnValue(Ok(undefined).toAsyncResult());
+    saveAuthToUpmConfig.mockReturnValue(AsyncOk(undefined));
 
     const npmLogin = mockService<NpmLoginService>();
-    npmLogin.mockReturnValue(Ok(exampleToken).toAsyncResult());
+    npmLogin.mockReturnValue(AsyncOk(exampleToken));
 
     const authNpmrc = mockService<AuthNpmrcService>();
-    authNpmrc.mockReturnValue(Ok(exampleNpmrcPath).toAsyncResult());
+    authNpmrc.mockReturnValue(AsyncOk(exampleNpmrcPath));
 
     const login = makeLoginService(
       saveAuthToUpmConfig,
@@ -66,7 +66,7 @@ describe("login", () => {
     it("should fail if config write fails", async () => {
       const expected = new GenericIOError("Write");
       const { login, saveAuthToUpmConfig } = makeDependencies();
-      saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
+      saveAuthToUpmConfig.mockReturnValue(AsyncErr(expected));
 
       const result = await login(
         exampleUser,
@@ -86,7 +86,7 @@ describe("login", () => {
     it("should fail if npm login fails", async () => {
       const expected = new RegistryAuthenticationError();
       const { login, npmLogin } = makeDependencies();
-      npmLogin.mockReturnValue(Err(expected).toAsyncResult());
+      npmLogin.mockReturnValue(AsyncErr(expected));
 
       const result = await login(
         exampleUser,
@@ -104,7 +104,7 @@ describe("login", () => {
     it("should fail if npmrc auth fails", async () => {
       const expected = new GenericIOError("Read");
       const { login, authNpmrc } = makeDependencies();
-      authNpmrc.mockReturnValue(Err(expected).toAsyncResult());
+      authNpmrc.mockReturnValue(AsyncErr(expected));
 
       const result = await login(
         exampleUser,
@@ -146,7 +146,7 @@ describe("login", () => {
     it("should fail if config write fails", async () => {
       const expected = new GenericIOError("Write");
       const { login, saveAuthToUpmConfig } = makeDependencies();
-      saveAuthToUpmConfig.mockReturnValue(Err(expected).toAsyncResult());
+      saveAuthToUpmConfig.mockReturnValue(AsyncErr(expected));
 
       const result = await login(
         exampleUser,

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -1,7 +1,6 @@
 import { TokenAuth, UPMConfig } from "../../src/domain/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
 import { Env, makeParseEnvService } from "../../src/services/parse-env";
-import { Err, Ok } from "ts-results-es";
 import { GetUpmConfigPath, LoadUpmConfig } from "../../src/io/upm-config-io";
 import { NoWslError } from "../../src/io/wsl";
 import { mockUpmConfig } from "../io/upm-config-io.mock";
@@ -10,6 +9,7 @@ import { makeMockLogger } from "../cli/log.mock";
 import { mockService } from "./service.mock";
 import { GetCwd } from "../../src/io/special-paths";
 import path from "path";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 const testRootPath = "/users/some-user/projects/MyUnityProject";
 
@@ -32,7 +32,7 @@ function makeDependencies() {
 
   const getUpmConfigPath = mockService<GetUpmConfigPath>();
   // The root directory does not contain an upm-config
-  getUpmConfigPath.mockReturnValue(Ok(testRootPath).toAsyncResult());
+  getUpmConfigPath.mockReturnValue(AsyncOk(testRootPath));
 
   const loadUpmConfig = mockService<LoadUpmConfig>();
   mockUpmConfig(loadUpmConfig, null);
@@ -280,7 +280,7 @@ describe("env", () => {
     it("should fail if upm-config dir cannot be determined", async () => {
       const { parseEnv, getUpmConfigPath } = makeDependencies();
       const expected = new NoWslError();
-      getUpmConfigPath.mockReturnValue(Err(expected).toAsyncResult());
+      getUpmConfigPath.mockReturnValue(AsyncErr(expected));
 
       const result = await parseEnv({ _global: {} });
 

--- a/test/services/remove-packages.test.ts
+++ b/test/services/remove-packages.test.ts
@@ -1,5 +1,4 @@
 import { FileMissingError, GenericIOError } from "../../src/io/common-errors";
-import { ResultCodes } from "../../src/cli/result-codes";
 import {
   mockProjectManifest,
   mockProjectManifestWriteResult,

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -2,12 +2,12 @@ import { mockService } from "./service.mock";
 import { makeResolveLatestVersionService } from "../../src/services/resolve-latest-version";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { PackumentNotFoundError } from "../../src/common-errors";
-import { Ok } from "ts-results-es";
 import { NoVersionsError, UnityPackument } from "../../src/domain/packument";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { FetchPackument } from "../../src/io/packument-io";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 describe("resolve latest version service", () => {
   const somePackage = makeDomainName("com.some.package");
@@ -36,7 +36,7 @@ describe("resolve latest version service", () => {
   it("should get specified latest version from first packument", async () => {
     const { resolveLatestVersion, fetchPackument } = makeDependencies();
     const packument = { "dist-tags": { latest: "1.0.0" } } as UnityPackument;
-    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(packument));
 
     const result = await resolveLatestVersion([exampleRegistry], somePackage)
       .promise;
@@ -49,7 +49,7 @@ describe("resolve latest version service", () => {
     const packument = {
       versions: { ["1.0.0"]: {} },
     } as unknown as UnityPackument;
-    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(packument));
 
     const result = await resolveLatestVersion([exampleRegistry], somePackage)
       .promise;
@@ -60,7 +60,7 @@ describe("resolve latest version service", () => {
   it("should fail if packument had no versions", async () => {
     const { resolveLatestVersion, fetchPackument } = makeDependencies();
     const packument = { versions: {} } as UnityPackument;
-    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(packument));
 
     const result = await resolveLatestVersion([exampleRegistry], somePackage)
       .promise;
@@ -73,8 +73,8 @@ describe("resolve latest version service", () => {
   it("should check all registries", async () => {
     const { resolveLatestVersion, fetchPackument } = makeDependencies();
     const packument = { "dist-tags": { latest: "1.0.0" } } as UnityPackument;
-    fetchPackument.mockReturnValueOnce(Ok(null).toAsyncResult());
-    fetchPackument.mockReturnValueOnce(Ok(packument).toAsyncResult());
+    fetchPackument.mockReturnValueOnce(AsyncOk(null));
+    fetchPackument.mockReturnValueOnce(AsyncOk(packument));
 
     const result = await resolveLatestVersion(
       [exampleRegistry, upstreamRegistry],

--- a/test/services/resolve-remote-packument-version.test.ts
+++ b/test/services/resolve-remote-packument-version.test.ts
@@ -1,6 +1,5 @@
 import { mockService } from "./service.mock";
 import { makeResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument-version";
-import { Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { Registry } from "../../src/domain/registry";
@@ -8,6 +7,7 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { buildPackument } from "../domain/data-packument";
 import { FetchPackument } from "../../src/io/packument-io";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 describe("resolve remote packument version", () => {
   const somePackage = makeDomainName("com.some.package");
@@ -27,7 +27,7 @@ describe("resolve remote packument version", () => {
   it("should fail if packument was not found", async () => {
     const { resolveRemovePackumentVersion, fetchPackument } =
       makeDependencies();
-    fetchPackument.mockReturnValue(Ok(null).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(null));
 
     const result = await resolveRemovePackumentVersion(
       somePackage,
@@ -48,7 +48,7 @@ describe("resolve remote packument version", () => {
         version.addDependency("com.other.package", "1.0.0")
       )
     );
-    fetchPackument.mockReturnValue(Ok(packument).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(packument));
 
     const result = await resolveRemovePackumentVersion(
       somePackage,

--- a/test/services/resolve-remote-packument.test.ts
+++ b/test/services/resolve-remote-packument.test.ts
@@ -6,8 +6,8 @@ import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { buildPackument } from "../domain/data-packument";
 import { mockService } from "./service.mock";
 import { FetchPackument } from "../../src/io/packument-io";
-import { Err, Ok } from "ts-results-es";
 import { GenericNetworkError } from "../../src/io/common-errors";
+import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 describe("resolve remove packument", () => {
   const exampleName = makeDomainName("com.some.package");
@@ -20,7 +20,7 @@ describe("resolve remove packument", () => {
 
   function makeDependencies() {
     const fetchPackument = mockService<FetchPackument>();
-    fetchPackument.mockReturnValue(Ok(examplePackument).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(examplePackument));
 
     const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
     return { resolveRemotePackument, fetchPackument } as const;
@@ -45,9 +45,7 @@ describe("resolve remove packument", () => {
   it("should find packument in first registry if possible", async () => {
     const { resolveRemotePackument, fetchPackument } = makeDependencies();
     fetchPackument.mockImplementation((registry) =>
-      Ok(
-        registry === exampleRegistryB ? examplePackument : null
-      ).toAsyncResult()
+      AsyncOk(registry === exampleRegistryB ? examplePackument : null)
     );
 
     const result = await resolveRemotePackument(exampleName, [
@@ -73,7 +71,7 @@ describe("resolve remove packument", () => {
 
   it("should be null if packument is not found in any registry", async () => {
     const { resolveRemotePackument, fetchPackument } = makeDependencies();
-    fetchPackument.mockReturnValue(Ok(null).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncOk(null));
 
     const result = await resolveRemotePackument(exampleName, [
       exampleRegistryA,
@@ -86,7 +84,7 @@ describe("resolve remove packument", () => {
   it("should fail if any packument fetch failed", async () => {
     const expected = new GenericNetworkError();
     const { resolveRemotePackument, fetchPackument } = makeDependencies();
-    fetchPackument.mockReturnValue(Err(expected).toAsyncResult());
+    fetchPackument.mockReturnValue(AsyncErr(expected));
 
     const result = await resolveRemotePackument(exampleName, [
       exampleRegistryA,

--- a/test/services/search-packages.test.ts
+++ b/test/services/search-packages.test.ts
@@ -7,10 +7,11 @@ import {
 import { makePackagesSearcher } from "../../src/services/search-packages";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { Err, Ok } from "ts-results-es";
+import { Err } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { GenericNetworkError } from "../../src/io/common-errors";
+import { AsyncOk } from "../../src/utils/result-utils";
 
 describe("search packages", () => {
   const exampleRegistry: Registry = {
@@ -35,12 +36,10 @@ describe("search packages", () => {
 
   function makeDependencies() {
     const searchRegistry = mockService<SearchRegistry>();
-    searchRegistry.mockReturnValue(Ok([exampleSearchResult]).toAsyncResult());
+    searchRegistry.mockReturnValue(AsyncOk([exampleSearchResult]));
 
     const fetchAllPackument = mockService<FetchAllPackuments>();
-    fetchAllPackument.mockReturnValue(
-      Ok(exampleAllPackumentsResult).toAsyncResult()
-    );
+    fetchAllPackument.mockReturnValue(AsyncOk(exampleAllPackumentsResult));
 
     const searchPackages = makePackagesSearcher(
       searchRegistry,


### PR DESCRIPTION
Writing `Ok(value).toAsyncResult()` is quite long. This change adds helper constructor functions for building async results. Both for ok and error results.