### PR TITLE
refactor: enable exact optionals

### DIFF
--- a/src/domain/project-manifest.ts
+++ b/src/domain/project-manifest.ts
@@ -113,9 +113,10 @@ export function mapScopedRegistry(
 ): UnityProjectManifest {
   const updated = mapF(tryGetScopedRegistryByUrl(manifest, registryUrl));
 
-  let newScopedRegistries = manifest.scopedRegistries?.filter(
-    (it) => it.url !== (updated?.url ?? registryUrl)
-  );
+  let newScopedRegistries =
+    manifest.scopedRegistries?.filter(
+      (it) => it.url !== (updated?.url ?? registryUrl)
+    ) ?? [];
 
   if (updated !== null)
     newScopedRegistries = [...(newScopedRegistries ?? []), updated];
@@ -164,9 +165,10 @@ export function addTestable(
 export function pruneManifest(
   manifest: UnityProjectManifest
 ): UnityProjectManifest {
+  if (manifest.scopedRegistries === undefined) return manifest;
   return {
     ...manifest,
-    scopedRegistries: manifest.scopedRegistries?.filter(
+    scopedRegistries: manifest.scopedRegistries.filter(
       (it) => it.scopes.length > 0
     ),
   };

--- a/src/services/remove-packages.ts
+++ b/src/services/remove-packages.ts
@@ -58,17 +58,18 @@ export function makeRemovePackages(
 
     manifest = removeDependency(manifest, packageName);
 
-    manifest = {
-      ...manifest,
-      scopedRegistries: manifest.scopedRegistries
-        // Remove package scope from all scoped registries
-        ?.map((scopedRegistry) => ({
-          ...scopedRegistry,
-          scopes: scopedRegistry.scopes.filter(
-            (scope) => scope !== packageName
-          ),
-        })),
-    };
+    if (manifest.scopedRegistries !== undefined)
+      manifest = {
+        ...manifest,
+        scopedRegistries: manifest.scopedRegistries
+          // Remove package scope from all scoped registries
+          .map((scopedRegistry) => ({
+            ...scopedRegistry,
+            scopes: scopedRegistry.scopes.filter(
+              (scope) => scope !== packageName
+            ),
+          })),
+      };
 
     return Ok([manifest, { name: packageName, version: versionInManifest }]);
   };

--- a/src/types/another-npm-registry-client.d.ts
+++ b/src/types/another-npm-registry-client.d.ts
@@ -16,7 +16,7 @@ declare module "another-npm-registry-client" {
     timeout?: number;
     follow?: boolean;
     staleOk?: boolean;
-    auth?: NpmAuth;
+    auth?: NpmAuth | undefined;
     fullMetadata?: boolean;
   };
 

--- a/test/domain/package-manifest.test.ts
+++ b/test/domain/package-manifest.test.ts
@@ -24,9 +24,7 @@ describe("package manifest", () => {
     });
 
     it("should empty list for missing dependencies property", () => {
-      const packageManifest = {
-        dependencies: undefined,
-      };
+      const packageManifest = {};
 
       const dependencies = dependenciesOf(packageManifest);
 

--- a/test/domain/upm-config.test.ts
+++ b/test/domain/upm-config.test.ts
@@ -105,7 +105,7 @@ describe("upm-config", () => {
         const config: UPMConfig = {
           npmAuth: {
             [url]: {
-              alwaysAuth: expected.alwaysAuth,
+              alwaysAuth: expected.alwaysAuth!,
               email: "real@email.com",
               token: expected.token,
             },
@@ -124,7 +124,7 @@ describe("upm-config", () => {
         const config: UPMConfig = {
           npmAuth: {
             [url]: {
-              alwaysAuth: expected.alwaysAuth,
+              alwaysAuth: expected.alwaysAuth!,
               email: "real@email.com",
               token: expected.token,
             },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -95,7 +95,7 @@
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,                  /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */


### PR DESCRIPTION
This change enables the `exactOptionalPropertyTypes` option in tsconfig. Also refactors code to work with this change.

This will give more security to prevent exporting explicit undefineds into external files.