### PR TITLE
refactor: remove unused properties

### DIFF
--- a/src/domain/package-manifest.ts
+++ b/src/domain/package-manifest.ts
@@ -9,27 +9,6 @@ import { MalformedPackumentError } from "../common-errors";
 type MajorMinor = `${number}.${number}`;
 
 /**
- * A package sample.
- * @see https://docs.unity3d.com/Manual/cus-samples.html
- */
-type Sample = {
-  /**
-   * The name of the sample as it appears in the package details on the
-   * Package Manager window.
-   */
-  displayName: string;
-  /**
-   * A brief description of what the sample demonstrates or contains.
-   * This is just for the package manifest.
-   */
-  description: string;
-  /**
-   * The path from the Samples~ folder to the sample’s root folder.
-   */
-  path: string;
-};
-
-/**
  * The content of a `package.json` file for a Unity package.
  * @see https://docs.unity3d.com/Manual/upm-manifestPkg.html
  */
@@ -75,13 +54,6 @@ export type UnityPackageManifest = Readonly<{
    */
   documentationUrl?: string;
   /**
-   * By default, a package’s assets are hidden in the Project window and
-   * omitted from the results when you use the Object Picker in the Inspector
-   * window. Set this property to “false” to make sure that this package’s
-   * assets are always visible.
-   */
-  hideInEditor?: boolean;
-  /**
    * An array of keywords used by the Package Manager search APIs.
    */
   keywords?: ReadonlyArray<string>;
@@ -94,14 +66,6 @@ export type UnityPackageManifest = Readonly<{
    * Custom location for this package’s license information specified as a URL.
    */
   licenseUrl?: string;
-  /**
-   * List of samples included in the package.
-   */
-  samples?: ReadonlyArray<Sample>;
-  /**
-   * A constant that provides additional information to the Package Manager.
-   */
-  type?: string;
   /**
    * Part of a Unity version indicating the specific release of Unity that the
    * package is compatible with.

--- a/src/domain/packument.ts
+++ b/src/domain/packument.ts
@@ -17,18 +17,7 @@ import { PackumentNotFoundError } from "../common-errors";
  */
 export type UnityPackumentVersion = Readonly<
   UnityPackageManifest & {
-    /**
-     * Same as {@link name}.
-     */
-    _id?: PackageId;
-    _nodeVersion?: string;
-    _npmVersion?: string;
-    _rev?: string;
     homepage?: string;
-    category?: string;
-    gitHead?: string;
-    readmeFilename?: string;
-    contributors?: ReadonlyArray<Maintainer>;
     dist?: Readonly<Dist>;
   }
 >;
@@ -41,16 +30,6 @@ export type UnityPackument = Readonly<{
    * The packages name.
    */
   name: DomainName;
-  /**
-   * Same as {@link name}.
-   */
-  _id?: DomainName;
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  _rev?: string;
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  _attachments?: Readonly<Record<string, unknown>>;
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  readme?: string;
   /**
    * The packages versions, organized by their version.
    */
@@ -82,8 +61,6 @@ export type UnityPackument = Readonly<{
   }>;
   // eslint-disable-next-line jsdoc/require-jsdoc
   date?: Date;
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  users?: Readonly<Record<string, unknown>>;
 }>;
 
 /**

--- a/src/domain/project-manifest.ts
+++ b/src/domain/project-manifest.ts
@@ -18,15 +18,6 @@ export type UnityProjectManifest = Readonly<{
    */
   dependencies: Readonly<Record<DomainName, SemanticVersion | PackageUrl>>;
   /**
-   * Enables a lock file to ensure that dependencies are resolved in a
-   * deterministic manner.
-   */
-  enableLockFile?: boolean;
-  /**
-   * Upgrades indirect dependencies based on Semantic Versioning rules.
-   */
-  resolutionStrategy?: string;
-  /**
    * Specify custom registries in addition to the default registry.
    * This allows you to host your own packages.
    */

--- a/test/cli/cmd-view.test.ts
+++ b/test/cli/cmd-view.test.ts
@@ -20,8 +20,6 @@ const somePackument = buildPackument(somePackage, (packument) =>
       created: "2019-11-28T18:51:58.123Z",
       [SemanticVersion.parse("1.0.0")]: "2019-11-28T18:51:58.123Z",
     })
-    .set("_rev", "3-418f950115c32bd0")
-    .set("readme", "A demo package")
     .addVersion("1.0.0", (version) =>
       version
         .set("displayName", "Package A")
@@ -29,11 +27,6 @@ const somePackument = buildPackument(somePackage, (packument) =>
         .set("unity", "2018.4")
         .set("description", "A demo package")
         .set("keywords", [""])
-        .set("category", "Unity")
-        .set("gitHead", "5c141ecfac59c389090a07540f44c8ac5d07a729")
-        .set("readmeFilename", "README.md")
-        .set("_nodeVersion", "12.13.1")
-        .set("_npmVersion", "6.12.1")
         .set("dist", {
           integrity:
             "sha512-MAh44bur7HGyfbCXH9WKfaUNS67aRMfO0VAbLkr+jwseb1hJue/I1pKsC7PKksuBYh4oqoo9Jov1cBcvjVgjmA==",

--- a/test/domain/data-packument.ts
+++ b/test/domain/data-packument.ts
@@ -1,7 +1,6 @@
 import assert from "assert";
 import { DomainName } from "../../src/domain/domain-name";
 import { SemanticVersion } from "../../src/domain/semantic-version";
-import { makePackageId } from "../../src/domain/package-id";
 import {
   UnityPackument,
   UnityPackumentVersion,
@@ -17,10 +16,8 @@ class UnityPackumentVersionBuilder {
   constructor(name: DomainName, version: SemanticVersion) {
     this.version = {
       name,
-      _id: makePackageId(name, version),
       version,
       dependencies: {},
-      contributors: [],
     };
   }
 
@@ -70,11 +67,8 @@ class UnityPackumentBuilder {
   constructor(name: DomainName) {
     this.packument = {
       name,
-      _id: name,
       versions: {},
       time: {},
-      users: {},
-      _attachments: {},
     };
   }
 


### PR DESCRIPTION
When designing some of the types which represent external data, we added all properties which exist in that data even when we don't use them.  This makes interacting and mocking these data types more difficult than it needs to be.

This change removes these properties since they have no impact on the app at all.