### PR TITLE
refactor: shrink service

### DIFF
--- a/src/cli/cmd-deps.ts
+++ b/src/cli/cmd-deps.ts
@@ -17,6 +17,7 @@ import { isZod } from "../utils/zod-utils";
 import { stringifyDependencyGraph } from "./dependency-logging";
 import os from "os";
 import chalk from "chalk";
+import { queryAllRegistriesLazy } from "../utils/sources";
 
 /**
  * Options passed to the deps command.
@@ -68,7 +69,11 @@ export function makeDepsCmd(
     const latestVersion =
       requestedVersion !== undefined && isZod(requestedVersion, SemanticVersion)
         ? requestedVersion
-        : (await resolveLatestVersion(sources, packageName))?.value ?? null;
+        : (
+            await queryAllRegistriesLazy(sources, (source) =>
+              resolveLatestVersion(source, packageName)
+            )
+          )?.value ?? null;
 
     if (latestVersion === null) throw new PackumentNotFoundError(packageName);
 

--- a/src/services/resolve-latest-version.ts
+++ b/src/services/resolve-latest-version.ts
@@ -1,21 +1,20 @@
-import { Registry } from "../domain/registry";
 import { DomainName } from "../domain/domain-name";
-import { SemanticVersion } from "../domain/semantic-version";
 import { tryResolvePackumentVersion } from "../domain/packument";
+import { Registry } from "../domain/registry";
+import { SemanticVersion } from "../domain/semantic-version";
 import { FetchPackument } from "../io/packument-io";
-import { FromRegistry, queryAllRegistriesLazy } from "../utils/sources";
 
 /**
  * Service for resolving the latest published version of a package.
- * @param sources All sources to check for the package.
+ * @param source The source to check for the package.
  * @param packageName The name of the package to search.
  * @returns The resolved version or null if the package does not exist on the
  * registry.
  */
 export type ResolveLatestVersion = (
-  sources: ReadonlyArray<Registry>,
+  source: Registry,
   packageName: DomainName
-) => Promise<FromRegistry<SemanticVersion> | null>;
+) => Promise<SemanticVersion | null>;
 
 /**
  * Makes a {@link ResolveLatestVersion} service function.
@@ -23,10 +22,7 @@ export type ResolveLatestVersion = (
 export function makeResolveLatestVersion(
   fetchPackument: FetchPackument
 ): ResolveLatestVersion {
-  async function tryResolveFrom(
-    source: Registry,
-    packageName: DomainName
-  ): Promise<SemanticVersion | null> {
+  return async (source, packageName) => {
     const packument = await fetchPackument(source, packageName);
     if (packument === null) return null;
 
@@ -34,11 +30,5 @@ export function makeResolveLatestVersion(
     if (resolveResult.isErr()) throw resolveResult.error;
 
     return resolveResult.value.version;
-  }
-
-  return (sources, packageName) => {
-    return queryAllRegistriesLazy(sources, (source) =>
-      tryResolveFrom(source, packageName)
-    );
   };
 }

--- a/test/cli/cmd-deps.test.ts
+++ b/test/cli/cmd-deps.test.ts
@@ -52,10 +52,7 @@ function makeDependencies() {
   resolveDependencies.mockResolvedValue(defaultGraph);
 
   const resolveLatestVersion = mockService<ResolveLatestVersion>();
-  resolveLatestVersion.mockResolvedValue({
-    source: exampleRegistryUrl,
-    value: someVersion,
-  });
+  resolveLatestVersion.mockResolvedValue(someVersion);
 
   const log = makeMockLogger();
 

--- a/test/services/resolve-latest-version.test.ts
+++ b/test/services/resolve-latest-version.test.ts
@@ -1,18 +1,17 @@
-import { mockService } from "./service.mock";
-import { makeResolveLatestVersion } from "../../src/services/resolve-latest-version";
 import { DomainName } from "../../src/domain/domain-name";
 import { UnityPackument } from "../../src/domain/packument";
 import { Registry } from "../../src/domain/registry";
-import { exampleRegistryUrl } from "../domain/data-registry";
 import { unityRegistryUrl } from "../../src/domain/registry-url";
-import { FetchPackument } from "../../src/io/packument-io";
 import { SemanticVersion } from "../../src/domain/semantic-version";
+import { FetchPackument } from "../../src/io/packument-io";
+import { makeResolveLatestVersion } from "../../src/services/resolve-latest-version";
+import { exampleRegistryUrl } from "../domain/data-registry";
+import { mockService } from "./service.mock";
 
-describe("resolve latest version service", () => {
+describe("resolve latest version", () => {
   const somePackage = DomainName.parse("com.some.package");
 
   const exampleRegistry: Registry = { url: exampleRegistryUrl, auth: null };
-  const upstreamRegistry: Registry = { url: unityRegistryUrl, auth: null };
 
   function makeDependencies() {
     const fetchPackument = mockService<FetchPackument>();
@@ -21,15 +20,7 @@ describe("resolve latest version service", () => {
     return { resolveLatestVersion, fetchPackument } as const;
   }
 
-  it("should be null if not given any sources", async () => {
-    const { resolveLatestVersion } = makeDependencies();
-
-    const actual = await resolveLatestVersion([], somePackage);
-
-    expect(actual).toBeNull();
-  });
-
-  it("should get specified latest version from first packument", async () => {
+  it("should get specified latest version from packument", async () => {
     const { resolveLatestVersion, fetchPackument } = makeDependencies();
     const packument = {
       versions: { ["1.0.0" as SemanticVersion]: { version: "1.0.0" } },
@@ -37,37 +28,20 @@ describe("resolve latest version service", () => {
     } as UnityPackument;
     fetchPackument.mockResolvedValue(packument);
 
-    const actual = await resolveLatestVersion([exampleRegistry], somePackage);
+    const actual = await resolveLatestVersion(exampleRegistry, somePackage);
 
-    expect(actual).toEqual({ value: "1.0.0", source: exampleRegistry.url });
+    expect(actual).toEqual("1.0.0");
   });
 
-  it("should get latest listed version from first packument if no latest was specified", async () => {
+  it("should get latest listed version from packument if no latest was specified", async () => {
     const { resolveLatestVersion, fetchPackument } = makeDependencies();
     const packument = {
       versions: { ["1.0.0" as SemanticVersion]: { version: "1.0.0" } },
     } as UnityPackument;
     fetchPackument.mockResolvedValue(packument);
 
-    const actual = await resolveLatestVersion([exampleRegistry], somePackage);
+    const actual = await resolveLatestVersion(exampleRegistry, somePackage);
 
-    expect(actual).toEqual({ value: "1.0.0", source: exampleRegistry.url });
-  });
-
-  it("should check all registries", async () => {
-    const { resolveLatestVersion, fetchPackument } = makeDependencies();
-    const packument = {
-      versions: { ["1.0.0" as SemanticVersion]: { version: "1.0.0" } },
-      "dist-tags": { latest: "1.0.0" },
-    } as UnityPackument;
-    fetchPackument.mockResolvedValueOnce(null);
-    fetchPackument.mockResolvedValueOnce(packument);
-
-    const actual = await resolveLatestVersion(
-      [exampleRegistry, upstreamRegistry],
-      somePackage
-    );
-
-    expect(actual).toEqual({ value: "1.0.0", source: upstreamRegistry.url });
+    expect(actual).toEqual("1.0.0");
   });
 });


### PR DESCRIPTION
Currently the "resolve latest version" service queried all registries. This should be a behavior that is added onto the service by client code.

Extracted the logic to query multiple sources out of the service. Service now only queries one source.