### PR TITLE
refactor: use zod for primitive validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "ts-custom-error": "^3.3.1",
         "ts-results-es": "^4.1.0",
         "update-notifier": "^5.1.0",
-        "yaml": "^2.2.2"
+        "yaml": "^2.2.2",
+        "zod": "^3.23.8"
       },
       "bin": {
         "openupm": "lib/index.js",
@@ -12235,6 +12236,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -20521,6 +20531,11 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "pkginfo": "^0.4.1",
         "promptly": "^3.2.0",
         "semver": "^7.5.4",
-        "ts-brand": "^0.0.2",
         "ts-custom-error": "^3.3.1",
         "ts-results-es": "^4.1.0",
         "update-notifier": "^5.1.0",
@@ -11728,11 +11727,6 @@
         "typescript": ">=4.2.0"
       }
     },
-    "node_modules/ts-brand": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ts-brand/-/ts-brand-0.0.2.tgz",
-      "integrity": "sha512-UhSzWY4On9ZHIj6DKkRYVN/8OaprbLAZ3b/Y2AJwdl6oozSABsQ0PvwDh4vOVdkvOtWQOkIrjctZ1kj8YfF3jA=="
-    },
     "node_modules/ts-custom-error": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
@@ -20206,11 +20200,6 @@
       "version": "1.0.3",
       "dev": true,
       "requires": {}
-    },
-    "ts-brand": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ts-brand/-/ts-brand-0.0.2.tgz",
-      "integrity": "sha512-UhSzWY4On9ZHIj6DKkRYVN/8OaprbLAZ3b/Y2AJwdl6oozSABsQ0PvwDh4vOVdkvOtWQOkIrjctZ1kj8YfF3jA=="
     },
     "ts-custom-error": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "ts-custom-error": "^3.3.1",
     "ts-results-es": "^4.1.0",
     "update-notifier": "^5.1.0",
