### PR TITLE
refactor: convert to service function

### DIFF
--- a/src/io/builtin-packages.ts
+++ b/src/io/builtin-packages.ts
@@ -8,9 +8,9 @@ import { DomainName } from "../domain/domain-name";
 import { CustomError } from "ts-custom-error";
 import path from "path";
 import { DebugLog } from "../logging";
-import { tryGetDirectoriesIn } from "./directory-io";
 import { assertIsNodeError } from "../utils/error-type-guards";
 import { resultifyAsyncOp } from "../utils/result-utils";
+import { GetDirectoriesIn } from "./directory-io";
 
 /**
  * Error for when an editor-version is not installed.
@@ -45,6 +45,7 @@ export type FindBuiltInPackages = (
  * Makes a {@link FindBuiltInPackages} function.
  */
 export function makeFindBuiltInPackages(
+  getDirectoriesIn: GetDirectoriesIn,
   debugLog: DebugLog
 ): FindBuiltInPackages {
   return (editorVersion) => {
@@ -58,7 +59,7 @@ export function makeFindBuiltInPackages(
       );
 
       return (
-        resultifyAsyncOp(tryGetDirectoriesIn(packagesDir))
+        resultifyAsyncOp(getDirectoriesIn(packagesDir))
           // We can assume correct format
           .map((names) => names as DomainName[])
           .mapErr((error) => {

--- a/src/io/directory-io.ts
+++ b/src/io/directory-io.ts
@@ -2,13 +2,21 @@ import fs from "fs/promises";
 
 /**
  * Attempts to get the names of all directories in a directory.
- * @param directoryPath The directories name.
- * TODO: Convert to service function.
+ * @param directoryPath The path of the directory to get directory names from.
+ * @returns The names of the directories. That is, only the name and not whole
+ * path.
  */
-export async function tryGetDirectoriesIn(
+export type GetDirectoriesIn = (
   directoryPath: string
-): Promise<ReadonlyArray<string>> {
-  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
-  const directories = entries.filter((it) => it.isDirectory());
-  return directories.map((it) => it.name);
+) => Promise<ReadonlyArray<string>>;
+
+/**
+ * Makes a {@link GetDirectoriesIn} function.
+ */
+export function makeGetDirectoriesIn(): GetDirectoriesIn {
+  return async (directoryPath) => {
+    const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+    const directories = entries.filter((it) => it.isDirectory());
+    return directories.map((it) => it.name);
+  };
 }

--- a/test/io/directory-io.test.ts
+++ b/test/io/directory-io.test.ts
@@ -1,17 +1,21 @@
 import { makeNodeError } from "./node-error.mock";
 import fs from "fs/promises";
-import { tryGetDirectoriesIn } from "../../src/io/directory-io";
 import { Dirent } from "node:fs";
+import { makeGetDirectoriesIn } from "../../src/io/directory-io";
 
 describe("directory io", () => {
+  function makeDependencies() {
+    const getDirectoriesIn = makeGetDirectoriesIn();
+    return { getDirectoriesIn } as const;
+  }
+
   describe("get directories", () => {
     it("should fail if directory could not be read", async () => {
       const expected = makeNodeError("EACCES");
+      const { getDirectoriesIn } = makeDependencies();
       jest.spyOn(fs, "readdir").mockRejectedValue(expected);
 
-      await expect(tryGetDirectoriesIn("/good/path/")).rejects.toEqual(
-        expected
-      );
+      await expect(getDirectoriesIn("/good/path/")).rejects.toEqual(expected);
     });
 
     it("should get names of directories", async () => {
@@ -21,8 +25,9 @@ describe("directory io", () => {
           { name: "a", isDirectory: () => true } as Dirent,
           { name: "b", isDirectory: () => true } as Dirent,
         ]);
+      const { getDirectoriesIn } = makeDependencies();
 
-      const actual = await tryGetDirectoriesIn("/good/path/");
+      const actual = await getDirectoriesIn("/good/path/");
 
       expect(actual).toEqual(["a", "b"]);
     });
@@ -34,8 +39,9 @@ describe("directory io", () => {
           { name: "a", isDirectory: () => true } as Dirent,
           { name: "b.txt", isDirectory: () => false } as Dirent,
         ]);
+      const { getDirectoriesIn } = makeDependencies();
 
-      const actual = await tryGetDirectoriesIn("/good/path/");
+      const actual = await getDirectoriesIn("/good/path/");
 
       expect(actual).toEqual(["a"]);
     });


### PR DESCRIPTION
Convert the function for getting directory names into a service function that needs to be injected.