### PR TITLE
feat: add new deps output

### DIFF
--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -16,6 +16,7 @@ import { SemanticVersion } from "../domain/semantic-version";
 import { isZod } from "../utils/zod-utils";
 import { stringifyDependencyGraph } from "./dependency-logging";
 import os from "os";
+import chalk from "chalk";
 
 /**
  * Options passed to the deps command.
@@ -85,7 +86,8 @@ export function makeDepsCmd(
     const output = stringifyDependencyGraph(
       dependencyGraph,
       packageName,
-      latestVersion
+      latestVersion,
+      chalk
     ).join(os.EOL);
     log.notice("", output);
 

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -9,16 +9,13 @@ import { CmdOptions } from "./options";
 import { PackumentNotFoundError } from "../common-errors";
 import { ResolveDependencies } from "../services/dependency-resolving";
 import { Logger } from "npmlog";
-import {
-  logFailedDependency,
-  logResolvedDependency,
-} from "./dependency-logging";
 import { DebugLog } from "../logging";
 import { ResultCodes } from "./result-codes";
 import { ResolveLatestVersion } from "../services/resolve-latest-version";
 import { SemanticVersion } from "../domain/semantic-version";
-import { NodeType, traverseDependencyGraph } from "../domain/dependency-graph";
 import { isZod } from "../utils/zod-utils";
+import { stringifyDependencyGraph } from "./dependency-logging";
+import os from "os";
 
 /**
  * Options passed to the deps command.
@@ -85,34 +82,12 @@ export function makeDepsCmd(
       deep
     );
 
-    for (const [
-      dependencyName,
-      dependencyVersion,
-      dependency,
-    ] of traverseDependencyGraph(dependencyGraph)) {
-      if (dependency.type === NodeType.Failed) {
-        if (dependencyName !== packageName)
-          logFailedDependency(
-            log,
-            dependencyName,
-            dependencyVersion,
-            dependency
-          );
-
-        continue;
-      }
-      const dependencyRef = makePackageReference(
-        dependencyName,
-        dependencyVersion
-      );
-
-      if (dependency.type === NodeType.Resolved)
-        logResolvedDependency(debugLog, dependencyRef, dependency.source);
-
-      if (dependencyName === packageName) continue;
-
-      log.notice("dependency", dependencyRef);
-    }
+    const output = stringifyDependencyGraph(
+      dependencyGraph,
+      packageName,
+      latestVersion
+    ).join(os.EOL);
+    log.notice("", output);
 
     return ResultCodes.Ok;
   };

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -21,7 +21,7 @@ import {
   VersionNotFoundError,
 } from "../domain/packument";
 import { PackumentNotFoundError } from "../common-errors";
-import { make } from "ts-brand";
+import { Chalk } from "chalk";
 
 /**
  * Logs information about a resolved dependency to a logger.
@@ -73,14 +73,20 @@ export function logFailedDependency(
  * @param graph The graph.
  * @param rootPackage The name of the graphs root package.
  * @param rootVersion The version of the graphs root package.
+ * @param chalk Used for coloring output. Omit if no color should be used.
  * @returns A string array representing the graph. Each string is a line.
  */
 export function stringifyDependencyGraph(
   graph: DependencyGraph,
   rootPackage: DomainName,
-  rootVersion: SemanticVersion
+  rootVersion: SemanticVersion,
+  chalk?: Chalk
 ): readonly string[] {
   const printedRefs = new Set<PackageReference>();
+
+  function tryColor(chalk: Chalk | undefined, s: string) {
+    return chalk !== undefined ? chalk(s) : s;
+  }
 
   function getNode(
     packageName: DomainName,
@@ -109,7 +115,7 @@ export function stringifyDependencyGraph(
   }
 
   function makeDuplicateLine(packageRef: PackageReference): string {
-    return `${packageRef} ..`;
+    return tryColor(chalk?.blueBright, `${packageRef} ..`);
   }
 
   function makeErrorLines(errors: FailedNode["errors"]): readonly string[] {
@@ -174,7 +180,7 @@ export function stringifyDependencyGraph(
          -  url2: package not found
        */
       const errorLines = makeErrorLines(node.errors);
-      return [packageRef, ...errorLines];
+      return [tryColor(chalk?.red, packageRef), ...errorLines];
     }
 
     // Resolved node

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -1,11 +1,19 @@
-import { PackageReference } from "../domain/package-reference";
+import {
+  makePackageReference,
+  PackageReference,
+} from "../domain/package-reference";
 import { RegistryUrl, unityRegistryUrl } from "../domain/registry-url";
 import { DebugLog } from "../logging";
 import { recordEntries } from "../utils/record-utils";
 import { Logger } from "npmlog";
 import { DomainName } from "../domain/domain-name";
 import { SemanticVersion } from "../domain/semantic-version";
-import { FailedNode } from "../domain/dependency-graph";
+import {
+  DependencyGraph,
+  FailedNode,
+  NodeType,
+  tryGetGraphNode,
+} from "../domain/dependency-graph";
 import { ResolvePackumentVersionError } from "../domain/packument";
 import { PackumentNotFoundError } from "../common-errors";
 
@@ -52,4 +60,73 @@ export function logFailedDependency(
   recordEntries(dependency.errors).forEach(([errorSource, error]) =>
     log.warn("", `  - "${errorSource}": ${errorMessageFor(error)}`)
   );
+}
+
+/**
+ * Stringifies a dependency graph for output.
+ * @param graph The graph.
+ * @param rootPackage The name of the graphs root package.
+ * @param rootVersion The version of the graphs root package.
+ * @returns A string array representing the graph. Each string is a line.
+ */
+export function stringifyDependencyGraph(
+  graph: DependencyGraph,
+  rootPackage: DomainName,
+  rootVersion: SemanticVersion
+): readonly string[] {
+  const printedRefs = new Set<PackageReference>();
+
+  function stringifyRecursively(
+    packageName: DomainName,
+    version: SemanticVersion
+  ): readonly string[] {
+    const node = tryGetGraphNode(graph, packageName, version);
+    if (node === null)
+      throw new RangeError(
+        `Dependency graph did not contain a node for ${makePackageReference(
+          rootPackage,
+          rootVersion
+        )}`
+      );
+
+    const packageRef = makePackageReference(packageName, version);
+
+    if (printedRefs.has(packageRef)) return [`${packageRef} ..`];
+    else printedRefs.add(packageRef);
+
+    if (node.type === NodeType.Unresolved) return [packageRef];
+
+    if (node.type === NodeType.Failed) {
+      const errorLines = recordEntries(node.errors).flatMap(
+        ([sourceUrl, error]) => {
+          const message =
+            error instanceof PackumentNotFoundError
+              ? "package not found"
+              : "version not found";
+          return `  - "${sourceUrl}": ${message}`;
+        }
+      );
+      return [packageRef, ...errorLines];
+    }
+
+    const dependencyBlocks = recordEntries(node.dependencies).map(
+      ([dependencyName, dependencyVersion]) =>
+        stringifyRecursively(dependencyName, dependencyVersion)
+    );
+    const dependencyLines = dependencyBlocks.flatMap((block, blockIndex) =>
+      block.map((line, lineIndex) => {
+        const prefix =
+          lineIndex === 0
+            ? "└─ "
+            : blockIndex < dependencyBlocks.length - 1
+            ? "│  "
+            : "   ";
+        return prefix + line;
+      })
+    );
+
+    return [packageRef, ...dependencyLines];
+  }
+
+  return stringifyRecursively(rootPackage, rootVersion);
 }

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -11,11 +11,17 @@ import { SemanticVersion } from "../domain/semantic-version";
 import {
   DependencyGraph,
   FailedNode,
+  GraphNode,
   NodeType,
+  ResolvedNode,
   tryGetGraphNode,
 } from "../domain/dependency-graph";
-import { ResolvePackumentVersionError } from "../domain/packument";
+import {
+  ResolvePackumentVersionError,
+  VersionNotFoundError,
+} from "../domain/packument";
 import { PackumentNotFoundError } from "../common-errors";
+import { make } from "ts-brand";
 
 /**
  * Logs information about a resolved dependency to a logger.
@@ -76,10 +82,10 @@ export function stringifyDependencyGraph(
 ): readonly string[] {
   const printedRefs = new Set<PackageReference>();
 
-  function stringifyRecursively(
+  function getNode(
     packageName: DomainName,
     version: SemanticVersion
-  ): readonly string[] {
+  ): GraphNode {
     const node = tryGetGraphNode(graph, packageName, version);
     if (node === null)
       throw new RangeError(
@@ -88,43 +94,95 @@ export function stringifyDependencyGraph(
           rootVersion
         )}`
       );
+    return node;
+  }
 
-    const packageRef = makePackageReference(packageName, version);
-
-    if (printedRefs.has(packageRef)) return [`${packageRef} ..`];
-    else printedRefs.add(packageRef);
-
-    if (node.type === NodeType.Unresolved) return [packageRef];
-
-    if (node.type === NodeType.Failed) {
-      const errorLines = recordEntries(node.errors).flatMap(
-        ([sourceUrl, error]) => {
-          const message =
-            error instanceof PackumentNotFoundError
-              ? "package not found"
-              : "version not found";
-          return `  - "${sourceUrl}": ${message}`;
-        }
-      );
-      return [packageRef, ...errorLines];
+  function makeErrorMessageFor(error: ResolvePackumentVersionError): string {
+    switch (error.constructor) {
+      case PackumentNotFoundError:
+        return "package not found";
+      case VersionNotFoundError:
+        return "version not found";
+      default:
+        return "unknown";
     }
+  }
 
-    const dependencyBlocks = recordEntries(node.dependencies).map(
+  function makeDuplicateLine(packageRef: PackageReference): string {
+    return `${packageRef} ..`;
+  }
+
+  function makeErrorLines(errors: FailedNode["errors"]): readonly string[] {
+    // Each error gets a line
+    return recordEntries(errors).map(([sourceUrl, error]) => {
+      const message = makeErrorMessageFor(error);
+      // With the source url and a message describing the error
+      return `  - "${sourceUrl}": ${message}`;
+    });
+  }
+
+  function makeDependencyLines(
+    dependencies: ResolvedNode["dependencies"]
+  ): readonly string[] {
+    const dependencyBlocks = recordEntries(dependencies).map(
       ([dependencyName, dependencyVersion]) =>
         stringifyRecursively(dependencyName, dependencyVersion)
     );
-    const dependencyLines = dependencyBlocks.flatMap((block, blockIndex) =>
-      block.map((line, lineIndex) => {
+    return dependencyBlocks.flatMap((block, blockIndex) => {
+      const isLastBlock = blockIndex >= dependencyBlocks.length - 1;
+      return block.map((line, lineIndex) => {
+        const isFirstLine = lineIndex === 0;
         const prefix =
-          lineIndex === 0
+          // The first line of a dependency block has the "arrow" in order
+          // to branch of from the parent
+          isFirstLine
             ? "└─ "
-            : blockIndex < dependencyBlocks.length - 1
-            ? "│  "
-            : "   ";
+            : // The other lines have different symbols depending on whether
+            // there are more blocks following.
+            isLastBlock
+            ? // If there are no more blocks then no symbol.
+              "   "
+            : // Otherwise draw a line down from the parent so that the
+              // next block's arrow can connect to it.
+              "│  ";
         return prefix + line;
-      })
-    );
+      });
+    });
+  }
 
+  function stringifyRecursively(
+    packageName: DomainName,
+    version: SemanticVersion
+  ): readonly string[] {
+    const node = getNode(packageName, version);
+    const packageRef = makePackageReference(packageName, version);
+
+    // We only print package@version once. If two packages depend on the
+    // same package@version, we print a short version of it.
+    const isDuplicate = printedRefs.has(packageRef);
+    if (isDuplicate) return [makeDuplicateLine(packageRef)];
+    else printedRefs.add(packageRef);
+
+    if (node.type === NodeType.Unresolved)
+      // package@version
+      return [packageRef];
+
+    if (node.type === NodeType.Failed) {
+      /*
+        package@version
+         -  url1: version not found
+         -  url2: package not found
+       */
+      const errorLines = makeErrorLines(node.errors);
+      return [packageRef, ...errorLines];
+    }
+
+    // Resolved node
+    /*
+      package@version
+      └─ dependency@version
+     */
+    const dependencyLines = makeDependencyLines(node.dependencies);
     return [packageRef, ...dependencyLines];
   }
 

--- a/src/domain/dependency-graph.ts
+++ b/src/domain/dependency-graph.ts
@@ -14,7 +14,7 @@ type UnresolvedNode = Readonly<{
   type: NodeType.Unresolved;
 }>;
 
-type ResolvedNode = Readonly<{
+export type ResolvedNode = Readonly<{
   type: NodeType.Resolved;
   source: RegistryUrl | "built-in";
   dependencies: Readonly<Record<DomainName, SemanticVersion>>;

--- a/src/domain/dependency-graph.ts
+++ b/src/domain/dependency-graph.ts
@@ -36,7 +36,7 @@ export type FailedNode = Readonly<{
   errors: Readonly<Record<RegistryUrl, ResolvePackumentVersionError>>;
 }>;
 
-type GraphNode = UnresolvedNode | ResolvedNode | FailedNode;
+export type GraphNode = UnresolvedNode | ResolvedNode | FailedNode;
 
 /**
  * A graph indicating which packages depend on which others.

--- a/test/cli/dependency-logging.test.ts
+++ b/test/cli/dependency-logging.test.ts
@@ -1,5 +1,3 @@
-import { makeDomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import {
   makeGraphFromSeed,
   markBuiltInResolved,
@@ -12,16 +10,18 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { VersionNotFoundError } from "../../src/domain/packument";
+import { DomainName } from "../../src/domain/domain-name";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 
 describe("dependency-logging", () => {
   describe("graph", () => {
-    const somePackage = makeDomainName("com.some.package");
-    const otherPackage = makeDomainName("com.other.package");
-    const anotherPackage = makeDomainName("com.another.package");
-    const thatPackage = makeDomainName("com.that.package");
+    const somePackage = DomainName.parse("com.some.package");
+    const otherPackage = DomainName.parse("com.other.package");
+    const anotherPackage = DomainName.parse("com.another.package");
+    const thatPackage = DomainName.parse("com.that.package");
 
-    const someVersion = makeSemanticVersion("1.2.3");
-    const otherVersion = makeSemanticVersion("2.3.4");
+    const someVersion = SemanticVersion.parse("1.2.3");
+    const otherVersion = SemanticVersion.parse("2.3.4");
 
     it("should fail if graph does not contain package", () => {
       const graph = makeGraphFromSeed(somePackage, someVersion);

--- a/test/cli/dependency-logging.test.ts
+++ b/test/cli/dependency-logging.test.ts
@@ -1,0 +1,173 @@
+import { makeDomainName } from "../../src/domain/domain-name";
+import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import {
+  makeGraphFromSeed,
+  markBuiltInResolved,
+  markFailed,
+  markRemoteResolved,
+} from "../../src/domain/dependency-graph";
+import { stringifyDependencyGraph } from "../../src/cli/dependency-logging";
+import { makePackageReference } from "../../src/domain/package-reference";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { PackumentNotFoundError } from "../../src/common-errors";
+import { unityRegistryUrl } from "../../src/domain/registry-url";
+import { VersionNotFoundError } from "../../src/domain/packument";
+
+describe("dependency-logging", () => {
+  describe("graph", () => {
+    const somePackage = makeDomainName("com.some.package");
+    const otherPackage = makeDomainName("com.other.package");
+    const anotherPackage = makeDomainName("com.another.package");
+    const thatPackage = makeDomainName("com.that.package");
+
+    const someVersion = makeSemanticVersion("1.2.3");
+    const otherVersion = makeSemanticVersion("2.3.4");
+
+    it("should fail if graph does not contain package", () => {
+      const graph = makeGraphFromSeed(somePackage, someVersion);
+
+      expect(() =>
+        stringifyDependencyGraph(graph, otherPackage, someVersion)
+      ).toThrow(RangeError);
+    });
+
+    it("should fail if graph does contain package but not at given version", () => {
+      const graph = makeGraphFromSeed(somePackage, someVersion);
+
+      expect(() =>
+        stringifyDependencyGraph(graph, somePackage, otherVersion)
+      ).toThrow(RangeError);
+    });
+
+    it("should output unresolved package in correct format", () => {
+      const graph = makeGraphFromSeed(somePackage, someVersion);
+
+      const actual = stringifyDependencyGraph(graph, somePackage, someVersion);
+
+      // Print just name@version
+      expect(actual).toEqual([
+        `${makePackageReference(somePackage, someVersion)}`,
+      ]);
+    });
+
+    it("should output resolved package in correct format", () => {
+      let graph = makeGraphFromSeed(somePackage, someVersion);
+      graph = markRemoteResolved(
+        graph,
+        somePackage,
+        someVersion,
+        exampleRegistryUrl,
+        {
+          [otherPackage]: otherVersion,
+          [anotherPackage]: someVersion,
+        }
+      );
+
+      const actual = stringifyDependencyGraph(graph, somePackage, someVersion);
+
+      // Print name@version plus dependencies in the next lines
+      expect(actual).toEqual([
+        `${makePackageReference(somePackage, someVersion)}`,
+        `└─ ${makePackageReference(otherPackage, otherVersion)}`,
+        `└─ ${makePackageReference(anotherPackage, someVersion)}`,
+      ]);
+    });
+
+    it("should output failed package in correct format", () => {
+      let graph = makeGraphFromSeed(somePackage, someVersion);
+      graph = markFailed(graph, somePackage, someVersion, {
+        [exampleRegistryUrl]: new PackumentNotFoundError(somePackage),
+        [unityRegistryUrl]: new VersionNotFoundError(
+          somePackage,
+          someVersion,
+          []
+        ),
+      });
+
+      const actual = stringifyDependencyGraph(graph, somePackage, someVersion);
+
+      // Print name@version plus error message in next line
+      expect(actual).toEqual([
+        `${makePackageReference(somePackage, someVersion)}`,
+        `  - "${exampleRegistryUrl}": package not found`,
+        `  - "${unityRegistryUrl}": version not found`,
+      ]);
+    });
+
+    it("should print deep graphs in correct format", () => {
+      let graph = makeGraphFromSeed(somePackage, someVersion);
+      graph = markRemoteResolved(
+        graph,
+        somePackage,
+        someVersion,
+        exampleRegistryUrl,
+        {
+          [otherPackage]: otherVersion,
+          [thatPackage]: someVersion,
+        }
+      );
+      graph = markRemoteResolved(
+        graph,
+        otherPackage,
+        otherVersion,
+        exampleRegistryUrl,
+        {
+          [anotherPackage]: someVersion,
+        }
+      );
+      graph = markBuiltInResolved(graph, anotherPackage, someVersion);
+      graph = markBuiltInResolved(graph, thatPackage, someVersion);
+
+      const actual = stringifyDependencyGraph(graph, somePackage, someVersion);
+
+      // Print | next to nested trees
+      expect(actual).toEqual([
+        `${makePackageReference(somePackage, someVersion)}`,
+        `└─ ${makePackageReference(otherPackage, otherVersion)}`,
+        `│  └─ ${makePackageReference(anotherPackage, someVersion)}`,
+        `└─ ${makePackageReference(thatPackage, someVersion)}`,
+      ]);
+    });
+
+    it("should fully print packages only once (don't print duplicates)", () => {
+      let graph = makeGraphFromSeed(somePackage, someVersion);
+      graph = markRemoteResolved(
+        graph,
+        somePackage,
+        someVersion,
+        exampleRegistryUrl,
+        {
+          [otherPackage]: otherVersion,
+          [anotherPackage]: someVersion,
+        }
+      );
+      graph = markRemoteResolved(
+        graph,
+        otherPackage,
+        otherVersion,
+        exampleRegistryUrl,
+        { [anotherPackage]: someVersion }
+      );
+      graph = markRemoteResolved(
+        graph,
+        anotherPackage,
+        someVersion,
+        exampleRegistryUrl,
+        { [thatPackage]: someVersion }
+      );
+      graph = markBuiltInResolved(graph, thatPackage, someVersion);
+
+      const actual = stringifyDependencyGraph(graph, somePackage, someVersion);
+
+      expect(actual).toEqual([
+        `${makePackageReference(somePackage, someVersion)}`,
+        `└─ ${makePackageReference(otherPackage, otherVersion)}`,
+        `│  └─ ${makePackageReference(anotherPackage, someVersion)}`,
+        `│     └─ ${makePackageReference(thatPackage, someVersion)}`,
+        // Because this package was printed before, now only its name is printed
+        // with a string at the end that indicates that this is a duplicate.
+        `└─ ${makePackageReference(anotherPackage, someVersion)} ..`,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This overhauls the output for the deps command as discussed in #366.

New output sample:

![image](https://github.com/user-attachments/assets/1733833c-6587-4444-a95c-202e82e1490c)
