### PR TITLE
refactor: rename services

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -3,7 +3,7 @@ import {
   LoadProjectManifest,
   WriteProjectManifest,
 } from "../io/project-manifest-io";
-import { ParseEnvService } from "../services/parse-env";
+import { ParseEnv } from "../services/parse-env";
 import {
   compareEditorVersion,
   stringifyEditorVersion,
@@ -36,9 +36,9 @@ import { Err, Ok, Result } from "ts-results-es";
 import { CustomError } from "ts-custom-error";
 import {
   DependencyResolveError,
-  ResolveDependenciesService,
+  ResolveDependencies,
 } from "../services/dependency-resolving";
-import { ResolveRemotePackumentVersionService } from "../services/resolve-remote-packument-version";
+import { ResolveRemotePackumentVersion } from "../services/resolve-remote-packument-version";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
 import { unityRegistryUrl } from "../domain/registry-url";
@@ -111,9 +111,9 @@ type AddCmd = (
  * Makes a {@link AddCmd} function.
  */
 export function makeAddCmd(
-  parseEnv: ParseEnvService,
-  resolveRemotePackumentVersion: ResolveRemotePackumentVersionService,
-  resolveDependencies: ResolveDependenciesService,
+  parseEnv: ParseEnv,
+  resolveRemotePackumentVersion: ResolveRemotePackumentVersion,
+  resolveDependencies: ResolveDependencies,
   loadProjectManifest: LoadProjectManifest,
   writeProjectManifest: WriteProjectManifest,
   determineEditorVersion: DetermineEditorVersion,

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -1,4 +1,4 @@
-import { ParseEnvService } from "../services/parse-env";
+import { ParseEnv } from "../services/parse-env";
 import { isPackageUrl } from "../domain/package-url";
 import {
   makePackageReference,
@@ -8,7 +8,7 @@ import {
 import { CmdOptions } from "./options";
 import { PackumentVersionResolveError } from "../packument-version-resolving";
 import { PackumentNotFoundError } from "../common-errors";
-import { ResolveDependenciesService } from "../services/dependency-resolving";
+import { ResolveDependencies } from "../services/dependency-resolving";
 import { Logger } from "npmlog";
 import { logValidDependency } from "./dependency-logging";
 import { VersionNotFoundError } from "../domain/packument";
@@ -49,8 +49,8 @@ function errorPrefixForError(error: PackumentVersionResolveError): string {
  * Makes a {@link DepsCmd} function.
  */
 export function makeDepsCmd(
-  parseEnv: ParseEnvService,
-  resolveDependencies: ResolveDependenciesService,
+  parseEnv: ParseEnv,
+  resolveDependencies: ResolveDependencies,
   log: Logger,
   debugLog: DebugLog
 ): DepsCmd {

--- a/src/cli/cmd-login.ts
+++ b/src/cli/cmd-login.ts
@@ -1,5 +1,5 @@
 import { GetUpmConfigPath } from "../io/upm-config-io";
-import { ParseEnvService } from "../services/parse-env";
+import { ParseEnv } from "../services/parse-env";
 import { coerceRegistryUrl } from "../domain/registry-url";
 import {
   promptEmail,
@@ -9,7 +9,7 @@ import {
 } from "./prompts";
 import { CmdOptions } from "./options";
 import { Logger } from "npmlog";
-import { LoginService } from "../services/login";
+import { Login } from "../services/login";
 import { ResultCodes } from "./result-codes";
 import { RegistryAuthenticationError } from "../io/common-errors";
 import { notifyEnvParsingFailed } from "./error-logging";
@@ -42,9 +42,9 @@ export type LoginCmd = (options: LoginOptions) => Promise<LoginResultCode>;
  * Makes a {@link LoginCmd} function.
  */
 export function makeLoginCmd(
-  parseEnv: ParseEnvService,
+  parseEnv: ParseEnv,
   getUpmConfigPath: GetUpmConfigPath,
-  login: LoginService,
+  login: Login,
   log: Logger
 ): LoginCmd {
   return async (options) => {

--- a/src/cli/cmd-remove.ts
+++ b/src/cli/cmd-remove.ts
@@ -2,7 +2,7 @@ import {
   ManifestLoadError,
   ManifestWriteError,
 } from "../io/project-manifest-io";
-import { EnvParseError, ParseEnvService } from "../services/parse-env";
+import { EnvParseError, ParseEnv } from "../services/parse-env";
 import { makePackageReference } from "../domain/package-reference";
 import { CmdOptions } from "./options";
 
@@ -47,7 +47,7 @@ export type RemoveCmd = (
  * Makes a {@link RemoveCmd} function.
  */
 export function makeRemoveCmd(
-  parseEnv: ParseEnvService,
+  parseEnv: ParseEnv,
   removePackages: RemovePackages,
   log: Logger
 ): RemoveCmd {

--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -1,5 +1,5 @@
 import * as os from "os";
-import { ParseEnvService } from "../services/parse-env";
+import { ParseEnv } from "../services/parse-env";
 import { CmdOptions } from "./options";
 import { formatAsTable } from "./output-formatting";
 import { Logger } from "npmlog";
@@ -29,7 +29,7 @@ export type SearchCmd = (
  * Makes a {@link SearchCmd} function.
  */
 export function makeSearchCmd(
-  parseEnv: ParseEnvService,
+  parseEnv: ParseEnv,
   searchPackages: SearchPackages,
   log: Logger,
   debugLog: DebugLog

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import assert from "assert";
 import { tryGetLatestVersion, UnityPackument } from "../domain/packument";
-import { ParseEnvService } from "../services/parse-env";
+import { ParseEnv } from "../services/parse-env";
 import {
   hasVersion,
   PackageReference,
@@ -104,7 +104,7 @@ const printInfo = function (packument: UnityPackument) {
  * Makes a {@link ViewCmd} function.
  */
 export function makeViewCmd(
-  parseEnv: ParseEnvService,
+  parseEnv: ParseEnv,
   resolveRemotePackument: ResolveRemotePackument,
   log: Logger
 ): ViewCmd {

--- a/src/io/all-packuments-io.ts
+++ b/src/io/all-packuments-io.ts
@@ -36,9 +36,7 @@ export type FetchAllPackuments = (
 /**
  * Makes a {@link FetchAllPackuments} function.
  */
-export function makeAllPackumentsFetcher(
-  debugLog: DebugLog
-): FetchAllPackuments {
+export function makeFetchAllPackuments(debugLog: DebugLog): FetchAllPackuments {
   return (registry) => {
     return new AsyncResult(
       npmFetch

--- a/src/io/builtin-packages.ts
+++ b/src/io/builtin-packages.ts
@@ -45,7 +45,7 @@ export type FindBuiltInPackages = (
 /**
  * Makes a {@link FindBuiltInPackages} function.
  */
-export function makeBuiltInPackagesFinder(
+export function makeFindBuiltInPackages(
   debugLog: DebugLog
 ): FindBuiltInPackages {
   return (editorVersion) => {

--- a/src/io/fs-result.ts
+++ b/src/io/fs-result.ts
@@ -28,7 +28,7 @@ export type ReadTextFile = (
 /**
  * Makes a {@link ReadTextFile} function.
  */
-export function makeTextReader(debugLog: DebugLog): ReadTextFile {
+export function makeReadText(debugLog: DebugLog): ReadTextFile {
   return (path) =>
     resultifyFsOp(debugLog, () => fs.readFile(path, { encoding: "utf8" }));
 }
@@ -47,7 +47,7 @@ export type WriteTextFile = (
 /**
  * Makes a {@link WriteTextFile} function.
  */
-export function makeTextWriter(debugLog: DebugLog): WriteTextFile {
+export function makeWriteText(debugLog: DebugLog): WriteTextFile {
   return (filePath, content) => {
     const dirPath = path.dirname(filePath);
     return resultifyFsOp(debugLog, () => fse.ensureDir(dirPath)).andThen(() =>

--- a/src/io/npm-search.ts
+++ b/src/io/npm-search.ts
@@ -55,7 +55,7 @@ export const getNpmFetchOptions = function (
 /**
  * Makes a {@link SearchRegistry} function.
  */
-export function makeRegistrySearcher(debugLog: DebugLog): SearchRegistry {
+export function makeSearchRegistry(debugLog: DebugLog): SearchRegistry {
   return (registry, keyword) => {
     return new AsyncResult(
       npmSearch(keyword, getNpmFetchOptions(registry))

--- a/src/io/npmrc-io.ts
+++ b/src/io/npmrc-io.ts
@@ -21,7 +21,7 @@ export type FindNpmrcPath = () => Result<string, FindNpmrcError>;
 /**
  * Makes a {@link FindNpmrcPath} function.
  */
-export function makeNpmrcPathFinder(getHomePath: GetHomePath): FindNpmrcPath {
+export function makeFindNpmrcPath(getHomePath: GetHomePath): FindNpmrcPath {
   return () => getHomePath().map((homePath) => path.join(homePath, ".npmrc"));
 }
 
@@ -42,7 +42,7 @@ export type LoadNpmrc = (
 /**
  * Makes a {@link LoadNpmrc} function.
  */
-export function makeNpmrcLoader(readFile: ReadTextFile): LoadNpmrc {
+export function makeLoadNpmrc(readFile: ReadTextFile): LoadNpmrc {
   return (path) =>
     readFile(path)
       .map<Npmrc | null>((content) => content.split(EOL))
@@ -69,7 +69,7 @@ export type SaveNpmrc = (
 /**
  * Makes a {@link SaveNpmrc} function.
  */
-export function makeNpmrcSaver(writeFile: WriteTextFile): SaveNpmrc {
+export function makeSaveNpmrc(writeFile: WriteTextFile): SaveNpmrc {
   return (path, npmrc) => {
     const content = npmrc.join(EOL);
     return writeFile(path, content).mapErr(() => new GenericIOError("Write"));

--- a/src/io/packument-io.ts
+++ b/src/io/packument-io.ts
@@ -30,7 +30,7 @@ export type FetchPackument = (
 /**
  * Makes a {@link FetchPackument} function.
  */
-export function makePackumentFetcher(
+export function makeFetchPackument(
   registryClient: RegClient.Instance
 ): FetchPackument {
   return (registry, name) => {

--- a/src/io/project-manifest-io.ts
+++ b/src/io/project-manifest-io.ts
@@ -71,7 +71,7 @@ export type LoadProjectManifest = (
 /**
  * Makes a {@link LoadProjectManifest} function.
  */
-export function makeProjectManifestLoader(
+export function makeLoadProjectManifest(
   readFile: ReadTextFile
 ): LoadProjectManifest {
   return (projectPath) => {
@@ -110,7 +110,7 @@ export type WriteProjectManifest = (
 /**
  * Makes a {@link WriteProjectManifest} function.
  */
-export function makeProjectManifestWriter(
+export function makeWriteProjectManifest(
   writeFile: WriteTextFile
 ): WriteProjectManifest {
   return (projectPath, manifest) => {

--- a/src/io/project-version-io.ts
+++ b/src/io/project-version-io.ts
@@ -63,7 +63,7 @@ export type LoadProjectVersion = (
 /**
  * Makes a {@link LoadProjectVersion} function.
  */
-export function makeProjectVersionLoader(
+export function makeLoadProjectVersion(
   readFile: ReadTextFile
 ): LoadProjectVersion {
   return (projectDirPath) => {

--- a/src/io/special-paths.ts
+++ b/src/io/special-paths.ts
@@ -60,7 +60,7 @@ export type GetHomePath = () => Result<string, GetHomePathError>;
 /**
  * Makes a {@link GetHomePath} function.
  */
-export function makeHomePathGetter(): GetHomePath {
+export function makeGetHomePath(): GetHomePath {
   return () => {
     const homePath = tryGetEnv("USERPROFILE") ?? tryGetEnv("HOME");
     if (homePath === null)
@@ -125,6 +125,6 @@ export type GetCwd = () => string;
 /**
  * Makes a {@link GetCwd} function.
  */
-export function makeCwdGetter(): GetCwd {
+export function makeGetCwd(): GetCwd {
   return process.cwd;
 }

--- a/src/io/upm-config-io.ts
+++ b/src/io/upm-config-io.ts
@@ -46,7 +46,7 @@ export type GetUpmConfigPath = (
 /**
  * Makes a {@link GetUpmConfigPath} function.
  */
-export function makeUpmConfigPathGetter(
+export function makeGetUpmConfigPath(
   getHomePath: GetHomePath
 ): GetUpmConfigPath {
   function getConfigDirectory(wsl: boolean, systemUser: boolean) {
@@ -96,7 +96,7 @@ export type LoadUpmConfig = (
 /**
  * Makes a {@link LoadUpmConfig} function.
  */
-export function makeUpmConfigLoader(readFile: ReadTextFile): LoadUpmConfig {
+export function makeLoadUpmConfig(readFile: ReadTextFile): LoadUpmConfig {
   return (configFilePath) =>
     readFile(configFilePath)
       .andThen(tryParseToml)

--- a/src/services/dependency-resolving.ts
+++ b/src/services/dependency-resolving.ts
@@ -11,14 +11,14 @@ import {
 import { RegistryUrl } from "../domain/registry-url";
 import { Registry } from "../domain/registry";
 import {
+  ResolveRemotePackumentVersion,
   ResolveRemotePackumentVersionError,
-  ResolveRemotePackumentVersionService,
 } from "./resolve-remote-packument-version";
 import { areArraysEqual } from "../utils/array-utils";
 import { dependenciesOf } from "../domain/package-manifest";
 import {
+  ResolveLatestVersion,
   ResolveLatestVersionError,
-  ResolveLatestVersionService,
 } from "./resolve-latest-version";
 import { Err, Ok, Result } from "ts-results-es";
 import { PackumentNotFoundError } from "../common-errors";
@@ -72,13 +72,13 @@ export type DependencyResolveError =
   | FetchPackumentError;
 
 /**
- * Service function for resolving all dependencies for a package.
+ * Function for resolving all dependencies for a package.
  * @param sources Sources from which dependencies can be resolved.
  * @param name The name of the package.
  * @param version The version for which to search dependencies.
  * @param deep Whether to search for all dependencies.
  */
-export type ResolveDependenciesService = (
+export type ResolveDependencies = (
   sources: ReadonlyArray<Registry>,
   name: DomainName,
   version: SemanticVersion | "latest" | undefined,
@@ -88,12 +88,12 @@ export type ResolveDependenciesService = (
 >;
 
 /**
- * Makes a {@link ResolveDependenciesService} function.
+ * Makes a {@link ResolveDependencies} function.
  */
-export function makeResolveDependenciesService(
-  resolveRemovePackumentVersion: ResolveRemotePackumentVersionService,
-  resolveLatestVersion: ResolveLatestVersionService
-): ResolveDependenciesService {
+export function makeResolveDependency(
+  resolveRemovePackumentVersion: ResolveRemotePackumentVersion,
+  resolveLatestVersion: ResolveLatestVersion
+): ResolveDependencies {
   // TODO: Add tests for this service
 
   return async (sources, name, version, deep) => {

--- a/src/services/determine-editor-version.ts
+++ b/src/services/determine-editor-version.ts
@@ -27,7 +27,7 @@ export type DetermineEditorVersion = (
 /**
  * Makes a {@link DetermineEditorVersion} function.
  */
-export function makeEditorVersionDeterminer(
+export function makeDetermineEditorVersion(
   loadProjectVersion: LoadProjectVersion
 ): DetermineEditorVersion {
   return (projectPath) => {

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -2,8 +2,8 @@ import { AsyncResult } from "ts-results-es";
 import { BasicAuth, encodeBasicAuth, TokenAuth } from "../domain/upm-config";
 import { RegistryUrl } from "../domain/registry-url";
 import { SaveAuthToUpmConfig, UpmAuthStoreError } from "./upm-auth";
-import { NpmLoginError, NpmLoginService } from "./npm-login";
-import { AuthNpmrcService, NpmrcAuthTokenUpdateError } from "./npmrc-auth";
+import { NpmLogin, NpmLoginError } from "./npm-login";
+import { AuthNpmrc, NpmrcAuthTokenUpdateError } from "./npmrc-auth";
 import { DebugLog } from "../logging";
 
 /**
@@ -31,7 +31,7 @@ export type LoginError =
  * @param onNpmrcUpdated Callback that notifies when the .npmrc file was
  * updated. Only called with token-based authentication.
  */
-export type LoginService = (
+export type Login = (
   username: string,
   password: string,
   email: string,
@@ -42,14 +42,14 @@ export type LoginService = (
 ) => AsyncResult<void, LoginError>;
 
 /**
- * Makes a {@link LoginService} function.
+ * Makes a {@link Login} function.
  */
-export function makeLoginService(
+export function makeLogin(
   saveAuthToUpmConfig: SaveAuthToUpmConfig,
-  npmLogin: NpmLoginService,
-  authNpmrc: AuthNpmrcService,
+  npmLogin: NpmLogin,
+  authNpmrc: AuthNpmrc,
   debugLog: DebugLog
-): LoginService {
+): Login {
   return (
     username,
     password,

--- a/src/services/npm-login.ts
+++ b/src/services/npm-login.ts
@@ -18,14 +18,14 @@ export type NpmLoginError = GenericNetworkError | RegistryAuthenticationError;
 type AuthenticationToken = string;
 
 /**
- * Service function for authenticating users with a npm registry.
+ * Function for authenticating users with a npm registry.
  * @param registryUrl The url of the registry into which to login.
  * @param username The username with which to login.
  * @param email The email with which to login.
  * @param password The password with which to login.
  * @returns An authentication token or null if registration failed.
  */
-export type NpmLoginService = (
+export type NpmLogin = (
   registryUrl: RegistryUrl,
   username: string,
   email: string,
@@ -33,12 +33,12 @@ export type NpmLoginService = (
 ) => AsyncResult<AuthenticationToken, NpmLoginError>;
 
 /**
- * Makes a new {@link NpmLoginService} function.
+ * Makes a new {@link NpmLogin} function.
  */
-export function makeNpmLoginService(
+export function makeNpmLogin(
   registryClient: RegClient.Instance,
   debugLog: DebugLog
-): NpmLoginService {
+): NpmLogin {
   return (registryUrl, username, email, password) => {
     return new AsyncResult(
       new Promise((resolve) => {

--- a/src/services/npmrc-auth.ts
+++ b/src/services/npmrc-auth.ts
@@ -19,22 +19,22 @@ export type NpmrcAuthTokenUpdateError =
   | NpmrcSaveError;
 
 /**
- * Service function for updating the user-wide npm-auth token inside a users
+ * Function for updating the user-wide npm-auth token inside a users
  * npmrc file.
  * @param registry The registry for which to set the auth token.
  * @param token The auth token.
  * @returns The path of the file to which the token was ultimately saved.
  */
-export type AuthNpmrcService = (
+export type AuthNpmrc = (
   registry: RegistryUrl,
   token: string
 ) => AsyncResult<string, NpmrcAuthTokenUpdateError>;
 
-export function makeAuthNpmrcService(
+export function makeAuthNpmrc(
   findPath: FindNpmrcPath,
   loadNpmrc: LoadNpmrc,
   saveNpmrc: SaveNpmrc
-): AuthNpmrcService {
+): AuthNpmrc {
   return (registry, token) => {
     // read config
     return findPath()

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -27,22 +27,22 @@ export type Env = Readonly<{
 export type EnvParseError = GetUpmConfigPathError | UpmConfigLoadError;
 
 /**
- * Service function for parsing environment information and global
+ * Function for parsing environment information and global
  * command-options for further usage.
  */
-export type ParseEnvService = (
+export type ParseEnv = (
   options: CmdOptions
 ) => Promise<Result<Env, EnvParseError>>;
 
 /**
- * Creates a {@link ParseEnvService} function.
+ * Creates a {@link ParseEnv} function.
  */
-export function makeParseEnvService(
+export function makeParseEnv(
   log: Logger,
   getUpmConfigPath: GetUpmConfigPath,
   loadUpmConfig: LoadUpmConfig,
   getCwd: GetCwd
-): ParseEnvService {
+): ParseEnv {
   function determineCwd(options: CmdOptions): string {
     return options._global.chdir !== undefined
       ? path.resolve(options._global.chdir)

--- a/src/services/remove-packages.ts
+++ b/src/services/remove-packages.ts
@@ -29,7 +29,7 @@ export type RemovePackages = (
   packageNames: ReadonlyArray<DomainName>
 ) => AsyncResult<ReadonlyArray<RemovedPackage>, RemovePackagesError>;
 
-export function makePackageRemover(
+export function makeRemovePackages(
   loadProjectManifest: LoadProjectManifest,
   writeProjectManifest: WriteProjectManifest
 ): RemovePackages {

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -20,18 +20,15 @@ export type ResolveLatestVersionError =
  * @param sources All sources to check for the package.
  * @param packageName The name of the package to search.
  */
-export type ResolveLatestVersionService = (
+export type ResolveLatestVersion = (
   sources: ReadonlyArray<Registry>,
   packageName: DomainName
 ) => AsyncResult<SemanticVersion, ResolveLatestVersionError>;
 
-export function makeResolveLatestVersionService(
+export function makeResolveLatestVersion(
   fetchPackument: FetchPackument
-): ResolveLatestVersionService {
-  const resolveLatestVersion: ResolveLatestVersionService = (
-    sources,
-    packageName
-  ) => {
+): ResolveLatestVersion {
+  const resolveLatestVersion: ResolveLatestVersion = (sources, packageName) => {
     if (sources.length === 0)
       return Err(new PackumentNotFoundError(packageName)).toAsyncResult();
 

--- a/src/services/resolve-remote-packument-version.ts
+++ b/src/services/resolve-remote-packument-version.ts
@@ -18,23 +18,23 @@ export type ResolveRemotePackumentVersionError =
   | FetchPackumentError;
 
 /**
- * Service function for resolving remove packument versions.
+ * Function for resolving remove packument versions.
  * @param packageName The name of the package to resolve.
  * @param requestedVersion The version that should be resolved.
  * @param source The registry to resolve the packument from.
  */
-export type ResolveRemotePackumentVersionService = (
+export type ResolveRemotePackumentVersion = (
   packageName: DomainName,
   requestedVersion: ResolvableVersion,
   source: Registry
 ) => AsyncResult<ResolvedPackumentVersion, ResolveRemotePackumentVersionError>;
 
 /**
- * Makes a {@link ResolveRemotePackumentVersionService} function.
+ * Makes a {@link ResolveRemotePackumentVersion} function.
  */
-export function makeResolveRemotePackumentVersionService(
+export function makeResolveRemotePackumentVersion(
   fetchPackument: FetchPackument
-): ResolveRemotePackumentVersionService {
+): ResolveRemotePackumentVersion {
   return (packageName, requestedVersion, source) =>
     fetchPackument(source, packageName)
       .andThen((maybePackument) => {

--- a/src/services/resolve-remote-packument.ts
+++ b/src/services/resolve-remote-packument.ts
@@ -54,7 +54,7 @@ function withSource(
 /**
  * Makes a {@link ResolveRemotePackument} function.
  */
-export function makeRemotePackumentResolver(
+export function makeResolveRemotePackument(
   fetchPackument: FetchPackument
 ): ResolveRemotePackument {
   function tryResolveFrom(source: Registry, packageName: DomainName) {

--- a/src/services/search-packages.ts
+++ b/src/services/search-packages.ts
@@ -33,7 +33,7 @@ export type SearchPackages = (
 /**
  * Makes a {@licence SearchPackages} function.
  */
-export function makePackagesSearcher(
+export function makeSearchPackages(
   searchRegistry: SearchRegistry,
   fetchAllPackuments: FetchAllPackuments
 ): SearchPackages {

--- a/src/services/upm-auth.ts
+++ b/src/services/upm-auth.ts
@@ -15,7 +15,7 @@ import { GenericIOError } from "../io/common-errors";
 export type UpmAuthStoreError = UpmConfigLoadError | GenericIOError;
 
 /**
- * Service function for storing authentication information in an upmconfig file.
+ * Function for storing authentication information in an upmconfig file.
  * @param configPath Path to the upmconfig file.
  * @param registry Url of the registry for which to authenticate.
  * @param auth Authentication information.
@@ -29,7 +29,7 @@ export type SaveAuthToUpmConfig = (
 /**
  * Makes a {@link SaveAuthToUpmConfig} function.
  */
-export function makeSaveAuthToUpmConfigService(
+export function makeSaveAuthToUpmConfig(
   loadUpmConfig: LoadUpmConfig,
   writeFile: WriteTextFile
 ): SaveAuthToUpmConfig {

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -1,6 +1,6 @@
 import { makeAddCmd } from "../../src/cli/cmd-add";
 import { makeDomainName } from "../../src/domain/domain-name";
-import { Env, ParseEnvService } from "../../src/services/parse-env";
+import { Env, ParseEnv } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { makeEditorVersion } from "../../src/domain/editor-version";
@@ -13,10 +13,10 @@ import { makeMockLogger } from "./log.mock";
 import { buildPackument } from "../domain/data-packument";
 import { mockResolvedPackuments } from "../services/packument-resolving.mock";
 import { buildProjectManifest } from "../domain/data-project-manifest";
-import { ResolveDependenciesService } from "../../src/services/dependency-resolving";
+import { ResolveDependencies } from "../../src/services/dependency-resolving";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { mockService } from "../services/service.mock";
-import { ResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument-version";
+import { ResolveRemotePackumentVersion } from "../../src/services/resolve-remote-packument-version";
 import {
   LoadProjectManifest,
   WriteProjectManifest,
@@ -59,18 +59,18 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv = mockService<ParseEnvService>();
+  const parseEnv = mockService<ParseEnv>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
   const resolveRemovePackumentVersion =
-    mockService<ResolveRemotePackumentVersionService>();
+    mockService<ResolveRemotePackumentVersion>();
   mockResolvedPackuments(
     resolveRemovePackumentVersion,
     [exampleRegistryUrl, somePackument],
     [exampleRegistryUrl, otherPackument]
   );
 
-  const resolveDependencies = mockService<ResolveDependenciesService>();
+  const resolveDependencies = mockService<ResolveDependencies>();
   resolveDependencies.mockResolvedValue(
     Ok([
       [

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -1,5 +1,5 @@
 import { makeDepsCmd } from "../../src/cli/cmd-deps";
-import { Env, ParseEnvService } from "../../src/services/parse-env";
+import { Env, ParseEnv } from "../../src/services/parse-env";
 import { Err, Ok } from "ts-results-es";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
@@ -8,7 +8,7 @@ import { makePackageReference } from "../../src/domain/package-reference";
 import { makeMockLogger } from "./log.mock";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { PackumentNotFoundError } from "../../src/common-errors";
-import { ResolveDependenciesService } from "../../src/services/dependency-resolving";
+import { ResolveDependencies } from "../../src/services/dependency-resolving";
 import { mockService } from "../services/service.mock";
 import { VersionNotFoundError } from "../../src/domain/packument";
 import { noopLogger } from "../../src/logging";
@@ -24,10 +24,10 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv = mockService<ParseEnvService>();
+  const parseEnv = mockService<ParseEnv>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
-  const resolveDependencies = mockService<ResolveDependenciesService>();
+  const resolveDependencies = mockService<ResolveDependencies>();
   resolveDependencies.mockResolvedValue(
     Ok([
       [

--- a/test/cli/cmd-login.test.ts
+++ b/test/cli/cmd-login.test.ts
@@ -1,12 +1,12 @@
 import { Err, Ok } from "ts-results-es";
 import { makeLoginCmd } from "../../src/cli/cmd-login";
 import { mockService } from "../services/service.mock";
-import { Env, ParseEnvService } from "../../src/services/parse-env";
+import { Env, ParseEnv } from "../../src/services/parse-env";
 import {
   GetUpmConfigPath,
   RequiredEnvMissingError,
 } from "../../src/io/upm-config-io";
-import { LoginService } from "../../src/services/login";
+import { Login } from "../../src/services/login";
 import { makeMockLogger } from "./log.mock";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
@@ -30,13 +30,13 @@ const exampleUpmConfigPath = "/user/home/.upmconfig.toml";
 
 describe("cmd-login", () => {
   function makeDependencies() {
-    const parseEnv = mockService<ParseEnvService>();
+    const parseEnv = mockService<ParseEnv>();
     parseEnv.mockResolvedValue(Ok(defaultEnv));
 
     const getUpmConfigPath = mockService<GetUpmConfigPath>();
     getUpmConfigPath.mockReturnValue(AsyncOk(exampleUpmConfigPath));
 
-    const login = mockService<LoginService>();
+    const login = mockService<Login>();
     login.mockReturnValue(AsyncOk());
 
     const log = makeMockLogger();

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -1,5 +1,5 @@
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { Env, ParseEnvService } from "../../src/services/parse-env";
+import { Env, ParseEnv } from "../../src/services/parse-env";
 import { makeRemoveCmd } from "../../src/cli/cmd-remove";
 import { Err, Ok } from "ts-results-es";
 import { makeDomainName } from "../../src/domain/domain-name";
@@ -18,7 +18,7 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv = mockService<ParseEnvService>();
+  const parseEnv = mockService<ParseEnv>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
   const removePackages = mockService<RemovePackages>();

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -5,7 +5,7 @@ import { makeMockLogger } from "./log.mock";
 import { SearchedPackument } from "../../src/io/npm-search";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Ok } from "ts-results-es";
-import { Env, ParseEnvService } from "../../src/services/parse-env";
+import { Env, ParseEnv } from "../../src/services/parse-env";
 import { mockService } from "../services/service.mock";
 import { SearchPackages } from "../../src/services/search-packages";
 import { noopLogger } from "../../src/logging";
@@ -22,7 +22,7 @@ const exampleSearchResult: SearchedPackument = {
 };
 
 function makeDependencies() {
-  const parseEnv = mockService<ParseEnvService>();
+  const parseEnv = mockService<ParseEnv>();
   parseEnv.mockResolvedValue(
     Ok({ registry: { url: exampleRegistryUrl, auth: null } } as Env)
   );

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -1,5 +1,5 @@
 import { makeViewCmd } from "../../src/cli/cmd-view";
-import { Env, ParseEnvService } from "../../src/services/parse-env";
+import { Env, ParseEnv } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { Err, Ok } from "ts-results-es";
@@ -55,7 +55,7 @@ const defaultEnv = {
 } as Env;
 
 function makeDependencies() {
-  const parseEnv = mockService<ParseEnvService>();
+  const parseEnv = mockService<ParseEnv>();
   parseEnv.mockResolvedValue(Ok(defaultEnv));
 
   const resolveRemotePackument = mockService<ResolveRemotePackument>();

--- a/test/io/all-packuments-io.test.ts
+++ b/test/io/all-packuments-io.test.ts
@@ -1,5 +1,5 @@
 import npmFetch from "npm-registry-fetch";
-import { makeAllPackumentsFetcher } from "../../src/io/all-packuments-io";
+import { makeFetchAllPackuments } from "../../src/io/all-packuments-io";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
@@ -17,7 +17,7 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const getAllPackuments = makeAllPackumentsFetcher(noopLogger);
+  const getAllPackuments = makeFetchAllPackuments(noopLogger);
   return { getAllPackuments } as const;
 }
 

--- a/test/io/builtin-packages.test.ts
+++ b/test/io/builtin-packages.test.ts
@@ -4,7 +4,7 @@ import * as fileIo from "../../src/io/fs-result";
 import { Err, Ok } from "ts-results-es";
 import {
   EditorNotInstalledError,
-  makeBuiltInPackagesFinder,
+  makeFindBuiltInPackages,
 } from "../../src/io/builtin-packages";
 import { makeEditorVersion } from "../../src/domain/editor-version";
 import { noopLogger } from "../../src/logging";
@@ -12,7 +12,7 @@ import { enoentError } from "./node-error.mock";
 import { AsyncErr, AsyncOk } from "../../src/utils/result-utils";
 
 function makeDependencies() {
-  const getBuiltInPackages = makeBuiltInPackagesFinder(noopLogger);
+  const getBuiltInPackages = makeFindBuiltInPackages(noopLogger);
   return { getBuiltInPackages } as const;
 }
 

--- a/test/io/fs-result.test.ts
+++ b/test/io/fs-result.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import {
-  makeTextReader,
-  makeTextWriter,
+  makeReadText,
+  makeWriteText,
   tryGetDirectoriesIn,
 } from "../../src/io/fs-result";
 import fse from "fs-extra";
@@ -12,7 +12,7 @@ import { makeNodeError } from "./node-error.mock";
 describe("fs-result", () => {
   describe("read text", () => {
     function makeDependencies() {
-      const readFile = makeTextReader(noopLogger);
+      const readFile = makeReadText(noopLogger);
 
       return { readFile } as const;
     }
@@ -40,7 +40,7 @@ describe("fs-result", () => {
 
   describe("write text", () => {
     function makeDependencies() {
-      const writeFile = makeTextWriter(noopLogger);
+      const writeFile = makeWriteText(noopLogger);
 
       return { writeFile } as const;
     }

--- a/test/io/npm-search.test.ts
+++ b/test/io/npm-search.test.ts
@@ -1,7 +1,7 @@
 import npmSearch from "libnpmsearch";
 import search from "libnpmsearch";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { makeRegistrySearcher } from "../../src/io/npm-search";
+import { makeSearchRegistry } from "../../src/io/npm-search";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { noopLogger } from "../../src/logging";
@@ -18,7 +18,7 @@ const exampleRegistry: Registry = {
 };
 
 function makeDependencies() {
-  const searchRegistry = makeRegistrySearcher(noopLogger);
+  const searchRegistry = makeSearchRegistry(noopLogger);
   return { searchRegistry } as const;
 }
 

--- a/test/io/npmrc-io.test.ts
+++ b/test/io/npmrc-io.test.ts
@@ -2,9 +2,9 @@ import { ReadTextFile, WriteTextFile } from "../../src/io/fs-result";
 import { AsyncResult, Err, Ok } from "ts-results-es";
 import { EOL } from "node:os";
 import {
-  makeNpmrcLoader,
-  makeNpmrcPathFinder,
-  makeNpmrcSaver,
+  makeLoadNpmrc,
+  makeFindNpmrcPath,
+  makeSaveNpmrc,
 } from "../../src/io/npmrc-io";
 import path from "path";
 import { GetHomePath } from "../../src/io/special-paths";
@@ -18,7 +18,7 @@ describe("npmrc-io", () => {
     function makeDependencies() {
       const getHomePath = mockService<GetHomePath>();
 
-      const findPath = makeNpmrcPathFinder(getHomePath);
+      const findPath = makeFindNpmrcPath(getHomePath);
 
       return { findPath, getHomePath } as const;
     }
@@ -48,7 +48,7 @@ describe("npmrc-io", () => {
     function makeDependencies() {
       const readText = mockService<ReadTextFile>();
 
-      const loadNpmrc = makeNpmrcLoader(readText);
+      const loadNpmrc = makeLoadNpmrc(readText);
       return { loadNpmrc, readText } as const;
     }
 
@@ -80,7 +80,7 @@ describe("npmrc-io", () => {
       const writeFile = mockService<WriteTextFile>();
       writeFile.mockReturnValue(new AsyncResult(Ok(undefined)));
 
-      const saveNpmrc = makeNpmrcSaver(writeFile);
+      const saveNpmrc = makeSaveNpmrc(writeFile);
       return { saveNpmrc, writeFile } as const;
     }
 

--- a/test/io/packument-io.test.ts
+++ b/test/io/packument-io.test.ts
@@ -5,7 +5,7 @@ import RegClient from "another-npm-registry-client";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { mockRegClientGetResult } from "../services/registry-client.mock";
-import { makePackumentFetcher } from "../../src/io/packument-io";
+import { makeFetchPackument } from "../../src/io/packument-io";
 
 describe("packument io", () => {
   describe("fetch", () => {
@@ -21,7 +21,7 @@ describe("packument io", () => {
         get: jest.fn(),
       };
 
-      const fetchPackument = makePackumentFetcher(regClient);
+      const fetchPackument = makeFetchPackument(regClient);
       return { fetchPackument, regClient } as const;
     }
     it("should get existing packument", async () => {

--- a/test/io/project-manifest-io.test.ts
+++ b/test/io/project-manifest-io.test.ts
@@ -1,6 +1,6 @@
 import {
-  makeProjectManifestLoader,
-  makeProjectManifestWriter,
+  makeLoadProjectManifest,
+  makeWriteProjectManifest,
   manifestPathFor,
 } from "../../src/io/project-manifest-io";
 import {
@@ -37,7 +37,7 @@ describe("project-manifest io", () => {
     function makeDependencies() {
       const readFile = mockService<ReadTextFile>();
 
-      const loadProjectManifest = makeProjectManifestLoader(readFile);
+      const loadProjectManifest = makeLoadProjectManifest(readFile);
       return { loadProjectManifest, readFile } as const;
     }
 
@@ -97,7 +97,7 @@ describe("project-manifest io", () => {
       const writeFile = mockService<WriteTextFile>();
       writeFile.mockReturnValue(AsyncOk());
 
-      const writeProjectManifest = makeProjectManifestWriter(writeFile);
+      const writeProjectManifest = makeWriteProjectManifest(writeFile);
       return { writeProjectManifest, writeFile } as const;
     }
 

--- a/test/io/project-version-io.test.ts
+++ b/test/io/project-version-io.test.ts
@@ -1,7 +1,7 @@
 import { ReadTextFile } from "../../src/io/fs-result";
 import { StringFormatError } from "../../src/utils/string-parsing";
 import { mockService } from "../services/service.mock";
-import { makeProjectVersionLoader } from "../../src/io/project-version-io";
+import { makeLoadProjectVersion } from "../../src/io/project-version-io";
 import { eaccesError, enoentError } from "./node-error.mock";
 import {
   FileMissingError,
@@ -15,7 +15,7 @@ describe("project-version-io", () => {
     function makeDependencies() {
       const readFile = mockService<ReadTextFile>();
 
-      const loadProjectVersion = makeProjectVersionLoader(readFile);
+      const loadProjectVersion = makeLoadProjectVersion(readFile);
 
       return { loadProjectVersion, readFile } as const;
     }

--- a/test/io/special-paths.test.ts
+++ b/test/io/special-paths.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { tryGetEnv } from "../../src/utils/env-util";
 import {
-  makeHomePathGetter,
+  makeGetHomePath,
   OSNotSupportedError,
   tryGetEditorInstallPath,
   VersionNotSupportedOnOsError,
@@ -15,7 +15,7 @@ jest.mock("../../src/utils/env-util");
 describe("special-paths", () => {
   describe("home", () => {
     function makeDependencies() {
-      const getHomePath = makeHomePathGetter();
+      const getHomePath = makeGetHomePath();
 
       return { getHomePath } as const;
     }

--- a/test/io/upm-config-io.test.ts
+++ b/test/io/upm-config-io.test.ts
@@ -1,6 +1,6 @@
 import {
-  makeUpmConfigLoader,
-  makeUpmConfigPathGetter,
+  makeLoadUpmConfig,
+  makeGetUpmConfigPath,
   RequiredEnvMissingError,
 } from "../../src/io/upm-config-io";
 import { Err, Ok } from "ts-results-es";
@@ -18,7 +18,7 @@ describe("upm-config-io", () => {
     function makeDependencies() {
       const getHomePath = mockService<GetHomePath>();
 
-      const getUpmConfigPath = makeUpmConfigPathGetter(getHomePath);
+      const getUpmConfigPath = makeGetUpmConfigPath(getHomePath);
 
       return { getUpmConfigPath, getHomePath } as const;
     }
@@ -51,7 +51,7 @@ describe("upm-config-io", () => {
       const readFile = mockService<ReadTextFile>();
       readFile.mockReturnValue(AsyncOk(""));
 
-      const loadUpmConfig = makeUpmConfigLoader(readFile);
+      const loadUpmConfig = makeLoadUpmConfig(readFile);
       return { loadUpmConfig, readFile } as const;
     }
 

--- a/test/services/determine-editor-version.test.ts
+++ b/test/services/determine-editor-version.test.ts
@@ -1,4 +1,4 @@
-import { makeEditorVersionDeterminer } from "../../src/services/determine-editor-version";
+import { makeDetermineEditorVersion } from "../../src/services/determine-editor-version";
 import { mockService } from "./service.mock";
 import { LoadProjectVersion } from "../../src/io/project-version-io";
 import { makeEditorVersion } from "../../src/domain/editor-version";
@@ -13,7 +13,7 @@ describe("determine editor version", () => {
     const loadProjectVersion = mockService<LoadProjectVersion>();
 
     const determineEditorVersion =
-      makeEditorVersionDeterminer(loadProjectVersion);
+      makeDetermineEditorVersion(loadProjectVersion);
     return { determineEditorVersion, loadProjectVersion } as const;
   }
 

--- a/test/services/login.test.ts
+++ b/test/services/login.test.ts
@@ -1,8 +1,8 @@
-import { makeLoginService } from "../../src/services/login";
+import { makeLogin } from "../../src/services/login";
 import { mockService } from "./service.mock";
 import { SaveAuthToUpmConfig } from "../../src/services/upm-auth";
-import { NpmLoginService } from "../../src/services/npm-login";
-import { AuthNpmrcService } from "../../src/services/npmrc-auth";
+import { NpmLogin } from "../../src/services/npm-login";
+import { AuthNpmrc } from "../../src/services/npmrc-auth";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { noopLogger } from "../../src/logging";
 import {
@@ -23,13 +23,13 @@ describe("login", () => {
     const saveAuthToUpmConfig = mockService<SaveAuthToUpmConfig>();
     saveAuthToUpmConfig.mockReturnValue(AsyncOk());
 
-    const npmLogin = mockService<NpmLoginService>();
+    const npmLogin = mockService<NpmLogin>();
     npmLogin.mockReturnValue(AsyncOk(exampleToken));
 
-    const authNpmrc = mockService<AuthNpmrcService>();
+    const authNpmrc = mockService<AuthNpmrc>();
     authNpmrc.mockReturnValue(AsyncOk(exampleNpmrcPath));
 
-    const login = makeLoginService(
+    const login = makeLogin(
       saveAuthToUpmConfig,
       npmLogin,
       authNpmrc,

--- a/test/services/npm-login.test.ts
+++ b/test/services/npm-login.test.ts
@@ -1,5 +1,5 @@
 import "assert";
-import { makeNpmLoginService } from "../../src/services/npm-login";
+import { makeNpmLogin } from "../../src/services/npm-login";
 import RegClient from "another-npm-registry-client";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -13,7 +13,7 @@ function makeDependencies() {
     get: jest.fn(),
   };
 
-  const addUser = makeNpmLoginService(registryClient, noopLogger);
+  const addUser = makeNpmLogin(registryClient, noopLogger);
   return { addUser, registryClient } as const;
 }
 

--- a/test/services/npmrc-auth.test.ts
+++ b/test/services/npmrc-auth.test.ts
@@ -3,7 +3,7 @@ import { AsyncResult, Err, Ok } from "ts-results-es";
 import { RequiredEnvMissingError } from "../../src/io/upm-config-io";
 import { emptyNpmrc, setToken } from "../../src/domain/npmrc";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { makeAuthNpmrcService } from "../../src/services/npmrc-auth";
+import { makeAuthNpmrc } from "../../src/services/npmrc-auth";
 import { mockService } from "./service.mock";
 import { GenericIOError } from "../../src/io/common-errors";
 
@@ -19,7 +19,7 @@ function makeDependencies() {
   const saveNpmrc = mockService<SaveNpmrc>();
   saveNpmrc.mockReturnValue(new AsyncResult(Ok(undefined)));
 
-  const authNpmrc = makeAuthNpmrcService(findPath, loadNpmrc, saveNpmrc);
+  const authNpmrc = makeAuthNpmrc(findPath, loadNpmrc, saveNpmrc);
   return { authNpmrc, findPath, loadNpmrc, saveNpmrc } as const;
 }
 

--- a/test/services/packument-resolving.mock.ts
+++ b/test/services/packument-resolving.mock.ts
@@ -5,19 +5,19 @@ import {
   UnityPackument,
 } from "../../src/domain/packument";
 import { RegistryUrl } from "../../src/domain/registry-url";
-import { ResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument-version";
+import { ResolveRemotePackumentVersion } from "../../src/services/resolve-remote-packument-version";
 
 type MockEntry = [RegistryUrl, UnityPackument];
 
 /**
- * Mocks the results of a {@link ResolveRemotePackumentVersionService}.
+ * Mocks the results of a {@link ResolveRemotePackumentVersion}.
  * @param resolveRemovePackumentVersion The service to mock.
  * @param entries The entries of the mocked registry. Each entry contains
  * the url under which the packument is registered and the packument. All
  * packuments not given in this list are assumed to not exist.
  */
 export function mockResolvedPackuments(
-  resolveRemovePackumentVersion: jest.MockedFunction<ResolveRemotePackumentVersionService>,
+  resolveRemovePackumentVersion: jest.MockedFunction<ResolveRemotePackumentVersion>,
   ...entries: MockEntry[]
 ) {
   return resolveRemovePackumentVersion.mockImplementation(

--- a/test/services/parse-env.test.ts
+++ b/test/services/parse-env.test.ts
@@ -1,6 +1,6 @@
 import { TokenAuth, UPMConfig } from "../../src/domain/upm-config";
 import { NpmAuth } from "another-npm-registry-client";
-import { Env, makeParseEnvService } from "../../src/services/parse-env";
+import { Env, makeParseEnv } from "../../src/services/parse-env";
 import { GetUpmConfigPath, LoadUpmConfig } from "../../src/io/upm-config-io";
 import { NoWslError } from "../../src/io/wsl";
 import { mockUpmConfig } from "../io/upm-config-io.mock";
@@ -41,12 +41,7 @@ function makeDependencies() {
   const getCwd = mockService<GetCwd>();
   getCwd.mockReturnValue(testRootPath);
 
-  const parseEnv = makeParseEnvService(
-    log,
-    getUpmConfigPath,
-    loadUpmConfig,
-    getCwd
-  );
+  const parseEnv = makeParseEnv(log, getUpmConfigPath, loadUpmConfig, getCwd);
   return {
     parseEnv,
     log,

--- a/test/services/remove-packages.test.ts
+++ b/test/services/remove-packages.test.ts
@@ -4,7 +4,7 @@ import {
   mockProjectManifestWriteResult,
 } from "../io/project-manifest-io.mock";
 import {
-  makePackageRemover,
+  makeRemovePackages,
   RemovedPackage,
 } from "../../src/services/remove-packages";
 import { mockService } from "./service.mock";
@@ -33,7 +33,7 @@ describe("remove packages", () => {
     const writeProjectManifest = mockService<WriteProjectManifest>();
     mockProjectManifestWriteResult(writeProjectManifest);
 
-    const removePackages = makePackageRemover(
+    const removePackages = makeRemovePackages(
       loadProjectManifest,
       writeProjectManifest
     );

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -1,5 +1,5 @@
 import { mockService } from "./service.mock";
-import { makeResolveLatestVersionService } from "../../src/services/resolve-latest-version";
+import { makeResolveLatestVersion } from "../../src/services/resolve-latest-version";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { NoVersionsError, UnityPackument } from "../../src/domain/packument";
@@ -18,8 +18,7 @@ describe("resolve latest version service", () => {
   function makeDependencies() {
     const fetchPackument = mockService<FetchPackument>();
 
-    const resolveLatestVersion =
-      makeResolveLatestVersionService(fetchPackument);
+    const resolveLatestVersion = makeResolveLatestVersion(fetchPackument);
     return { resolveLatestVersion, fetchPackument } as const;
   }
 

--- a/test/services/resolve-remote-packument-version.test.ts
+++ b/test/services/resolve-remote-packument-version.test.ts
@@ -1,5 +1,5 @@
 import { mockService } from "./service.mock";
-import { makeResolveRemotePackumentVersionService } from "../../src/services/resolve-remote-packument-version";
+import { makeResolveRemotePackumentVersion } from "../../src/services/resolve-remote-packument-version";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { Registry } from "../../src/domain/registry";
@@ -20,7 +20,7 @@ describe("resolve remote packument version", () => {
     const fetchPackument = mockService<FetchPackument>();
 
     const resolveRemovePackumentVersion =
-      makeResolveRemotePackumentVersionService(fetchPackument);
+      makeResolveRemotePackumentVersion(fetchPackument);
     return { resolveRemovePackumentVersion, fetchPackument } as const;
   }
 

--- a/test/services/resolve-remote-packument.test.ts
+++ b/test/services/resolve-remote-packument.test.ts
@@ -1,4 +1,4 @@
-import { makeRemotePackumentResolver } from "../../src/services/resolve-remote-packument";
+import { makeResolveRemotePackument } from "../../src/services/resolve-remote-packument";
 import { makeDomainName } from "../../src/domain/domain-name";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -22,7 +22,7 @@ describe("resolve remove packument", () => {
     const fetchPackument = mockService<FetchPackument>();
     fetchPackument.mockReturnValue(AsyncOk(examplePackument));
 
-    const resolveRemotePackument = makeRemotePackumentResolver(fetchPackument);
+    const resolveRemotePackument = makeResolveRemotePackument(fetchPackument);
     return { resolveRemotePackument, fetchPackument } as const;
   }
 

--- a/test/services/search-packages.test.ts
+++ b/test/services/search-packages.test.ts
@@ -4,7 +4,7 @@ import {
   AllPackuments,
   FetchAllPackuments,
 } from "../../src/io/all-packuments-io";
-import { makePackagesSearcher } from "../../src/services/search-packages";
+import { makeSearchPackages } from "../../src/services/search-packages";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Err } from "ts-results-es";
@@ -41,7 +41,7 @@ describe("search packages", () => {
     const fetchAllPackument = mockService<FetchAllPackuments>();
     fetchAllPackument.mockReturnValue(AsyncOk(exampleAllPackumentsResult));
 
-    const searchPackages = makePackagesSearcher(
+    const searchPackages = makeSearchPackages(
       searchRegistry,
       fetchAllPackument
     );


### PR DESCRIPTION
Shorten service and service-constructor names by removing the "Service" word. Its not really necessary