### PR TITLE
refactor: dependency resolving logic

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -177,7 +177,7 @@ export function makeAddCmd(
           const [depsValid, depsInvalid] = await resolveDependencies(
             [env.registry, env.upstreamRegistry],
             name,
-            requestedVersion,
+            versionToAdd,
             true
           );
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -111,7 +111,6 @@ const checkIsBuiltInPackage = makeCheckIsBuiltInPackage(
 );
 const resolveDependencies = makeResolveDependency(
   resolveRemovePackumentVersion,
-  resolveLatestVersion,
   checkIsBuiltInPackage
 );
 const saveAuthToUpmConfig = makeSaveAuthToUpmConfig(
@@ -137,7 +136,13 @@ const addCmd = makeAddCmd(
 );
 const loginCmd = makeLoginCmd(parseEnv, getUpmConfigPath, login, log);
 const searchCmd = makeSearchCmd(parseEnv, searchPackages, log, debugLog);
-const depsCmd = makeDepsCmd(parseEnv, resolveDependencies, log, debugLog);
+const depsCmd = makeDepsCmd(
+  parseEnv,
+  resolveDependencies,
+  resolveLatestVersion,
+  log,
+  debugLog
+);
 const removeCmd = makeRemoveCmd(parseEnv, removePackages, log);
 const viewCmd = makeViewCmd(parseEnv, fetchPackument, log);
 


### PR DESCRIPTION
Currently, you can either pass a semantic version or "latest" to the dependency-resolve service. The service will then resolve the packages latest version if no semantic version was given.

This complicates the logic inside the service. For this reason, now the client calling the service needs to determine the latest version and pass it to the service.