### PR TITLE
opt(ci): remove unnecessary ci step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: npm ci
         run: npm ci
-      - name: Build
-        run: npm run build
       - name: Unit tests
         run: npm run test:unit
   e2e-test:


### PR DESCRIPTION
Building the project is not necessary for unit tests. We can skip this step.