-    "yaml": "^2.2.2"
+    "yaml": "^2.2.2",
+    "zod": "^3.23.8"
   },
   "volta": {
     "node": "18.20.2"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "pkginfo": "^0.4.1",
     "promptly": "^3.2.0",
     "semver": "^7.5.4",
-    "ts-brand": "^0.0.2",
     "ts-custom-error": "^3.3.1",
     "ts-results-es": "^4.1.0",
     "update-notifier": "^5.1.0",

--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -1,4 +1,4 @@
-import { isPackageUrl, PackageUrl } from "../domain/package-url";
+import { PackageUrl } from "../domain/package-url";
 import {
   LoadProjectManifest,
   WriteProjectManifest,
@@ -43,6 +43,7 @@ import { Err } from "ts-results-es";
 import { PackumentNotFoundError } from "../common-errors";
 
 import { ResolvePackumentVersionError } from "../domain/packument";
+import { isZod } from "../utils/zod-utils";
 
 export class PackageIncompatibleError extends CustomError {
   constructor(
@@ -152,7 +153,10 @@ export function makeAddCmd(
       // packages that added to scope registry
       const pkgsInScope = Array.of<DomainName>();
       let versionToAdd = requestedVersion;
-      if (requestedVersion === undefined || !isPackageUrl(requestedVersion)) {
+      if (
+        requestedVersion === undefined ||
+        !isZod(requestedVersion, PackageUrl)
+      ) {
         let resolveResult = await resolveRemotePackumentVersion(
           name,
           requestedVersion,

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -16,7 +16,7 @@ import {
 import { DebugLog } from "../logging";
 import { ResultCodes } from "./result-codes";
 import { ResolveLatestVersion } from "../services/resolve-latest-version";
-import { isSemanticVersion } from "../domain/semantic-version";
+import { SemanticVersion } from "../domain/semantic-version";
 import { NodeType, traverseDependencyGraph } from "../domain/dependency-graph";
 import { isZod } from "../utils/zod-utils";
 
@@ -68,7 +68,7 @@ export function makeDepsCmd(
     }
 
     const latestVersion =
-      requestedVersion !== undefined && isSemanticVersion(requestedVersion)
+      requestedVersion !== undefined && isZod(requestedVersion, SemanticVersion)
         ? requestedVersion
         : (await resolveLatestVersion(sources, packageName))?.value ?? null;
 

--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -1,5 +1,5 @@
 import { ParseEnv } from "../services/parse-env";
-import { isPackageUrl } from "../domain/package-url";
+import { PackageUrl } from "../domain/package-url";
 import {
   makePackageReference,
   PackageReference,
@@ -18,6 +18,7 @@ import { ResultCodes } from "./result-codes";
 import { ResolveLatestVersion } from "../services/resolve-latest-version";
 import { isSemanticVersion } from "../domain/semantic-version";
 import { NodeType, traverseDependencyGraph } from "../domain/dependency-graph";
+import { isZod } from "../utils/zod-utils";
 
 /**
  * Options passed to the deps command.
@@ -61,7 +62,7 @@ export function makeDepsCmd(
 
     const [packageName, requestedVersion] = splitPackageReference(pkg);
 
-    if (requestedVersion !== undefined && isPackageUrl(requestedVersion)) {
+    if (requestedVersion !== undefined && isZod(requestedVersion, PackageUrl)) {
       log.error("", "cannot get dependencies for url-version");
       return ResultCodes.Error;
     }

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -1,5 +1,5 @@
 import promptly from "promptly";
-import { makeRegistryUrl, RegistryUrl } from "../domain/registry-url";
+import { RegistryUrl } from "../domain/registry-url";
 
 /**
  * Prompts the user for their username.
@@ -31,6 +31,6 @@ export function promptEmail(): Promise<string> {
  */
 export function promptRegistryUrl(): Promise<RegistryUrl> {
   return promptly.prompt("Registry: ", {
-    validator: [makeRegistryUrl],
+    validator: [RegistryUrl.parse],
   }) as Promise<RegistryUrl>;
 }

--- a/src/cli/validators.ts
+++ b/src/cli/validators.ts
@@ -1,7 +1,8 @@
 import { mustBeParsable, mustSatisfy } from "./cli-parsing";
 import { isPackageReference } from "../domain/package-reference";
-import { isDomainName } from "../domain/domain-name";
 import { coerceRegistryUrl } from "../domain/registry-url";
+import { isZod } from "../utils/zod-utils";
+import { DomainName } from "../domain/domain-name";
 
 export const mustBePackageReference = mustSatisfy(
   isPackageReference,
@@ -9,7 +10,7 @@ export const mustBePackageReference = mustSatisfy(
 );
 
 export const mustBeDomainName = mustSatisfy(
-  isDomainName,
+  (s): s is DomainName => isZod(s, DomainName),
   (input) => `"${input}" is not a valid package name`
 );
 

--- a/src/domain/base64.ts
+++ b/src/domain/base64.ts
@@ -1,9 +1,11 @@
-import { Brand } from "ts-brand";
+import { z } from "zod";
+
+export const Base64 = z.string().base64().brand("Base64");
 
 /**
  * A Base64 encoded string.
  */
-export type Base64 = Brand<string, "Base64">;
+export type Base64 = z.TypeOf<typeof Base64>;
 
 /**
  * Encodes a string using base64.

--- a/src/domain/domain-name.ts
+++ b/src/domain/domain-name.ts
@@ -1,12 +1,4 @@
-import { Brand } from "ts-brand";
-import assert from "assert";
-
-/**
- * A string matching the format of a domain name.
- * @example com.unity
- * @example com.my-company
- */
-export type DomainName = Brand<string, "DomainName">;
+import { z } from "zod";
 
 const segmentRegex = /^(?!.*--|^-.*|.*-$)[a-zA-Z0-9-]+$/;
 
@@ -15,22 +7,20 @@ function domainSegmentsIn(hostName: string): string[] {
 }
 
 /**
- * Checks if a string is a domain name. Only does basic syntax validation.
- * Does not check for correct segment-count etc.
- * @param s The string.
+ * Schema for {@link DomainName}.
  */
-export function isDomainName(s: string): s is DomainName {
-  const segments = domainSegmentsIn(s);
-  if (segments.length === 0) return false;
-  return segments.every((segment) => segmentRegex.test(segment));
-}
+export const DomainName = z
+  .string()
+  .refine((s) => {
+    const segments = domainSegmentsIn(s);
+    if (segments.length === 0) return false;
+    return segments.every((segment) => segmentRegex.test(segment));
+  })
+  .brand("DomainName");
 
 /**
- * Constructs a domain-name from a string.
- * @param s The string.
- * @throws {assert.AssertionError} If string is not in valid format.
+ * A string matching the format of a domain name.
+ * @example com.unity
+ * @example com.my-company
  */
-export function makeDomainName(s: string): DomainName {
-  assert(isDomainName(s), `"${s}" is a domain name`);
-  return s;
-}
+export type DomainName = z.TypeOf<typeof DomainName>;

--- a/src/domain/package-id.ts
+++ b/src/domain/package-id.ts
@@ -1,5 +1,5 @@
 import { DomainName } from "./domain-name";
-import { isSemanticVersion, SemanticVersion } from "./semantic-version";
+import { SemanticVersion } from "./semantic-version";
 import { trySplitAtFirstOccurrenceOf } from "../utils/string-utils";
 import { isZod } from "../utils/zod-utils";
 
@@ -17,7 +17,9 @@ export type PackageId = `${DomainName}@${SemanticVersion}`;
 export function isPackageId(s: string): s is PackageId {
   const [name, version] = trySplitAtFirstOccurrenceOf(s, "@");
   return (
-    isZod(name, DomainName) && version !== null && isSemanticVersion(version)
+    isZod(name, DomainName) &&
+    version !== null &&
+    isZod(version, SemanticVersion)
   );
 }
 

--- a/src/domain/package-id.ts
+++ b/src/domain/package-id.ts
@@ -1,6 +1,7 @@
-import { DomainName, isDomainName } from "./domain-name";
+import { DomainName } from "./domain-name";
 import { isSemanticVersion, SemanticVersion } from "./semantic-version";
 import { trySplitAtFirstOccurrenceOf } from "../utils/string-utils";
+import { isZod } from "../utils/zod-utils";
 
 /**
  * Represents a package at a specific version. The version is here is a
@@ -15,7 +16,9 @@ export type PackageId = `${DomainName}@${SemanticVersion}`;
  */
 export function isPackageId(s: string): s is PackageId {
   const [name, version] = trySplitAtFirstOccurrenceOf(s, "@");
-  return isDomainName(name) && version !== null && isSemanticVersion(version);
+  return (
+    isZod(name, DomainName) && version !== null && isSemanticVersion(version)
+  );
 }
 
 /**

--- a/src/domain/package-reference.ts
+++ b/src/domain/package-reference.ts
@@ -1,5 +1,5 @@
 import { DomainName } from "./domain-name";
-import { isSemanticVersion, SemanticVersion } from "./semantic-version";
+import { SemanticVersion } from "./semantic-version";
 import { PackageUrl } from "./package-url";
 import { trySplitAtFirstOccurrenceOf } from "../utils/string-utils";
 import assert from "assert";
@@ -42,7 +42,7 @@ export type PackageReference = DomainName | ReferenceWithVersion;
  * @param s The string.
  */
 function isVersionReference(s: string): s is VersionReference {
-  return s === "latest" || isSemanticVersion(s) || isZod(s, PackageUrl);
+  return s === "latest" || isZod(s, SemanticVersion) || isZod(s, PackageUrl);
 }
 
 /**

--- a/src/domain/package-reference.ts
+++ b/src/domain/package-reference.ts
@@ -1,8 +1,9 @@
-import { DomainName, isDomainName } from "./domain-name";
+import { DomainName } from "./domain-name";
 import { isSemanticVersion, SemanticVersion } from "./semantic-version";
 import { isPackageUrl, PackageUrl } from "./package-url";
 import { trySplitAtFirstOccurrenceOf } from "../utils/string-utils";
 import assert from "assert";
+import { assertZod, isZod } from "../utils/zod-utils";
 
 /**
  * A string with the format of one of the supported version tags.
@@ -51,7 +52,7 @@ function isVersionReference(s: string): s is VersionReference {
 export function isPackageReference(s: string): s is PackageReference {
   const [name, version] = trySplitAtFirstOccurrenceOf(s, "@");
   return (
-    isDomainName(name) && (version === null || isVersionReference(version))
+    isZod(name, DomainName) && (version === null || isVersionReference(version))
   );
 }
 
@@ -79,7 +80,7 @@ export function makePackageReference(
   name: string,
   version?: string
 ): PackageReference {
-  assert(isDomainName(name), `${name} is valid package-name`);
+  assertZod(name, DomainName);
   assert(
     version === undefined || isVersionReference(version),
     `"${version}" is valid version-reference`

--- a/src/domain/package-reference.ts
+++ b/src/domain/package-reference.ts
@@ -1,6 +1,6 @@
 import { DomainName } from "./domain-name";
 import { isSemanticVersion, SemanticVersion } from "./semantic-version";
-import { isPackageUrl, PackageUrl } from "./package-url";
+import { PackageUrl } from "./package-url";
 import { trySplitAtFirstOccurrenceOf } from "../utils/string-utils";
 import assert from "assert";
 import { assertZod, isZod } from "../utils/zod-utils";
@@ -42,7 +42,7 @@ export type PackageReference = DomainName | ReferenceWithVersion;
  * @param s The string.
  */
 function isVersionReference(s: string): s is VersionReference {
-  return s === "latest" || isSemanticVersion(s) || isPackageUrl(s);
+  return s === "latest" || isSemanticVersion(s) || isZod(s, PackageUrl);
 }
 
 /**

--- a/src/domain/package-url.ts
+++ b/src/domain/package-url.ts
@@ -1,19 +1,20 @@
-import { Brand } from "ts-brand";
+import { z } from "zod";
+
+const GitUrl = z.string().startsWith("git");
+
+const HttpUrl = z.string().startsWith("http");
+
+const FileUrl = z.string().startsWith("file");
 
 /**
- * A string of an url pointing to a local or remote package.
+ * Schema for {@link PackageUrl}.
  */
-export type PackageUrl = Brand<string, "PackageUrl">;
-
-const isGit = (version: string): boolean => version.startsWith("git");
-
-const isHttp = (version: string): boolean => version.startsWith("http");
-
-const isLocal = (version: string): boolean => version.startsWith("file");
+export const PackageUrl = z
+  .union([GitUrl, HttpUrl, FileUrl])
+  .brand("PackageUrl");
 
 /**
  * Checks if a version is a package-url.
  * @param version The version.
  */
-export const isPackageUrl = (version: string): version is PackageUrl =>
-  isGit(version) || isHttp(version) || isLocal(version);
+export type PackageUrl = z.TypeOf<typeof PackageUrl>;

--- a/src/domain/registry-url.ts
+++ b/src/domain/registry-url.ts
@@ -1,30 +1,19 @@
-import { Brand } from "ts-brand";
-import assert from "assert";
 import { removeTrailingSlash } from "../utils/string-utils";
+import { z } from "zod";
+
+/**
+ * Schema for {@link RegistryUrl}.
+ */
+export const RegistryUrl = z
+  .string()
+  .regex(/http(s?):\/\/.*[^/]$/)
+  .brand("RegistryUrl");
 
 /**
  * A string of a http-based registry-url.
  * Registry-urls may not have trailing slashes.
  */
-export type RegistryUrl = Brand<string, "RegistryUrl">;
-
-/**
- * Checks that a string is a valid registry.
- * @param s The string.
- */
-export function isRegistryUrl(s: string): s is RegistryUrl {
-  return /http(s?):\/\/.*[^/]$/.test(s);
-}
-
-/**
- * Constructs a registry-url.
- * @param s The string.
- * @throws {assert.AssertionError} If string does not have valid format.
- */
-export function makeRegistryUrl(s: string): RegistryUrl {
-  assert(isRegistryUrl(s), `"${s}" is url`);
-  return s;
-}
+export type RegistryUrl = z.TypeOf<typeof RegistryUrl>;
 
 /**
  * Attempts to coerce a string into a registry-url, by
@@ -36,7 +25,7 @@ export function makeRegistryUrl(s: string): RegistryUrl {
 export function coerceRegistryUrl(s: string): RegistryUrl {
   if (!s.toLowerCase().startsWith("http")) s = "http://" + s;
   s = removeTrailingSlash(s);
-  return makeRegistryUrl(s);
+  return RegistryUrl.parse(s);
 }
 
-export const unityRegistryUrl = makeRegistryUrl("https://packages.unity.com");
+export const unityRegistryUrl = RegistryUrl.parse("https://packages.unity.com");

--- a/src/domain/semantic-version.ts
+++ b/src/domain/semantic-version.ts
@@ -1,26 +1,16 @@
-import { Brand } from "ts-brand";
 import semver from "semver/preload";
-import assert from "assert";
+import { z } from "zod";
+
+/**
+ * Schema for {@link SemanticVersion}.
+ */
+export const SemanticVersion = z
+  .string()
+  .refine(semver.parse)
+  .brand("SemanticVersion");
 
 /**
  * A string with a semantic-version format.
  * @see https://semver.org/.
  */
-export type SemanticVersion = Brand<string, "SemanticVersion">;
-
-/**
- * Checks if a string is a semantic version.
- * @param s The string.
- */
-export function isSemanticVersion(s: string): s is SemanticVersion {
-  return semver.parse(s) !== null;
-}
-
-/**
- * Constructs a semantic version from a string.
- * @param s The string. Will be validated.
- */
-export function makeSemanticVersion(s: string): SemanticVersion {
-  assert(isSemanticVersion(s), `"${s}" is a semantic version`);
-  return s;
-}
+export type SemanticVersion = z.TypeOf<typeof SemanticVersion>;

--- a/src/services/parse-env.ts
+++ b/src/services/parse-env.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { GetUpmConfigPath, LoadUpmConfig } from "../io/upm-config-io";
 import path from "path";
-import { coerceRegistryUrl, makeRegistryUrl } from "../domain/registry-url";
+import { coerceRegistryUrl, RegistryUrl } from "../domain/registry-url";
 import { tryGetAuthForRegistry, UPMConfig } from "../domain/upm-config";
 import { CmdOptions } from "../cli/options";
 import { tryGetEnv } from "../utils/env-util";
@@ -84,7 +84,7 @@ export function makeParseEnv(
     const url =
       options._global.registry !== undefined
         ? coerceRegistryUrl(options._global.registry)
-        : makeRegistryUrl("https://package.openupm.com");
+        : RegistryUrl.parse("https://package.openupm.com");
 
     if (upmConfig === null) return { url, auth: null };
 
@@ -101,7 +101,7 @@ export function makeParseEnv(
   }
 
   function determineUpstreamRegistry(): Registry {
-    const url = makeRegistryUrl("https://packages.unity.com");
+    const url = RegistryUrl.parse("https://packages.unity.com");
 
     return { url, auth: null };
   }

--- a/src/utils/zod-utils.ts
+++ b/src/utils/zod-utils.ts
@@ -1,4 +1,4 @@
-import { ZodAny, ZodType, ZodTypeDef } from "zod";
+import { ZodType } from "zod";
 import { AssertionError } from "assert";
 
 /**

--- a/src/utils/zod-utils.ts
+++ b/src/utils/zod-utils.ts
@@ -1,0 +1,35 @@
+import { ZodAny, ZodType, ZodTypeDef } from "zod";
+import { AssertionError } from "assert";
+
+/**
+ * Checks that a value matches a zod type. Also narrows the value to the
+ * zod schemas type.
+ * @param value The value to check.
+ * @param schema The zod schema to check against.
+ */
+export function isZod<TZod extends ZodType>(
+  value: TZod["_input"],
+  schema: TZod
+): value is TZod["_output"] {
+  return schema.safeParse(value).success;
+}
+
+/**
+ * Asserts that a value matches a zod type. Also narrows the value to the
+ * zod schemas type.
+ * @param value The value to check.
+ * @param schema The zod schema to check against.
+ * @throws AssertionError if value does not match schema.
+ */
+export function assertZod<TZod extends ZodType>(
+  value: TZod["_input"],
+  schema: TZod
+): asserts value is TZod["_output"] {
+  const result = schema.safeParse(value);
+  if (!result.success)
+    throw new AssertionError({
+      actual: value,
+      expected: "Instance of: " + schema,
+      message: result.error.message,
+    });
+}

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -4,7 +4,7 @@ import {
   PackageIncompatibleError,
   UnresolvedDependenciesError,
 } from "../../src/cli/cmd-add";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { Env, ParseEnv } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
@@ -37,8 +37,8 @@ import {
   markRemoteResolved,
 } from "../../src/domain/dependency-graph";
 
-const somePackage = makeDomainName("com.some.package");
-const otherPackage = makeDomainName("com.other.package");
+const somePackage = DomainName.parse("com.some.package");
+const otherPackage = DomainName.parse("com.other.package");
 const somePackument = buildPackument(somePackage, (packument) =>
   packument.addVersion("1.0.0", (version) =>
     version.set("unity", "2022.2").addDependency(otherPackage, "1.0.0")
@@ -413,7 +413,7 @@ describe("cmd-add", () => {
     const { addCmd, writeProjectManifest } = makeDependencies();
 
     // The second package can not be added
-    await addCmd([somePackage, makeDomainName("com.unknown.package")], {
+    await addCmd([somePackage, DomainName.parse("com.unknown.package")], {
       _global: {},
     }).catch(() => {});
 

--- a/test/cli/cmd-add.test.ts
+++ b/test/cli/cmd-add.test.ts
@@ -15,7 +15,7 @@ import { buildPackument } from "../domain/data-packument";
 import { mockResolvedPackuments } from "../services/packument-resolving.mock";
 import { buildProjectManifest } from "../domain/data-project-manifest";
 import { ResolveDependencies } from "../../src/services/dependency-resolving";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { mockService } from "../services/service.mock";
 import {
   ResolvedPackumentVersion,
@@ -65,7 +65,7 @@ const defaultEnv = {
   upstreamRegistry: { url: unityRegistryUrl, auth: null },
 } as Env;
 
-const someVersion = makeSemanticVersion("1.0.0");
+const someVersion = SemanticVersion.parse("1.0.0");
 
 function makeDependencies() {
   const parseEnv = mockService<ParseEnv>();

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -5,7 +5,7 @@ import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { DomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
 import { makeMockLogger } from "./log.mock";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { PackumentNotFoundError } from "../../src/common-errors";
 import { ResolveDependencies } from "../../src/services/dependency-resolving";
 import { mockService } from "../services/service.mock";
@@ -27,7 +27,7 @@ const defaultEnv = {
   upstreamRegistry: { url: unityRegistryUrl, auth: null },
 } as Env;
 
-const someVersion = makeSemanticVersion("1.2.3");
+const someVersion = SemanticVersion.parse("1.2.3");
 
 function makeDependencies() {
   const parseEnv = mockService<ParseEnv>();

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -2,7 +2,7 @@ import { makeDepsCmd } from "../../src/cli/cmd-deps";
 import { Env, ParseEnv } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
 import { makeMockLogger } from "./log.mock";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
@@ -19,8 +19,8 @@ import {
   markRemoteResolved,
 } from "../../src/domain/dependency-graph";
 
-const somePackage = makeDomainName("com.some.package");
-const otherPackage = makeDomainName("com.other.package");
+const somePackage = DomainName.parse("com.some.package");
+const otherPackage = DomainName.parse("com.other.package");
 
 const defaultEnv = {
   registry: { url: exampleRegistryUrl, auth: null },

--- a/test/cli/cmd-remove.test.ts
+++ b/test/cli/cmd-remove.test.ts
@@ -1,14 +1,14 @@
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { Env, ParseEnv } from "../../src/services/parse-env";
 import { makeRemoveCmd } from "../../src/cli/cmd-remove";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { SemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import { mockService } from "../services/service.mock";
 import { RemovePackages } from "../../src/services/remove-packages";
 import { AsyncOk } from "../../src/utils/result-utils";
 
-const somePackage = makeDomainName("com.some.package");
+const somePackage = DomainName.parse("com.some.package");
 const defaultEnv = {
   cwd: "/users/some-user/projects/SomeProject",
   registry: { url: exampleRegistryUrl, auth: null },

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -1,6 +1,6 @@
 import { makeSearchCmd, SearchOptions } from "../../src/cli/cmd-search";
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import { SearchedPackument } from "../../src/io/npm-search";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -12,10 +12,10 @@ import { ResultCodes } from "../../src/cli/result-codes";
 
 const exampleSearchResult: SearchedPackument = {
   name: DomainName.parse("com.example.package-a"),
-  versions: { [makeSemanticVersion("1.0.0")]: "latest" },
+  versions: { [SemanticVersion.parse("1.0.0")]: "latest" },
   description: "A demo package",
   date: new Date(2019, 9, 2, 3, 2, 38),
-  "dist-tags": { latest: makeSemanticVersion("1.0.0") },
+  "dist-tags": { latest: SemanticVersion.parse("1.0.0") },
 };
 
 function makeDependencies() {

--- a/test/cli/cmd-search.test.ts
+++ b/test/cli/cmd-search.test.ts
@@ -1,5 +1,5 @@
 import { makeSearchCmd, SearchOptions } from "../../src/cli/cmd-search";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import { SearchedPackument } from "../../src/io/npm-search";
@@ -11,7 +11,7 @@ import { noopLogger } from "../../src/logging";
 import { ResultCodes } from "../../src/cli/result-codes";
 
 const exampleSearchResult: SearchedPackument = {
-  name: makeDomainName("com.example.package-a"),
+  name: DomainName.parse("com.example.package-a"),
   versions: { [makeSemanticVersion("1.0.0")]: "latest" },
   description: "A demo package",
   date: new Date(2019, 9, 2, 3, 2, 38),

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -4,7 +4,7 @@ import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { DomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
 import { buildPackument } from "../domain/data-packument";
 import { mockService } from "../services/service.mock";
@@ -18,7 +18,7 @@ const somePackument = buildPackument(somePackage, (packument) =>
     .set("time", {
       modified: "2019-11-28T18:51:58.123Z",
       created: "2019-11-28T18:51:58.123Z",
-      [makeSemanticVersion("1.0.0")]: "2019-11-28T18:51:58.123Z",
+      [SemanticVersion.parse("1.0.0")]: "2019-11-28T18:51:58.123Z",
     })
     .set("_rev", "3-418f950115c32bd0")
     .set("readme", "A demo package")
@@ -72,7 +72,7 @@ describe("cmd-view", () => {
     const { viewCmd } = makeDependencies();
 
     const resultCode = await viewCmd(
-      makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
+      makePackageReference(somePackage, SemanticVersion.parse("1.0.0")),
       { _global: {} }
     );
 
@@ -92,7 +92,7 @@ describe("cmd-view", () => {
     const { viewCmd, log } = makeDependencies();
 
     await viewCmd(
-      makePackageReference(somePackage, makeSemanticVersion("1.0.0")),
+      makePackageReference(somePackage, SemanticVersion.parse("1.0.0")),
       { _global: {} }
     );
 

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -2,7 +2,7 @@ import { makeViewCmd } from "../../src/cli/cmd-view";
 import { Env, ParseEnv } from "../../src/services/parse-env";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makePackageReference } from "../../src/domain/package-reference";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { makeMockLogger } from "./log.mock";
@@ -12,7 +12,7 @@ import { ResultCodes } from "../../src/cli/result-codes";
 import { FetchPackument } from "../../src/io/packument-io";
 import { PackumentNotFoundError } from "../../src/common-errors";
 
-const somePackage = makeDomainName("com.some.package");
+const somePackage = DomainName.parse("com.some.package");
 const somePackument = buildPackument(somePackage, (packument) =>
   packument
     .set("time", {

--- a/test/domain/data-packument.ts
+++ b/test/domain/data-packument.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { DomainName, isDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import {
   isSemanticVersion,
   SemanticVersion,
@@ -9,6 +9,7 @@ import {
   UnityPackument,
   UnityPackumentVersion,
 } from "../../src/domain/packument";
+import { isZod } from "../../src/utils/zod-utils";
 
 /**
  * Builder class for {@link UnityPackumentVersion}.
@@ -32,7 +33,7 @@ class UnityPackumentVersionBuilder {
    * @param version The version.
    */
   addDependency(name: string, version: string): UnityPackumentVersionBuilder {
-    assert(isDomainName(name), `${name} is domain name`);
+    assert(isZod(name, DomainName), `${name} is domain name`);
     assert(isSemanticVersion(version), `${version} is semantic version`);
     this.version = {
       ...this.version,
@@ -129,7 +130,7 @@ export function buildPackument(
   name: string,
   build?: (builder: UnityPackumentBuilder) => unknown
 ): UnityPackument {
-  assert(isDomainName(name), `${name} is domain name`);
+  assert(isZod(name, DomainName));
   const builder = new UnityPackumentBuilder(name);
   if (build !== undefined) build(builder);
   return builder.packument;

--- a/test/domain/data-packument.ts
+++ b/test/domain/data-packument.ts
@@ -1,9 +1,6 @@
 import assert from "assert";
 import { DomainName } from "../../src/domain/domain-name";
-import {
-  isSemanticVersion,
-  SemanticVersion,
-} from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { makePackageId } from "../../src/domain/package-id";
 import {
   UnityPackument,
@@ -34,7 +31,7 @@ class UnityPackumentVersionBuilder {
    */
   addDependency(name: string, version: string): UnityPackumentVersionBuilder {
     assert(isZod(name, DomainName), `${name} is domain name`);
-    assert(isSemanticVersion(version), `${version} is semantic version`);
+    assert(isZod(version, SemanticVersion), `${version} is semantic version`);
     this.version = {
       ...this.version,
       dependencies: {
@@ -90,7 +87,7 @@ class UnityPackumentBuilder {
     version: string,
     build?: (builder: UnityPackumentVersionBuilder) => unknown
   ): UnityPackumentBuilder {
-    assert(isSemanticVersion(version), `${version} is semantic version`);
+    assert(isZod(version, SemanticVersion), `${version} is semantic version`);
     const builder = new UnityPackumentVersionBuilder(
       this.packument.name,
       version

--- a/test/domain/data-project-manifest.ts
+++ b/test/domain/data-project-manifest.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { SemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
 import {

--- a/test/domain/data-project-manifest.ts
+++ b/test/domain/data-project-manifest.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { isSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
 import {
   addTestable,
@@ -66,7 +66,7 @@ class UnityProjectManifestBuilder {
     testable: boolean
   ): UnityProjectManifestBuilder {
     assertZod(name, DomainName);
-    assert(isSemanticVersion(version), `${version} is semantic version`);
+    assertZod(version, SemanticVersion);
     if (withScope) this.addScope(name);
     if (testable) this.addTestable(name);
     this.manifest = setDependency(this.manifest, name, version);

--- a/test/domain/data-project-manifest.ts
+++ b/test/domain/data-project-manifest.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import { isDomainName } from "../../src/domain/domain-name";
 import { isSemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
 import {
@@ -10,6 +9,8 @@ import {
   UnityProjectManifest,
 } from "../../src/domain/project-manifest";
 import { exampleRegistryUrl } from "./data-registry";
+import { assertZod } from "../../src/utils/zod-utils";
+import { DomainName } from "../../src/domain/domain-name";
 
 /**
  * Builder class for {@link UnityProjectManifest}.
@@ -26,7 +27,7 @@ class UnityProjectManifestBuilder {
    * @param name The name of the scope.
    */
   addScope(name: string): UnityProjectManifestBuilder {
-    assert(isDomainName(name), `${name} is domain name`);
+    assertZod(name, DomainName);
 
     this.manifest = mapScopedRegistry(
       this.manifest,
@@ -46,7 +47,7 @@ class UnityProjectManifestBuilder {
    * @param name The packages name.
    */
   addTestable(name: string): UnityProjectManifestBuilder {
-    assert(isDomainName(name), `${name} is domain name`);
+    assertZod(name, DomainName);
     this.manifest = addTestable(this.manifest, name);
     return this;
   }
@@ -64,7 +65,7 @@ class UnityProjectManifestBuilder {
     withScope: boolean,
     testable: boolean
   ): UnityProjectManifestBuilder {
-    assert(isDomainName(name), `${name} is domain name`);
+    assertZod(name, DomainName);
     assert(isSemanticVersion(version), `${version} is semantic version`);
     if (withScope) this.addScope(name);
     if (testable) this.addTestable(name);

--- a/test/domain/data-registry.ts
+++ b/test/domain/data-registry.ts
@@ -1,3 +1,3 @@
-import { makeRegistryUrl } from "../../src/domain/registry-url";
+import { RegistryUrl } from "../../src/domain/registry-url";
 
-export const exampleRegistryUrl = makeRegistryUrl("https://example.com");
+export const exampleRegistryUrl = RegistryUrl.parse("https://example.com");

--- a/test/domain/dependency-graph.test.ts
+++ b/test/domain/dependency-graph.test.ts
@@ -1,4 +1,4 @@
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import {
   graphNodeCount,
@@ -15,9 +15,9 @@ import { exampleRegistryUrl } from "./data-registry";
 import { PackumentNotFoundError } from "../../src/common-errors";
 
 describe("dependency graph", () => {
-  const somePackage = makeDomainName("com.some.package");
-  const otherPackage = makeDomainName("com.other.package");
-  const anotherPackage = makeDomainName("com.another.package");
+  const somePackage = DomainName.parse("com.some.package");
+  const otherPackage = DomainName.parse("com.other.package");
+  const anotherPackage = DomainName.parse("com.another.package");
   const someVersion = makeSemanticVersion("1.0.0");
 
   describe("traverse", () => {

--- a/test/domain/dependency-graph.test.ts
+++ b/test/domain/dependency-graph.test.ts
@@ -1,5 +1,5 @@
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import {
   graphNodeCount,
   makeGraphFromSeed,
@@ -18,7 +18,7 @@ describe("dependency graph", () => {
   const somePackage = DomainName.parse("com.some.package");
   const otherPackage = DomainName.parse("com.other.package");
   const anotherPackage = DomainName.parse("com.another.package");
-  const someVersion = makeSemanticVersion("1.0.0");
+  const someVersion = SemanticVersion.parse("1.0.0");
 
   describe("traverse", () => {
     it("should output all nodes", () => {

--- a/test/domain/domain-name.arb.ts
+++ b/test/domain/domain-name.arb.ts
@@ -1,5 +1,5 @@
 import fc from "fast-check";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 
 /**
  * Single char string [A-Z].
@@ -50,4 +50,4 @@ export const arbDomainName = fc
     maxLength: 4,
   })
   .map((segments) => segments.join("."))
-  .map(makeDomainName);
+  .map(DomainName.parse);

--- a/test/domain/domain-name.test.ts
+++ b/test/domain/domain-name.test.ts
@@ -1,4 +1,5 @@
-import { isDomainName } from "../../src/domain/domain-name";
+import { isZod } from "../../src/utils/zod-utils";
+import { DomainName } from "../../src/domain/domain-name";
 
 describe("domain-name", () => {
   describe("validation", () => {
@@ -9,7 +10,7 @@ describe("domain-name", () => {
       "at.ac.my-school",
       "dev.comradevanti123",
     ])(`should be ok for "%s"`, (s) => {
-      expect(isDomainName(s)).toBeTruthy();
+      expect(isZod(s, DomainName)).toBeTruthy();
     });
 
     it.each([
@@ -24,7 +25,7 @@ describe("domain-name", () => {
       // No trailing hyphens
       "com.unity-",
     ])(`should not be ok for "%s"`, (s) => {
-      expect(isDomainName(s)).toBeFalsy();
+      expect(isZod(s, DomainName)).toBeFalsy();
     });
   });
 });

--- a/test/domain/package-url.test.ts
+++ b/test/domain/package-url.test.ts
@@ -1,14 +1,15 @@
-import { isPackageUrl } from "../../src/domain/package-url";
+import { PackageUrl } from "../../src/domain/package-url";
 import fc from "fast-check";
 import { arbDomainName } from "./domain-name.arb";
+import { isZod } from "../../src/utils/zod-utils";
 
 describe("package-url", () => {
   describe("validation", () => {
     it("should be ok for http", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
-          const input = `https://github.com/user/${{packumentName}}`;
-          expect(isPackageUrl(input)).toBeTruthy();
+          const input = `https://github.com/user/${{ packumentName }}`;
+          expect(isZod(input, PackageUrl)).toBeTruthy();
         })
       );
     });
@@ -17,7 +18,7 @@ describe("package-url", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `https://github.com/user/${{ packumentName }}`;
-          expect(isPackageUrl(input)).toBeTruthy();
+          expect(isZod(input, PackageUrl)).toBeTruthy();
         })
       );
     });
@@ -26,7 +27,7 @@ describe("package-url", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `git@github:user/${{ packumentName }}`;
-          expect(isPackageUrl(input)).toBeTruthy();
+          expect(isZod(input, PackageUrl)).toBeTruthy();
         })
       );
     });
@@ -35,7 +36,7 @@ describe("package-url", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `file:/path/to/${{ packumentName }}`;
-          expect(isPackageUrl(input)).toBeTruthy();
+          expect(isZod(input, PackageUrl)).toBeTruthy();
         })
       );
     });
@@ -46,7 +47,7 @@ describe("package-url", () => {
       // Bad protocol
       "ftp://my.server/my-package",
     ])(`should not be ok for "%s"`, (url) => {
-      expect(isPackageUrl(url)).not.toBeTruthy();
+      expect(isZod(url, PackageUrl)).not.toBeTruthy();
     });
   });
 });

--- a/test/domain/packument.test.ts
+++ b/test/domain/packument.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/domain/packument";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { buildPackument } from "./data-packument";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 
 describe("packument", () => {
   describe("get latest version", () => {
@@ -63,8 +63,8 @@ describe("packument", () => {
   });
 
   describe("resolve version", () => {
-    const somePackage = makeDomainName("com.some.package");
-    const otherPackage = makeDomainName("com.other.package");
+    const somePackage = DomainName.parse("com.some.package");
+    const otherPackage = DomainName.parse("com.other.package");
     const someHighVersion = makeSemanticVersion("2.0.0");
     const someLowVersion = makeSemanticVersion("1.0.0");
     const somePackument = buildPackument(somePackage, (packument) =>

--- a/test/domain/packument.test.ts
+++ b/test/domain/packument.test.ts
@@ -5,7 +5,7 @@ import {
   tryResolvePackumentVersion,
   VersionNotFoundError,
 } from "../../src/domain/packument";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { buildPackument } from "./data-packument";
 import { DomainName } from "../../src/domain/domain-name";
 
@@ -13,7 +13,7 @@ describe("packument", () => {
   describe("get latest version", () => {
     it("should first get version from dist-tags", async () => {
       const packument = {
-        "dist-tags": { latest: makeSemanticVersion("1.0.0") },
+        "dist-tags": { latest: SemanticVersion.parse("1.0.0") },
       };
 
       const version = tryGetLatestVersion(packument);
@@ -23,7 +23,7 @@ describe("packument", () => {
 
     it("should then get version from version property", async () => {
       const packument = {
-        version: makeSemanticVersion("1.0.0"),
+        version: SemanticVersion.parse("1.0.0"),
       };
 
       const version = tryGetLatestVersion(packument);
@@ -42,7 +42,7 @@ describe("packument", () => {
 
   describe("get version", () => {
     it("should find existing packument version", () => {
-      const version = makeSemanticVersion("1.0.0");
+      const version = SemanticVersion.parse("1.0.0");
       const packument = buildPackument("com.some.package", (packument) =>
         packument.addVersion(version)
       );
@@ -53,7 +53,7 @@ describe("packument", () => {
     });
 
     it("should not find missing packument version", () => {
-      const version = makeSemanticVersion("1.0.0");
+      const version = SemanticVersion.parse("1.0.0");
       const packument = buildPackument("com.some.package");
 
       const packumentVersion = tryGetPackumentVersion(packument, version);
@@ -65,8 +65,8 @@ describe("packument", () => {
   describe("resolve version", () => {
     const somePackage = DomainName.parse("com.some.package");
     const otherPackage = DomainName.parse("com.other.package");
-    const someHighVersion = makeSemanticVersion("2.0.0");
-    const someLowVersion = makeSemanticVersion("1.0.0");
+    const someHighVersion = SemanticVersion.parse("2.0.0");
+    const someLowVersion = SemanticVersion.parse("1.0.0");
     const somePackument = buildPackument(somePackage, (packument) =>
       packument
         .addVersion(someLowVersion, (version) =>
@@ -110,7 +110,7 @@ describe("packument", () => {
     });
 
     it("should fail if version is not found", () => {
-      const someNonExistentVersion = makeSemanticVersion("3.0.0");
+      const someNonExistentVersion = SemanticVersion.parse("3.0.0");
 
       const result = tryResolvePackumentVersion(
         somePackument,

--- a/test/domain/project-manifest.test.ts
+++ b/test/domain/project-manifest.test.ts
@@ -11,11 +11,11 @@ import {
 import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
-import { makeRegistryUrl } from "../../src/domain/registry-url";
 import fc from "fast-check";
 import { arbDomainName } from "./domain-name.arb";
 import { exampleRegistryUrl } from "./data-registry";
 import { buildProjectManifest } from "./data-project-manifest";
+import { RegistryUrl } from "../../src/domain/registry-url";
 
 describe("project-manifest", () => {
   describe("set dependency", () => {
@@ -91,7 +91,7 @@ describe("project-manifest", () => {
   describe("get scoped-registry", () => {
     it("should should find scoped-registry with url if present", () => {
       let manifest = emptyProjectManifest;
-      const url = makeRegistryUrl("https://test.com");
+      const url = RegistryUrl.parse("https://test.com");
       const expected = makeScopedRegistry("test", url);
 
       manifest = setScopedRegistry(manifest, expected);
@@ -101,10 +101,10 @@ describe("project-manifest", () => {
 
     it("should should not find scoped-registry with incorrect url", () => {
       let manifest = emptyProjectManifest;
-      const url = makeRegistryUrl("https://test.com");
+      const url = RegistryUrl.parse("https://test.com");
       const expected = makeScopedRegistry(
         "test",
-        makeRegistryUrl("https://test2.com")
+        RegistryUrl.parse("https://test2.com")
       );
 
       manifest = setScopedRegistry(manifest, expected);

--- a/test/domain/project-manifest.test.ts
+++ b/test/domain/project-manifest.test.ts
@@ -9,7 +9,7 @@ import {
   tryGetScopedRegistryByUrl,
 } from "../../src/domain/project-manifest";
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
 import fc from "fast-check";
 import { arbDomainName } from "./domain-name.arb";
@@ -27,7 +27,7 @@ describe("project-manifest", () => {
           manifest = setDependency(
             manifest,
             packumentName,
-            makeSemanticVersion("1.2.3")
+            SemanticVersion.parse("1.2.3")
           );
 
           expect(manifest.dependencies).toEqual({ [packumentName]: "1.2.3" });
@@ -43,12 +43,12 @@ describe("project-manifest", () => {
           manifest = setDependency(
             manifest,
             packumentName,
-            makeSemanticVersion("1.2.3")
+            SemanticVersion.parse("1.2.3")
           );
           manifest = setDependency(
             manifest,
             packumentName,
-            makeSemanticVersion("2.3.4")
+            SemanticVersion.parse("2.3.4")
           );
 
           expect(manifest.dependencies).toEqual({ [packumentName]: "2.3.4" });
@@ -66,7 +66,7 @@ describe("project-manifest", () => {
           manifest = setDependency(
             manifest,
             packumentName,
-            makeSemanticVersion("1.2.3")
+            SemanticVersion.parse("1.2.3")
           );
           manifest = removeDependency(manifest, packumentName);
 

--- a/test/domain/project-manifest.test.ts
+++ b/test/domain/project-manifest.test.ts
@@ -8,7 +8,7 @@ import {
   setScopedRegistry,
   tryGetScopedRegistryByUrl,
 } from "../../src/domain/project-manifest";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { addScope, makeScopedRegistry } from "../../src/domain/scoped-registry";
 import { makeRegistryUrl } from "../../src/domain/registry-url";
@@ -150,7 +150,7 @@ describe("project-manifest", () => {
     it("should not updated scoped-registry after returning it", () => {
       let manifest = emptyProjectManifest;
       const initial = makeScopedRegistry("test", exampleRegistryUrl);
-      const expected = addScope(initial, makeDomainName("wow"));
+      const expected = addScope(initial, DomainName.parse("wow"));
       manifest = setScopedRegistry(manifest, initial);
 
       manifest = mapScopedRegistry(
@@ -181,8 +181,8 @@ describe("project-manifest", () => {
     it("should add testables in alphabetical order", () => {
       let manifest = emptyProjectManifest;
 
-      manifest = addTestable(manifest, makeDomainName("b"));
-      manifest = addTestable(manifest, makeDomainName("a"));
+      manifest = addTestable(manifest, DomainName.parse("b"));
+      manifest = addTestable(manifest, DomainName.parse("a"));
 
       expect(manifest.testables).toEqual(["a", "b"]);
     });
@@ -190,7 +190,7 @@ describe("project-manifest", () => {
 
   describe("has dependency", () => {
     it("should be true if manifest has dependency", () => {
-      const packageName = makeDomainName("com.some.package");
+      const packageName = DomainName.parse("com.some.package");
       const manifest = buildProjectManifest((manifest) =>
         manifest.addDependency(packageName, "1.0.0", true, true)
       );
@@ -199,7 +199,7 @@ describe("project-manifest", () => {
     });
 
     it("should be false if manifest does not have dependency", () => {
-      const packageName = makeDomainName("com.some.package");
+      const packageName = DomainName.parse("com.some.package");
 
       expect(hasDependency(emptyProjectManifest, packageName)).toBeFalsy();
     });

--- a/test/domain/registry-url.test.ts
+++ b/test/domain/registry-url.test.ts
@@ -1,14 +1,12 @@
-import {
-  coerceRegistryUrl,
-  isRegistryUrl,
-} from "../../src/domain/registry-url";
+import { coerceRegistryUrl, RegistryUrl } from "../../src/domain/registry-url";
+import { isZod } from "../../src/utils/zod-utils";
 
 describe("registry-url", () => {
   describe("validation", () => {
     it.each(["http://registry.npmjs.org", "https://registry.npmjs.org"])(
       `"should be ok for "%s"`,
       (input) => {
-        expect(isRegistryUrl(input)).toBeTruthy();
+        expect(isZod(input, RegistryUrl)).toBeTruthy();
       }
     );
 
@@ -18,7 +16,7 @@ describe("registry-url", () => {
       // Trailing slash
       "http://registry.npmjs.org/",
     ])(`"should not be ok for "%s"`, (input) => {
-      expect(isRegistryUrl(input)).not.toBeTruthy();
+      expect(isZod(input, RegistryUrl)).not.toBeTruthy();
     });
   });
 

--- a/test/domain/scoped-registry.test.ts
+++ b/test/domain/scoped-registry.test.ts
@@ -5,7 +5,7 @@ import {
   makeScopedRegistry,
   removeScope,
 } from "../../src/domain/scoped-registry";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import fc from "fast-check";
 import { arbDomainName } from "./domain-name.arb";
 import { exampleRegistryUrl } from "./data-registry";
@@ -29,8 +29,8 @@ describe("scoped-registry", () => {
     it("should keep scope-list alphabetical", () => {
       let registry = makeScopedRegistry("test", exampleRegistryUrl);
 
-      registry = addScope(registry, makeDomainName("b"));
-      registry = addScope(registry, makeDomainName("a"));
+      registry = addScope(registry, DomainName.parse("b"));
+      registry = addScope(registry, DomainName.parse("a"));
 
       expect(registry.scopes).toEqual(["a", "b"]);
     });
@@ -90,12 +90,12 @@ describe("scoped-registry", () => {
 
     it("should not do nothing if scope does not exist", () => {
       let registry = makeScopedRegistry("test", exampleRegistryUrl, [
-        makeDomainName("a"),
+        DomainName.parse("a"),
       ]);
 
-      registry = removeScope(registry, makeDomainName("b"));
+      registry = removeScope(registry, DomainName.parse("b"));
 
-      expect(hasScope(registry, makeDomainName("a"))).toBeTruthy();
+      expect(hasScope(registry, DomainName.parse("a"))).toBeTruthy();
     });
 
     it("should remove duplicate scopes", () => {

--- a/test/domain/semantic-version.test.ts
+++ b/test/domain/semantic-version.test.ts
@@ -1,15 +1,16 @@
-import { isSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
+import { isZod } from "../../src/utils/zod-utils";
 
 describe("semantic-version", () => {
   describe("validate", () => {
     it.each(["1.2.3", "1.2.3-alpha"])(`should be ok for "%s"`, (input) => {
-      expect(isSemanticVersion(input)).toBeTruthy();
+      expect(isZod(input, SemanticVersion)).toBeTruthy();
     });
 
     it.each(["", " ", "wow", "1", "1.2"])(
       `should not be ok for "%s"`,
       (input) => {
-        expect(isSemanticVersion(input)).not.toBeTruthy();
+        expect(isZod(input, SemanticVersion)).not.toBeTruthy();
       }
     );
   });

--- a/test/domain/upm-config.test.ts
+++ b/test/domain/upm-config.test.ts
@@ -12,7 +12,7 @@ import {
   UPMConfig,
 } from "../../src/domain/upm-config";
 import { Base64 } from "../../src/domain/base64";
-import { makeRegistryUrl, RegistryUrl } from "../../src/domain/registry-url";
+import { RegistryUrl } from "../../src/domain/registry-url";
 import { NpmAuth } from "another-npm-registry-client";
 
 import { exampleRegistryUrl } from "./data-registry";
@@ -97,7 +97,7 @@ describe("upm-config", () => {
     });
     describe("get auth for registry", () => {
       it("should find auth for url without trailing slash", () => {
-        const url = makeRegistryUrl("https://registry.npmjs.com");
+        const url = RegistryUrl.parse("https://registry.npmjs.com");
         const expected: NpmAuth = {
           alwaysAuth: false,
           token: "This is not a valid token",
@@ -147,7 +147,7 @@ describe("upm-config", () => {
 
         const actual = tryGetAuthForRegistry(
           config,
-          makeRegistryUrl("https://registryB.com")
+          RegistryUrl.parse("https://registryB.com")
         );
         expect(actual).toBeNull();
       });

--- a/test/e2e/add.e2e.ts
+++ b/test/e2e/add.e2e.ts
@@ -4,7 +4,7 @@ import { prepareUnityProject } from "./setup/project";
 import { ResultCodes } from "../../src/cli/result-codes";
 import { getProjectManifest } from "./check/project-manifest";
 import { emptyProjectManifest } from "../../src/domain/project-manifest";
-import { makeRegistryUrl, RegistryUrl } from "../../src/domain/registry-url";
+import { RegistryUrl } from "../../src/domain/registry-url";
 
 describe("add packages", () => {
   type SuccessfulAddCase = {
@@ -287,7 +287,7 @@ describe("add packages", () => {
         },
       ],
       ["jp.keijiro.metamesh"],
-      makeRegistryUrl("https://registry.npmjs.com")
+      RegistryUrl.parse("https://registry.npmjs.com")
     );
   });
 });

--- a/test/io/packument-io.test.ts
+++ b/test/io/packument-io.test.ts
@@ -1,6 +1,6 @@
 import { buildPackument } from "../domain/data-packument";
 import { HttpErrorBase } from "npm-registry-fetch/lib/errors";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import RegClient from "another-npm-registry-client";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -10,7 +10,7 @@ import { noopLogger } from "../../src/logging";
 
 describe("packument io", () => {
   describe("fetch", () => {
-    const packageA = makeDomainName("package-a");
+    const packageA = DomainName.parse("package-a");
     const exampleRegistry: Registry = {
       url: exampleRegistryUrl,
       auth: null,

--- a/test/services/built-in-package-check.test.ts
+++ b/test/services/built-in-package-check.test.ts
@@ -3,12 +3,12 @@ import { makeCheckIsBuiltInPackage } from "../../src/services/built-in-package-c
 import { mockService } from "./service.mock";
 import { FetchPackument } from "../../src/io/packument-io";
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { UnityPackument } from "../../src/domain/packument";
 
 describe("is built-in package", () => {
   const somePackage = DomainName.parse("com.some.package");
-  const someVersion = makeSemanticVersion("1.0.0");
+  const someVersion = SemanticVersion.parse("1.0.0");
 
   function makeDependencies() {
     const checkIsUnityPackage = mockService<CheckIsUnityPackage>();

--- a/test/services/built-in-package-check.test.ts
+++ b/test/services/built-in-package-check.test.ts
@@ -2,12 +2,12 @@ import { CheckIsUnityPackage } from "../../src/services/unity-package-check";
 import { makeCheckIsBuiltInPackage } from "../../src/services/built-in-package-check";
 import { mockService } from "./service.mock";
 import { FetchPackument } from "../../src/io/packument-io";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { UnityPackument } from "../../src/domain/packument";
 
 describe("is built-in package", () => {
-  const somePackage = makeDomainName("com.some.package");
+  const somePackage = DomainName.parse("com.some.package");
   const someVersion = makeSemanticVersion("1.0.0");
 
   function makeDependencies() {

--- a/test/services/dependency-resolving.test.ts
+++ b/test/services/dependency-resolving.test.ts
@@ -5,7 +5,7 @@ import { CheckIsBuiltInPackage } from "../../src/services/built-in-package-check
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { Registry } from "../../src/domain/registry";
 import { NodeType, tryGetGraphNode } from "../../src/domain/dependency-graph";
 import { PackumentNotFoundError } from "../../src/common-errors";
@@ -20,8 +20,8 @@ describe("dependency resolving", () => {
   const somePackage = DomainName.parse("com.some.package");
   const otherPackage = DomainName.parse("com.other.package");
 
-  const someVersion = makeSemanticVersion("1.0.0");
-  const otherVersion = makeSemanticVersion("2.0.0");
+  const someVersion = SemanticVersion.parse("1.0.0");
+  const otherVersion = SemanticVersion.parse("2.0.0");
 
   function makeDependencies() {
     const fetchPackument = mockService<FetchPackument>();

--- a/test/services/dependency-resolving.test.ts
+++ b/test/services/dependency-resolving.test.ts
@@ -4,7 +4,7 @@ import { FetchPackument } from "../../src/io/packument-io";
 import { CheckIsBuiltInPackage } from "../../src/services/built-in-package-check";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { Registry } from "../../src/domain/registry";
 import { NodeType, tryGetGraphNode } from "../../src/domain/dependency-graph";
@@ -17,8 +17,8 @@ describe("dependency resolving", () => {
     { url: unityRegistryUrl, auth: null },
   ];
 
-  const somePackage = makeDomainName("com.some.package");
-  const otherPackage = makeDomainName("com.other.package");
+  const somePackage = DomainName.parse("com.some.package");
+  const otherPackage = DomainName.parse("com.other.package");
 
   const someVersion = makeSemanticVersion("1.0.0");
   const otherVersion = makeSemanticVersion("2.0.0");

--- a/test/services/remove-packages.test.ts
+++ b/test/services/remove-packages.test.ts
@@ -7,15 +7,15 @@ import {
   LoadProjectManifest,
   WriteProjectManifest,
 } from "../../src/io/project-manifest-io";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { buildProjectManifest } from "../domain/data-project-manifest";
 import path from "path";
 import { PackumentNotFoundError } from "../../src/common-errors";
 
 describe("remove packages", () => {
   const someProjectPath = path.resolve("/home/projects/MyUnityProject");
-  const somePackage = makeDomainName("com.some.package");
-  const otherPackage = makeDomainName("com.other.package");
+  const somePackage = DomainName.parse("com.some.package");
+  const otherPackage = DomainName.parse("com.other.package");
 
   const defaultManifest = buildProjectManifest((manifest) =>
     manifest.addDependency(somePackage, "1.0.0", true, true)

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -1,6 +1,6 @@
 import { mockService } from "./service.mock";
 import { makeResolveLatestVersion } from "../../src/services/resolve-latest-version";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { UnityPackument } from "../../src/domain/packument";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -9,7 +9,7 @@ import { FetchPackument } from "../../src/io/packument-io";
 import { SemanticVersion } from "../../src/domain/semantic-version";
 
 describe("resolve latest version service", () => {
-  const somePackage = makeDomainName("com.some.package");
+  const somePackage = DomainName.parse("com.some.package");
 
   const exampleRegistry: Registry = { url: exampleRegistryUrl, auth: null };
   const upstreamRegistry: Registry = { url: unityRegistryUrl, auth: null };

--- a/test/services/resolve-remote-packument-version.test.ts
+++ b/test/services/resolve-remote-packument-version.test.ts
@@ -1,6 +1,6 @@
 import { mockService } from "./service.mock";
 import { makeResolveRemotePackumentVersion } from "../../src/services/resolve-remote-packument-version";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
@@ -9,7 +9,7 @@ import { buildPackument } from "../domain/data-packument";
 import { FetchPackument } from "../../src/io/packument-io";
 
 describe("resolve remote packument version", () => {
-  const somePackage = makeDomainName("com.some.package");
+  const somePackage = DomainName.parse("com.some.package");
 
   const someVersion = makeSemanticVersion("1.0.0");
 

--- a/test/services/resolve-remote-packument-version.test.ts
+++ b/test/services/resolve-remote-packument-version.test.ts
@@ -1,7 +1,7 @@
 import { mockService } from "./service.mock";
 import { makeResolveRemotePackumentVersion } from "../../src/services/resolve-remote-packument-version";
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { PackumentNotFoundError } from "../../src/common-errors";
@@ -11,7 +11,7 @@ import { FetchPackument } from "../../src/io/packument-io";
 describe("resolve remote packument version", () => {
   const somePackage = DomainName.parse("com.some.package");
 
-  const someVersion = makeSemanticVersion("1.0.0");
+  const someVersion = SemanticVersion.parse("1.0.0");
 
   const someRegistry: Registry = { url: exampleRegistryUrl, auth: null };
 

--- a/test/services/search-packages.test.ts
+++ b/test/services/search-packages.test.ts
@@ -8,7 +8,7 @@ import { makeSearchPackages } from "../../src/services/search-packages";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
 import { DomainName } from "../../src/domain/domain-name";
-import { makeSemanticVersion } from "../../src/domain/semantic-version";
+import { SemanticVersion } from "../../src/domain/semantic-version";
 import { noopLogger } from "../../src/logging";
 
 describe("search packages", () => {
@@ -21,10 +21,10 @@ describe("search packages", () => {
 
   const exampleSearchResult: SearchedPackument = {
     name: DomainName.parse("com.example.package-a"),
-    versions: { [makeSemanticVersion("1.0.0")]: "latest" },
+    versions: { [SemanticVersion.parse("1.0.0")]: "latest" },
     description: "A demo package",
     date: new Date(2019, 9, 2, 3, 2, 38),
-    "dist-tags": { latest: makeSemanticVersion("1.0.0") },
+    "dist-tags": { latest: SemanticVersion.parse("1.0.0") },
   };
 
   const exampleAllPackumentsResult = {

--- a/test/services/search-packages.test.ts
+++ b/test/services/search-packages.test.ts
@@ -7,7 +7,7 @@ import {
 import { makeSearchPackages } from "../../src/services/search-packages";
 import { Registry } from "../../src/domain/registry";
 import { exampleRegistryUrl } from "../domain/data-registry";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 import { makeSemanticVersion } from "../../src/domain/semantic-version";
 import { noopLogger } from "../../src/logging";
 
@@ -20,7 +20,7 @@ describe("search packages", () => {
   const exampleKeyword = "package-a";
 
   const exampleSearchResult: SearchedPackument = {
-    name: makeDomainName("com.example.package-a"),
+    name: DomainName.parse("com.example.package-a"),
     versions: { [makeSemanticVersion("1.0.0")]: "latest" },
     description: "A demo package",
     date: new Date(2019, 9, 2, 3, 2, 38),

--- a/test/services/unity-package-check.test.ts
+++ b/test/services/unity-package-check.test.ts
@@ -1,10 +1,10 @@
 import { makeCheckIsUnityPackage } from "../../src/services/unity-package-check";
 import { mockService } from "./service.mock";
 import { CheckUrlExists } from "../../src/io/check-url";
-import { makeDomainName } from "../../src/domain/domain-name";
+import { DomainName } from "../../src/domain/domain-name";
 
 describe("is unity package", () => {
-  const somePackage = makeDomainName("com.some.package");
+  const somePackage = DomainName.parse("com.some.package");
 
   function makeDependencies() {
     const checkUrlExists = mockService<CheckUrlExists>();


### PR DESCRIPTION
Currently validation for constrained primitive types, such as SemanticVersion or DomainName, is done manually. They are then branded using `ts-brand`.

This change transitions to using Zod for validation and branding. This is in preparation for using zod to validate external data.