### PR TITLE
feat: multiple upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The tool is designed to work with [the OpenUPM registry](https://openupm.com), b
       - [Authenticate for the Windows system user](#authenticate-for-the-windows-system-user)
       - [Troubleshooting](#troubleshooting)
     - [Command options](#command-options)
-  - [Work with Unity official (upstream) registry](#work-with-unity-official-upstream-registry)
+  - [Work with different registries](#work-with-different-registries)
   - [Work with proxy](#work-with-proxy)
   - [Contributors](#contributors)
 
@@ -240,22 +240,40 @@ Show verbose logging
 openupm --verbose ...
 ```
 
-## Work with Unity official (upstream) registry
+## Work with different registries
 
-Most commands can fall back to Unity upstream registry if necessary, to make it easier to mix the official registry with a 3rd-party registry. i.e.
+By default the openupm will query any package from the following registries: 
 
-```
-$ openupm add com.unity.addressables com.littlebigfun.addressable-importer
-added: com.unity.addressables@1.4.0                # from unity registry
-added: com.littlebigfun.addressable-importer@0.4.1 # from openupm registry
-...
-```
+1. Openupm (https://package.openupm.com)
+2. Unity (https://packages.unity.com)
 
-Turn off Unity official (upstream) registry
+Any package will be searched on these registries in the order that they are listed above. If you want to install packages from your own third party registries you can do this via the `--registry` option.
 
-```
-openupm --no-upstream ...
-```
+```openupm --registry https://package.my-registry.com add com.my.package```
+
+This will query the following registries:
+
+1. The private registry (https://package.my-registry.com)
+2. Unity (https://packages.unity.com)
+
+Let's say `com.my.package` depends on a Openupm package. With the above configuration the install would fail because Openupm is not part of the queried registries. To fix, add Openupm to the --registry option.
+
+```openupm --registry https://package.my-registry.com https://package.openupm.com add com.my.package```
+
+The query will now look like this:
+
+1. The private registry (https://package.my-registry.com)
+2. Openupm (https://package.openupm.com)
+3. Unity (https://packages.unity.com)
+
+Finally, it may not always be desirable to search the Unity registry. If you want to remove it from the registry list, run with the `--no-upstream` option.
+
+```openupm --registry https://package.my-registry.com https://package.openupm.com --no-upstream add com.my.package```
+
+The resulting query is:
+
+1. The private registry (https://package.my-registry.com)
+2. Openupm (https://package.openupm.com)
 
 ## Work with proxy
 

--- a/src/app/add-dependencies.ts
+++ b/src/app/add-dependencies.ts
@@ -404,11 +404,7 @@ export async function addDependenciesUsing(
     }
     if (shouldAddTestable) manifest = addTestable(manifest, packageName);
 
-    return addDependencyToManifest(
-      manifest,
-      packageName,
-      versionToAdd as SemanticVersion | PackageUrl
-    );
+    return addDependencyToManifest(manifest, packageName, versionToAdd);
   }
 
   let manifest = await loadProjectManifest(projectDirectory);

--- a/src/app/add-dependencies.ts
+++ b/src/app/add-dependencies.ts
@@ -252,7 +252,6 @@ export async function addDependenciesUsing(
         ).promise;
         if (unityResult.isOk()) {
           resolveResult = unityResult;
-          isUnityPackage = true;
         } else {
           resolveResult = pickMostFixable(resolveResult, unityResult);
         }
@@ -261,6 +260,7 @@ export async function addDependenciesUsing(
       if (resolveResult.isErr()) throw resolveResult.error;
 
       const packumentVersion = resolveResult.value.packumentVersion;
+      isUnityPackage = resolveResult.value.source === unityRegistryUrl;
       versionToAdd = packumentVersion.version;
 
       // Only do compatibility check when we have a editor version to check against

--- a/src/app/add-dependencies.ts
+++ b/src/app/add-dependencies.ts
@@ -189,7 +189,7 @@ function pickMostFixable(
  * compatibility. If set to null then compatibility will not be checked.
  * @param primaryRegistry The primary registry from which to resolve
  * dependencies.
- * @param useUpstream Whether to fall back to the upstream registry.
+ * @param useUnity Whether to fall back to the Unity registry.
  * @param force Whether to force add the dependencies.
  * @param shouldAddTestable Whether to also add dependencies to the `testables`.
  * @param pkgs References to the dependencies to add.
@@ -204,7 +204,7 @@ export async function addDependenciesUsing(
   projectDirectory: string,
   editorVersion: ReleaseVersion | null,
   primaryRegistry: Registry,
-  useUpstream: boolean,
+  useUnity: boolean,
   force: boolean,
   shouldAddTestable: boolean,
   pkgs: ReadonlyArray<PackageReference>
@@ -230,8 +230,7 @@ export async function addDependenciesUsing(
     packageName: DomainName,
     requestedVersion: VersionReference | undefined
   ): Promise<[UnityProjectManifest, AddResult]> {
-    // is upstream package flag
-    let isUpstreamPackage = false;
+    let isUnityPackage = false;
 
     // packages that added to scope registry
     const packagesInScope = Array.of<DomainName>();
@@ -245,17 +244,17 @@ export async function addDependenciesUsing(
         requestedVersion,
         primaryRegistry
       ).promise;
-      if (resolveResult.isErr() && useUpstream) {
-        const upstreamResult = await getRegistryPackumentVersion(
+      if (resolveResult.isErr() && useUnity) {
+        const unityResult = await getRegistryPackumentVersion(
           packageName,
           requestedVersion,
           unityRegistry
         ).promise;
-        if (upstreamResult.isOk()) {
-          resolveResult = upstreamResult;
-          isUpstreamPackage = true;
+        if (unityResult.isOk()) {
+          resolveResult = unityResult;
+          isUnityPackage = true;
         } else {
-          resolveResult = pickMostFixable(resolveResult, upstreamResult);
+          resolveResult = pickMostFixable(resolveResult, unityResult);
         }
       }
 
@@ -292,7 +291,7 @@ export async function addDependenciesUsing(
       }
 
       // packagesInScope
-      if (!isUpstreamPackage) {
+      if (!isUnityPackage) {
         await debugLog(
           `fetch: ${makePackageReference(packageName, requestedVersion)}`
         );
@@ -360,7 +359,7 @@ export async function addDependenciesUsing(
       versionToAdd as PackageUrl | SemanticVersion
     );
 
-    if (!isUpstreamPackage && packagesInScope.length > 0) {
+    if (!isUnityPackage && packagesInScope.length > 0) {
       manifest = mapScopedRegistry(manifest, primaryRegistry.url, (initial) => {
         let updated =
           initial ?? makeEmptyScopedRegistryFor(primaryRegistry.url);

--- a/src/app/add-dependencies.ts
+++ b/src/app/add-dependencies.ts
@@ -385,22 +385,15 @@ export async function addDependenciesUsing(
     return [versionToAdd, isUnityPackage];
   }
 
-  function addUrlDependency(
-    manifest: UnityProjectManifest,
-    packageName: DomainName,
-    version: PackageUrl
-  ): [UnityProjectManifest, AddResult] {
-    if (shouldAddTestable) manifest = addTestable(manifest, packageName);
-    return addDependencyToManifest(manifest, packageName, version);
-  }
-
   async function addSingle(
     manifest: UnityProjectManifest,
     packageName: DomainName,
     requestedVersion: VersionReference | undefined
   ): Promise<[UnityProjectManifest, AddResult]> {
+    if (shouldAddTestable) manifest = addTestable(manifest, packageName);
+
     if (isZod(requestedVersion, PackageUrl))
-      return addUrlDependency(manifest, packageName, requestedVersion);
+      return addDependencyToManifest(manifest, packageName, requestedVersion);
 
     const [versionToAdd, isUnityPackage] = await resolveDependency(
       packageName,

--- a/src/app/add-dependencies.ts
+++ b/src/app/add-dependencies.ts
@@ -275,14 +275,14 @@ export async function addDependenciesUsing(
 
       // add depsValid to packagesInScope.
       scopes.push(dependencyName);
-
-      // print suggestion for depsInvalid
-      if (unresolvedDependencies.length > 0 && !force)
-        throw new UnresolvedDependenciesError(
-          makePackageReference(packageName, verison),
-          unresolvedDependencies
-        );
     }
+
+    // print suggestion for depsInvalid
+    if (unresolvedDependencies.length > 0 && !force)
+      throw new UnresolvedDependenciesError(
+        makePackageReference(packageName, verison),
+        unresolvedDependencies
+      );
 
     return scopes;
   }

--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -6,6 +6,7 @@ import { loadRegistryAuthUsing } from "../app/get-registry-auth";
 import { DebugLog } from "../domain/logging";
 import { makePackageReference } from "../domain/package-reference";
 import { recordEntries } from "../domain/record-utils";
+import { unityRegistry } from "../domain/registry";
 import { getHomePathFromEnv } from "../domain/special-paths";
 import { getUserUpmConfigPathFor } from "../domain/upm-config";
 import type { ReadTextFile, WriteTextFile } from "../io/fs";
@@ -104,6 +105,9 @@ openupm add <pkg>@<version> [otherPkgs...]`
           options.registry
         );
 
+        const sources = [primaryRegistry];
+        if (options.upstream) sources.push(unityRegistry);
+
         const addResults = await addDependenciesUsing(
           readTextFile,
           writeTextFile,
@@ -112,8 +116,7 @@ openupm add <pkg>@<version> [otherPkgs...]`
           debugLog,
           projectDirectory,
           typeof editorVersion === "string" ? null : editorVersion,
-          primaryRegistry,
-          options.upstream,
+          sources,
           options.force,
           options.test,
           pkgs

--- a/src/cli/dependency-logging.ts
+++ b/src/cli/dependency-logging.ts
@@ -34,7 +34,7 @@ export async function logResolvedDependency(
     source === "built-in"
       ? "[internal] "
       : source === unityRegistryUrl
-      ? "[upstream]"
+      ? "[unity]"
       : "";
   const message = `${packageRef} ${tag}`;
   await debugLog(message);

--- a/src/cli/opt-registry.ts
+++ b/src/cli/opt-registry.ts
@@ -1,5 +1,6 @@
 import { Option } from "@commander-js/extra-typings";
 import { openupmRegistryUrl } from "../domain/registry-url";
+import { eachValue } from "./cli-parsing";
 import { mustBeRegistryUrl } from "./validators";
 
 /**
@@ -12,3 +13,11 @@ export const primaryRegistryUrlOpt = new Option(
 )
   .argParser(mustBeRegistryUrl)
   .default(openupmRegistryUrl, "Use the openupm registry by default");
+
+/**
+ * CLI option for multiple primary registries from which to resolve packages.
+ */
+export const primaryRegistriesUrlOpt = new Option(
+  "-r, --registry <url...>",
+  "specify registry url"
+).argParser(eachValue(mustBeRegistryUrl));

--- a/test/e2e/add.test.ts
+++ b/test/e2e/add.test.ts
@@ -293,7 +293,7 @@ describe("add packages", () => {
     );
   });
 
-  it("should add package from upstream if no matching version was found in primary registry", async () => {
+  it("should add package from Unity registry if no matching version was found in primary registry", async () => {
     // See https://github.com/openupm/openupm-cli/issues/41
     await testSuccessfulAdd(
       [

--- a/test/integration/app/add-dependencies.test.ts
+++ b/test/integration/app/add-dependencies.test.ts
@@ -13,7 +13,7 @@ import { makeEditorVersion } from "../../../src/domain/editor-version";
 import { partialApply } from "../../../src/domain/fp-utils";
 import { noopLogger } from "../../../src/domain/logging";
 import { emptyProjectManifest } from "../../../src/domain/project-manifest";
-import type { Registry } from "../../../src/domain/registry";
+import { unityRegistry, type Registry } from "../../../src/domain/registry";
 import { unityRegistryUrl } from "../../../src/domain/registry-url";
 import { SemanticVersion } from "../../../src/domain/semantic-version";
 import { getRegistryPackumentUsing } from "../../../src/io/registry";
@@ -117,8 +117,7 @@ describe("add dependencies", () => {
     const result = await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       true,
       false,
       [badEditorPackument.name]
@@ -138,8 +137,7 @@ describe("add dependencies", () => {
     const result = await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       true,
       false,
       [incompatiblePackument.name]
@@ -160,8 +158,7 @@ describe("add dependencies", () => {
       addDependencies(
         someProjectDir,
         makeEditorVersion(2020, 1, 1, "f", 1),
-        someRegistry,
-        true,
+        [someRegistry, unityRegistry],
         false,
         false,
         [incompatiblePackument.name]
@@ -176,8 +173,7 @@ describe("add dependencies", () => {
       addDependencies(
         someProjectDir,
         makeEditorVersion(2020, 1, 1, "f", 1),
-        someRegistry,
-        true,
+        [someRegistry, unityRegistry],
         true,
         false,
         [unknownPackage]
@@ -192,8 +188,7 @@ describe("add dependencies", () => {
       addDependencies(
         someProjectDir,
         makeEditorVersion(2020, 1, 1, "f", 1),
-        someRegistry,
-        true,
+        [someRegistry, unityRegistry],
         false,
         false,
         [badEditorPackument.name]
@@ -205,9 +200,14 @@ describe("add dependencies", () => {
     const { addDependencies } = makeDependencies();
 
     await expect(() =>
-      addDependencies(someProjectDir, null, someRegistry, true, false, false, [
-        packumentWithBadDependency.name,
-      ])
+      addDependencies(
+        someProjectDir,
+        null,
+        [someRegistry, unityRegistry],
+        false,
+        false,
+        [packumentWithBadDependency.name]
+      )
     ).rejects.toBeInstanceOf(UnresolvedDependenciesError);
   });
 
@@ -217,8 +217,7 @@ describe("add dependencies", () => {
     const result = await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       true,
       false,
       [packumentWithBadDependency.name]
@@ -238,8 +237,7 @@ describe("add dependencies", () => {
     await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       false,
       false,
       [somePackument.name]
@@ -265,8 +263,7 @@ describe("add dependencies", () => {
     await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       false,
       false,
       [somePackument.name]
@@ -286,8 +283,7 @@ describe("add dependencies", () => {
     await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       false,
       false,
       [somePackument.name]
@@ -313,8 +309,7 @@ describe("add dependencies", () => {
     await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       false,
       true,
       [somePackument.name]
@@ -334,8 +329,7 @@ describe("add dependencies", () => {
     await addDependencies(
       someProjectDir,
       null,
-      someRegistry,
-      true,
+      [someRegistry, unityRegistry],
       false,
       true,
       // The second package can not be added

--- a/test/integration/app/add-dependencies.test.ts
+++ b/test/integration/app/add-dependencies.test.ts
@@ -102,12 +102,11 @@ describe("add dependencies", () => {
   beforeEach(() => {
     mockRegistryPackuments(someRegistryUrl, [
       somePackument,
-      otherPackument,
       packumentWithBadDependency,
       badEditorPackument,
       incompatiblePackument,
     ]);
-    mockRegistryPackuments(unityRegistryUrl, []);
+    mockRegistryPackuments(unityRegistryUrl, [otherPackument]);
   });
 
   it("should add package with invalid editor version when running with force", async () => {
@@ -295,7 +294,7 @@ describe("add dependencies", () => {
           {
             name: expect.any(String),
             url: someRegistryUrl,
-            scopes: [otherPackument.name, somePackument.name],
+            scopes: [somePackument.name],
           },
         ],
       })

--- a/test/integration/app/add-dependencies.test.ts
+++ b/test/integration/app/add-dependencies.test.ts
@@ -13,14 +13,14 @@ import { makeEditorVersion } from "../../../src/domain/editor-version";
 import { partialApply } from "../../../src/domain/fp-utils";
 import { noopLogger } from "../../../src/domain/logging";
 import { emptyProjectManifest } from "../../../src/domain/project-manifest";
-import { unityRegistry, type Registry } from "../../../src/domain/registry";
+import { unityRegistry } from "../../../src/domain/registry";
 import { unityRegistryUrl } from "../../../src/domain/registry-url";
 import { SemanticVersion } from "../../../src/domain/semantic-version";
 import { getRegistryPackumentUsing } from "../../../src/io/registry";
 import { fetchCheckUrlExists } from "../../../src/io/www";
 import { buildPackument } from "../../common/data-packument";
 import { buildProjectManifest } from "../../common/data-project-manifest";
-import { someRegistryUrl } from "../../common/data-registry";
+import { someRegistry, someRegistryUrl } from "../../common/data-registry";
 import { makeMockLogger } from "../../common/log.mock";
 import { MockFs } from "../fs.mock";
 import { mockRegistryPackuments } from "../registry.mock";
@@ -28,7 +28,6 @@ import { mockRegistryPackuments } from "../registry.mock";
 describe("add dependencies", () => {
   const someVersion = SemanticVersion.parse("1.0.0");
   const unknownPackage = DomainName.parse("com.unknown.parse");
-  const someRegistry: Registry = { url: someRegistryUrl, auth: null };
 
   const otherPackument = buildPackument("com.other.package", (packument) =>
     packument.addVersion(someVersion, (version) =>


### PR DESCRIPTION
This allows users to use any number of upstream registries when resolving packages.

See #349.