### PR TITLE
refactor: shrink cli index

### DIFF
--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -1,4 +1,4 @@
-import { Argument, Command } from "@commander-js/extra-typings";
+import { Argument, Command, Option } from "@commander-js/extra-typings";
 import { Logger } from "npmlog";
 import { addDependenciesUsing } from "../app/add-dependencies";
 import { determineEditorVersionUsing } from "../app/determine-editor-version";
@@ -27,6 +27,16 @@ const otherPkgsArg = new Argument(
   "References to additional packages that should be added"
 ).argParser(eachValue(mustBePackageReference));
 
+const addTestableOpt = new Option(
+  "-t, --test",
+  "add package as testable"
+).default(false);
+
+const forceOpt = new Option(
+  "-f, --force",
+  "force add package if missing deps or editor version is not qualified"
+).default(false);
+
 /**
  * Makes the `openupm add` cli command with the given dependencies.
  * @param checkUrlExists IO function to check whether a url exists.
@@ -46,14 +56,11 @@ export function makeAddCmd(
   debugLog: DebugLog
 ) {
   return new Command("add")
+    .aliases(["install", "i"])
     .addArgument(pkgArg)
     .addArgument(otherPkgsArg)
-    .aliases(["install", "i"])
-    .option("-t, --test", "add package as testable")
-    .option(
-      "-f, --force",
-      "force add package if missing deps or editor version is not qualified"
-    )
+    .addOption(addTestableOpt)
+    .addOption(forceOpt)
     .description(
       `add package to manifest json
 openupm add <pkg> [otherPkgs...]
@@ -111,8 +118,8 @@ openupm add <pkg>@<version> [otherPkgs...]`
           typeof editorVersion === "string" ? null : editorVersion,
           primaryRegistry,
           env.upstream,
-          addOptions.force === true,
-          addOptions.test === true,
+          addOptions.force,
+          addOptions.test,
           pkgs
         );
 

--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -22,6 +22,11 @@ const pkgArg = new Argument(
   "Reference to the package that should be added"
 ).argParser(mustBePackageReference);
 
+const otherPkgsArg = new Argument(
+  "[otherPkgs...]",
+  "References to additional packages that should be added"
+).argParser(eachValue(mustBePackageReference));
+
 /**
  * Makes the `openupm add` cli command with the given dependencies.
  * @param checkUrlExists IO function to check whether a url exists.
@@ -42,11 +47,7 @@ export function makeAddCmd(
 ) {
   return new Command("add")
     .addArgument(pkgArg)
-    .argument(
-      "[otherPkgs...]",
-      "References to additional packages that should be added",
-      eachValue(mustBePackageReference)
-    )
+    .addArgument(otherPkgsArg)
     .aliases(["install", "i"])
     .option("-t, --test", "add package as testable")
     .option(

--- a/src/cli/cmd-add.ts
+++ b/src/cli/cmd-add.ts
@@ -1,4 +1,4 @@
-import { Command } from "@commander-js/extra-typings";
+import { Argument, Command } from "@commander-js/extra-typings";
 import { Logger } from "npmlog";
 import { addDependenciesUsing } from "../app/add-dependencies";
 import { determineEditorVersionUsing } from "../app/determine-editor-version";
@@ -16,6 +16,11 @@ import { withErrorLogger } from "./error-logging";
 import type { GlobalOptions } from "./options";
 import { parseEnvUsing } from "./parse-env";
 import { mustBePackageReference } from "./validators";
+
+const pkgArg = new Argument(
+  "<pkg>",
+  "Reference to the package that should be added"
+).argParser(mustBePackageReference);
 
 /**
  * Makes the `openupm add` cli command with the given dependencies.
@@ -36,11 +41,7 @@ export function makeAddCmd(
   debugLog: DebugLog
 ) {
   return new Command("add")
-    .argument(
-      "<pkg>",
-      "Reference to the package that should be added",
-      mustBePackageReference
-    )
+    .addArgument(pkgArg)
     .argument(
       "[otherPkgs...]",
       "References to additional packages that should be added",

--- a/src/cli/cmd-search.ts
+++ b/src/cli/cmd-search.ts
@@ -16,7 +16,15 @@ import { parseEnvUsing } from "./parse-env";
 import { ResultCodes } from "./result-codes";
 
 /**
- * Makes a {@link SearchCmd} function.
+ * Makes the `openupm search` cli command with the given dependencies.
+ * @param readTextFile IO function for reading a text file.
+ * @param searchRegistry IO function for sending a search request to a
+ * registry.
+ * @param fetchAllPackuments IO function for getting all packages from a
+ * registry.
+ * @param log Logger for cli output.
+ * @param debugLog IO function for debug-logs.
+ * @returns The command.
  */
 export function makeSearchCmd(
   readTextFile: ReadTextFile,

--- a/src/cli/cmd-view.ts
+++ b/src/cli/cmd-view.ts
@@ -1,88 +1,91 @@
+import { Command } from "@commander-js/extra-typings";
 import { Logger } from "npmlog";
 import { EOL } from "os";
 import { loadRegistryAuthUsing } from "../app/get-registry-auth";
 import { queryAllRegistriesLazy } from "../app/query-registries";
 import { PackumentNotFoundError } from "../domain/common-errors";
 import type { DebugLog } from "../domain/logging";
-import {
-  hasVersion,
-  PackageReference,
-  splitPackageReference,
-} from "../domain/package-reference";
+import { hasVersion, splitPackageReference } from "../domain/package-reference";
 import { unityRegistry } from "../domain/registry";
 import { getHomePathFromEnv } from "../domain/special-paths";
 import { getUserUpmConfigPathFor } from "../domain/upm-config";
 import type { ReadTextFile } from "../io/fs";
 import type { GetRegistryPackument } from "../io/registry";
-import { CmdOptions } from "./options";
+import { withErrorLogger } from "./error-logging";
+import { GlobalOptions } from "./options";
 import { formatPackumentInfo } from "./output-formatting";
 import { parseEnvUsing } from "./parse-env";
 import { ResultCodes } from "./result-codes";
+import { mustBePackageReference } from "./validators";
 
 /**
- * Options passed to the view command.
- */
-export type ViewOptions = CmdOptions;
-
-/**
- * The possible result codes with which the view command can exit.
- */
-export type ViewResultCode = ResultCodes.Ok | ResultCodes.Error;
-
-/**
- * Cmd-handler for viewing package information.
- * @param pkg Reference to the package to view.
- * @param options Command options.
- */
-export type ViewCmd = (
-  pkg: PackageReference,
-  options: ViewOptions
-) => Promise<ViewResultCode>;
-
-/**
- * Makes a {@link ViewCmd} function.
+ * Makes the `openupm view` cli command with the given dependencies.
+ * @param getRegistryPackument IO function for fetching registry packages.
+ * @param readTextFile IO function for reading a text file.
+ * @param debugLog IO function for debug-logs.
+ * @param log Logger for cli output.
+ * @returns The command.
  */
 export function makeViewCmd(
   getRegistryPackument: GetRegistryPackument,
   readTextFile: ReadTextFile,
   debugLog: DebugLog,
   log: Logger
-): ViewCmd {
-  return async (pkg, options) => {
-    // parse env
-    const env = await parseEnvUsing(log, process.env, process.cwd(), options);
-    const homePath = getHomePathFromEnv(process.env);
-    const upmConfigPath = getUserUpmConfigPathFor(
-      process.env,
-      homePath,
-      env.systemUser
+) {
+  return new Command("view")
+    .argument("<pkg>", "Reference to a package", mustBePackageReference)
+    .aliases(["v", "info", "show"])
+    .description("view package information")
+    .action(
+      withErrorLogger(log, async function (pkg, _, cmd) {
+        const globalOptions = cmd.optsWithGlobals<GlobalOptions>();
+
+        // parse env
+        const env = await parseEnvUsing(
+          log,
+          process.env,
+          process.cwd(),
+          globalOptions
+        );
+        const homePath = getHomePathFromEnv(process.env);
+        const upmConfigPath = getUserUpmConfigPathFor(
+          process.env,
+          homePath,
+          env.systemUser
+        );
+
+        const primaryRegistry = await loadRegistryAuthUsing(
+          readTextFile,
+          debugLog,
+          upmConfigPath,
+          env.primaryRegistryUrl
+        );
+
+        // parse name
+        if (hasVersion(pkg)) {
+          const [name] = splitPackageReference(pkg);
+          log.warn(
+            "",
+            `please do not specify a version (Write only '${name}').`
+          );
+          return process.exit(ResultCodes.Error);
+        }
+
+        // verify name
+        const sources = [
+          primaryRegistry,
+          ...(env.upstream ? [unityRegistry] : []),
+        ];
+        const packumentFromRegistry = await queryAllRegistriesLazy(
+          sources,
+          (source) => getRegistryPackument(source, pkg)
+        );
+        const packument = packumentFromRegistry?.value ?? null;
+        if (packument === null) throw new PackumentNotFoundError(pkg);
+
+        const output = formatPackumentInfo(packument, EOL);
+        log.notice("", output);
+        return process.exit(ResultCodes.Ok);
+      })
     );
-
-    const primaryRegistry = await loadRegistryAuthUsing(
-      readTextFile,
-      debugLog,
-      upmConfigPath,
-      env.primaryRegistryUrl
-    );
-
-    // parse name
-    if (hasVersion(pkg)) {
-      const [name] = splitPackageReference(pkg);
-      log.warn("", `please do not specify a version (Write only '${name}').`);
-      return ResultCodes.Error;
-    }
-
-    // verify name
-    const sources = [primaryRegistry, ...(env.upstream ? [unityRegistry] : [])];
-    const packumentFromRegistry = await queryAllRegistriesLazy(
-      sources,
-      (source) => getRegistryPackument(source, pkg)
-    );
-    const packument = packumentFromRegistry?.value ?? null;
-    if (packument === null) throw new PackumentNotFoundError(pkg);
-
-    const output = formatPackumentInfo(packument, EOL);
-    log.notice("", output);
-    return ResultCodes.Ok;
-  };
 }

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -26,13 +26,13 @@ import {
   type ResolvePackumentVersionError,
 } from "../domain/packument";
 import { recordEntries } from "../domain/record-utils";
-import { NoSystemUserProfilePath } from "../domain/upm-config";
-import { RegistryAuthenticationError } from "../io/common-errors";
 import {
   NoHomePathError,
   OSNotSupportedError,
   VersionNotSupportedOnOsError,
 } from "../domain/special-paths";
+import { NoSystemUserProfilePath } from "../domain/upm-config";
+import { RegistryAuthenticationError } from "../io/common-errors";
 import { RegistryAuthLoadError } from "./parse-env";
 import { ResultCodes } from "./result-codes";
 
@@ -166,16 +166,16 @@ export function logError(log: Logger, error: unknown) {
  * @returns A new function that has the same behaviour as the original but with
  * error logging.
  */
-export function withErrorLogger<
-  TArgs extends unknown[],
-  TOut extends ResultCodes
->(
+export function withErrorLogger<TArgs extends unknown[], TOut>(
   log: Logger,
   cmd: (...args: TArgs) => Promise<TOut>
 ): (...args: TArgs) => Promise<TOut> {
-  return (...args) =>
-    cmd(...args).catch((error) => {
+  return async (...args) => {
+    try {
+      return await cmd(...args);
+    } catch (error) {
       logError(log, error);
       process.exit(ResultCodes.Error);
-    });
+    }
+  };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -58,14 +58,6 @@ const fetchPackument = getRegistryPackumentUsing(
 const searchRegistry = searchRegistryUsing(debugLogToConsole);
 const fetchAllPackuments = getAllRegistryPackumentsUsing(debugLogToConsole);
 
-const loginCmd = makeLoginCmd(
-  homePath,
-  getAuthTokenUsing(registryClient, debugLogToConsole),
-  readTextFile,
-  writeTextFile,
-  debugLogToConsole,
-  log
-);
 const searchCmd = makeSearchCmd(
   readTextFile,
   searchRegistry,
@@ -181,24 +173,16 @@ program.addCommand(
   )
 );
 
-program
-  .command("login")
-  .aliases(["add-user", "adduser"])
-  .option("-u, --username <username>", "username")
-  .option("-p, --password <password>", "password")
-  .option("-e, --email <email>", "email address")
-  .option("--basic-auth", "use basic authentication instead of token")
-  .option(
-    "--always-auth",
-    "always auth for tarball hosted on a different domain"
+program.addCommand(
+  makeLoginCmd(
+    homePath,
+    getAuthTokenUsing(registryClient, debugLogToConsole),
+    readTextFile,
+    writeTextFile,
+    debugLogToConsole,
+    log
   )
-  .description("authenticate with a scoped registry")
-  .action(
-    withErrorLogger(log, async function (options) {
-      const resultCode = await loginCmd(makeCmdOptions(options));
-      process.exit(resultCode);
-    })
-  );
+);
 
 // prompt for invalid command
 program.on("command:*", function () {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,6 @@ import {
   searchRegistryUsing,
 } from "../io/registry";
 import { fetchCheckUrlExists } from "../io/www";
-import { eachValue } from "./cli-parsing";
 import { makeAddCmd } from "./cmd-add";
 import { makeDepsCmd } from "./cmd-deps";
 import { makeLoginCmd } from "./cmd-login";
@@ -23,11 +22,7 @@ import { makeSearchCmd } from "./cmd-search";
 import { makeViewCmd } from "./cmd-view";
 import { withErrorLogger } from "./error-logging";
 import { CmdOptions } from "./options";
-import {
-  mustBeDomainName,
-  mustBePackageReference,
-  mustBeRegistryUrl,
-} from "./validators";
+import { mustBePackageReference, mustBeRegistryUrl } from "./validators";
 
 // Composition root
 
@@ -64,12 +59,6 @@ const searchCmd = makeSearchCmd(
   fetchAllPackuments,
   log,
   debugLogToConsole
-);
-const removeCmd = makeRemoveCmd(
-  readTextFile,
-  writeTextFile,
-  debugLogToConsole,
-  log
 );
 const viewCmd = makeViewCmd(
   getRegistryPackumentUsing(registryClient, debugLogToConsole),
@@ -115,29 +104,9 @@ program.addCommand(
   )
 );
 
-program
-  .command("remove")
-  .argument("<pkg>", "Name of the package to remove", mustBeDomainName)
-  .argument(
-    "[otherPkgs...]",
-    "Names of additional packages to remove",
-    eachValue(mustBeDomainName)
-  )
-  .aliases(["rm", "uninstall"])
-  .description("remove package from manifest json")
-  .action(
-    withErrorLogger(
-      log,
-      async function (packageName, otherPackageNames, options) {
-        const packageNames = [packageName].concat(otherPackageNames);
-        const resultCode = await removeCmd(
-          packageNames,
-          makeCmdOptions(options)
-        );
-        process.exit(resultCode);
-      }
-    )
-  );
+program.addCommand(
+  makeRemoveCmd(readTextFile, writeTextFile, debugLogToConsole, log)
+);
 
 program
   .command("search")

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -73,13 +73,6 @@ const searchCmd = makeSearchCmd(
   log,
   debugLogToConsole
 );
-const depsCmd = makeDepsCmd(
-  readTextFile,
-  fetchPackument,
-  fetchCheckUrlExists,
-  log,
-  debugLogToConsole
-);
 const removeCmd = makeRemoveCmd(
   readTextFile,
   writeTextFile,
@@ -178,22 +171,15 @@ program
     })
   );
 
-program
-  .command("deps")
-  .argument("<pkg>", "Reference to a package", mustBePackageReference)
-  .alias("dep")
-  .option("-d, --deep", "view package dependencies recursively")
-  .description(
-    `view package dependencies
-openupm deps <pkg>
-openupm deps <pkg>@<version>`
+program.addCommand(
+  makeDepsCmd(
+    readTextFile,
+    fetchPackument,
+    fetchCheckUrlExists,
+    log,
+    debugLogToConsole
   )
-  .action(
-    withErrorLogger(log, async function (pkg, options) {
-      const resultCode = await depsCmd(pkg, makeCmdOptions(options));
-      process.exit(resultCode);
-    })
-  );
+);
 
 program
   .command("login")

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,17 +1,14 @@
 import { createCommand } from "@commander-js/extra-typings";
-import RegClient from "another-npm-registry-client";
-import npmlog from "npmlog";
+import type { Logger } from "npmlog";
 import pkginfo from "pkginfo";
-import updateNotifier from "update-notifier";
-import pkg from "../../package.json";
-import { DebugLog } from "../domain/logging";
+import type { DebugLog } from "../domain/logging";
 import { getHomePathFromEnv } from "../domain/special-paths";
 import { readTextFile, writeTextFile } from "../io/fs";
 import {
-  getAllRegistryPackumentsUsing,
-  getAuthTokenUsing,
-  getRegistryPackumentUsing,
-  searchRegistryUsing,
+  type GetAllRegistryPackuments,
+  type GetAuthToken,
+  type GetRegistryPackument,
+  type SearchRegistry,
 } from "../io/registry";
 import { fetchCheckUrlExists } from "../io/www";
 import { makeAddCmd } from "./cmd-add";
@@ -22,112 +19,90 @@ import { makeSearchCmd } from "./cmd-search";
 import { makeViewCmd } from "./cmd-view";
 import { mustBeRegistryUrl } from "./validators";
 
-// Composition root
-
-const log = npmlog;
-
 /**
- * {@link DebugLog} function which uses {@link npmlog} to print logs to
- * the console.
+ * Makes the openupm cli app with the given dependencies.
+ * @param fetchPackument IO function for fetching registry packuments.
+ * @param searchRegistry IO function for using the search API on a registry.
+ * @param fetchAllPackuments IO function for getting all packuments from
+ * a registry.
+ * @param getAuthToken IO function for getting a users auth token from a
+ * registry.
+ * @param log Logger for printing output.
+ * @param debugLog IO function for printing debug logs.
+ * @returns Root command.
  */
-const debugLogToConsole: DebugLog = async function (message, context) {
-  const contextMessage =
-    context !== undefined
-      ? `\n${
-          context instanceof Error
-            ? context.toString()
-            : JSON.stringify(context, null, 2)
-        }`
-      : "";
-  return log.verbose("", `${message}${contextMessage}`);
-};
+export function makeOpenupmCli(
+  fetchPackument: GetRegistryPackument,
+  searchRegistry: SearchRegistry,
+  fetchAllPackuments: GetAllRegistryPackuments,
+  getAuthToken: GetAuthToken,
+  log: Logger,
+  debugLog: DebugLog
+) {
+  const homePath = getHomePathFromEnv(process.env);
 
-const homePath = getHomePathFromEnv(process.env);
-const registryClient = new RegClient({ log });
-const fetchPackument = getRegistryPackumentUsing(
-  registryClient,
-  debugLogToConsole
-);
-const searchRegistry = searchRegistryUsing(debugLogToConsole);
-const fetchAllPackuments = getAllRegistryPackumentsUsing(debugLogToConsole);
+  pkginfo(module);
+  const program = createCommand()
+    .version(module.exports.version)
+    .option("-c, --chdir <path>", "change the working directory")
+    .option("-r, --registry <url>", "specify registry url", mustBeRegistryUrl)
+    .option("-v, --verbose", "output extra debugging")
+    .option("--system-user", "auth for Windows system user")
+    .option("--no-upstream", "don't use upstream unity registry")
+    .option("--no-color", "disable color");
 
-// update-notifier
-pkginfo(module);
-const notifier = updateNotifier({ pkg });
-notifier.notify();
+  program.addCommand(
+    makeAddCmd(
+      fetchCheckUrlExists,
+      fetchPackument,
+      readTextFile,
+      writeTextFile,
+      log,
+      debugLog
+    )
+  );
 
-const program = createCommand()
-  .version(module.exports.version)
-  .option("-c, --chdir <path>", "change the working directory")
-  .option("-r, --registry <url>", "specify registry url", mustBeRegistryUrl)
-  .option("-v, --verbose", "output extra debugging")
-  .option("--system-user", "auth for Windows system user")
-  .option("--no-upstream", "don't use upstream unity registry")
-  .option("--no-color", "disable color");
+  program.addCommand(makeRemoveCmd(readTextFile, writeTextFile, debugLog, log));
 
-program.addCommand(
-  makeAddCmd(
-    fetchCheckUrlExists,
-    fetchPackument,
-    readTextFile,
-    writeTextFile,
-    log,
-    debugLogToConsole
-  )
-);
+  program.addCommand(
+    makeSearchCmd(
+      readTextFile,
+      searchRegistry,
+      fetchAllPackuments,
+      log,
+      debugLog
+    )
+  );
 
-program.addCommand(
-  makeRemoveCmd(readTextFile, writeTextFile, debugLogToConsole, log)
-);
+  program.addCommand(makeViewCmd(fetchPackument, readTextFile, debugLog, log));
 
-program.addCommand(
-  makeSearchCmd(
-    readTextFile,
-    searchRegistry,
-    fetchAllPackuments,
-    log,
-    debugLogToConsole
-  )
-);
+  program.addCommand(
+    makeDepsCmd(
+      readTextFile,
+      fetchPackument,
+      fetchCheckUrlExists,
+      log,
+      debugLog
+    )
+  );
 
-program.addCommand(
-  makeViewCmd(
-    getRegistryPackumentUsing(registryClient, debugLogToConsole),
-    readTextFile,
-    debugLogToConsole,
-    log
-  )
-);
+  program.addCommand(
+    makeLoginCmd(
+      homePath,
+      getAuthToken,
+      readTextFile,
+      writeTextFile,
+      debugLog,
+      log
+    )
+  );
 
-program.addCommand(
-  makeDepsCmd(
-    readTextFile,
-    fetchPackument,
-    fetchCheckUrlExists,
-    log,
-    debugLogToConsole
-  )
-);
+  // prompt for invalid command
+  program.on("command:*", function () {
+    log.warn("", `unknown command: ${program.args.join(" ")}`);
+    log.warn("", "see --help for a list of available commands");
+    process.exit(1);
+  });
 
-program.addCommand(
-  makeLoginCmd(
-    homePath,
-    getAuthTokenUsing(registryClient, debugLogToConsole),
-    readTextFile,
-    writeTextFile,
-    debugLogToConsole,
-    log
-  )
-);
-
-// prompt for invalid command
-program.on("command:*", function () {
-  log.warn("", `unknown command: ${program.args.join(" ")}`);
-  log.warn("", "see --help for a list of available commands");
-  process.exit(1);
-});
-
-program.parse(process.argv);
-
-// print help if no command is given
-if (!program.args.length) program.help();
+  return program;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,13 +53,6 @@ const fetchPackument = getRegistryPackumentUsing(
 const searchRegistry = searchRegistryUsing(debugLogToConsole);
 const fetchAllPackuments = getAllRegistryPackumentsUsing(debugLogToConsole);
 
-const searchCmd = makeSearchCmd(
-  readTextFile,
-  searchRegistry,
-  fetchAllPackuments,
-  log,
-  debugLogToConsole
-);
 const viewCmd = makeViewCmd(
   getRegistryPackumentUsing(registryClient, debugLogToConsole),
   readTextFile,
@@ -108,17 +101,15 @@ program.addCommand(
   makeRemoveCmd(readTextFile, writeTextFile, debugLogToConsole, log)
 );
 
-program
-  .command("search")
-  .argument("<keyword>", "The keyword to search")
-  .aliases(["s", "se", "find"])
-  .description("Search package by keyword")
-  .action(
-    withErrorLogger(log, async function (keyword, options) {
-      const resultCode = await searchCmd(keyword, makeCmdOptions(options));
-      process.exit(resultCode);
-    })
-  );
+program.addCommand(
+  makeSearchCmd(
+    readTextFile,
+    searchRegistry,
+    fetchAllPackuments,
+    log,
+    debugLogToConsole
+  )
+);
 
 program
   .command("view")

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -58,14 +58,6 @@ const fetchPackument = getRegistryPackumentUsing(
 const searchRegistry = searchRegistryUsing(debugLogToConsole);
 const fetchAllPackuments = getAllRegistryPackumentsUsing(debugLogToConsole);
 
-const addCmd = makeAddCmd(
-  fetchCheckUrlExists,
-  fetchPackument,
-  readTextFile,
-  writeTextFile,
-  log,
-  debugLogToConsole
-);
 const loginCmd = makeLoginCmd(
   homePath,
   getAuthTokenUsing(registryClient, debugLogToConsole),
@@ -127,36 +119,16 @@ function makeCmdOptions<T extends Record<string, unknown>>(
   return { ...specificOptions, ...program.opts() };
 }
 
-program
-  .command("add")
-  .argument(
-    "<pkg>",
-    "Reference to the package that should be added",
-    mustBePackageReference
+program.addCommand(
+  makeAddCmd(
+    fetchCheckUrlExists,
+    fetchPackument,
+    readTextFile,
+    writeTextFile,
+    log,
+    debugLogToConsole
   )
-  .argument(
-    "[otherPkgs...]",
-    "References to additional packages that should be added",
-    eachValue(mustBePackageReference)
-  )
-  .aliases(["install", "i"])
-  .option("-t, --test", "add package as testable")
-  .option(
-    "-f, --force",
-    "force add package if missing deps or editor version is not qualified"
-  )
-  .description(
-    `add package to manifest json
-openupm add <pkg> [otherPkgs...]
-openupm add <pkg>@<version> [otherPkgs...]`
-  )
-  .action(
-    withErrorLogger(log, async function (pkg, otherPkgs, options) {
-      const pkgs = [pkg].concat(otherPkgs);
-      const resultCode = await addCmd(pkgs, makeCmdOptions(options));
-      process.exit(resultCode);
-    })
-  );
+);
 
 program
   .command("remove")

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,7 +1,7 @@
 /**
  * Options which are shared between commands.
  */
-type GlobalOptions = Readonly<{
+export type GlobalOptions = Readonly<{
   /**
    * Override package registry to use.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,60 @@
 #!/usr/bin/env node
 
-import "./cli";
+import RegClient from "another-npm-registry-client";
+import npmlog from "npmlog";
+import updateNotifier from "update-notifier";
+import pkg from "../package.json";
+import { makeOpenupmCli } from "./cli";
+import type { DebugLog } from "./domain/logging";
+import {
+  getAllRegistryPackumentsUsing,
+  getAuthTokenUsing,
+  getRegistryPackumentUsing,
+  searchRegistryUsing,
+} from "./io/registry";
+
+// Composition root
+
+const log = npmlog;
+
+const debugLogToConsole: DebugLog = async function (message, context) {
+  const contextMessage =
+    context !== undefined
+      ? `\n${
+          context instanceof Error
+            ? context.toString()
+            : JSON.stringify(context, null, 2)
+        }`
+      : "";
+  return log.verbose("", `${message}${contextMessage}`);
+};
+
+const registryClient = new RegClient({ log });
+const fetchPackument = getRegistryPackumentUsing(
+  registryClient,
+  debugLogToConsole
+);
+const searchRegistry = searchRegistryUsing(debugLogToConsole);
+const fetchAllPackuments = getAllRegistryPackumentsUsing(debugLogToConsole);
+const getAuthToken = getAuthTokenUsing(registryClient, debugLogToConsole);
+
+const openupmCli = makeOpenupmCli(
+  fetchPackument,
+  searchRegistry,
+  fetchAllPackuments,
+  getAuthToken,
+  log,
+  debugLogToConsole
+);
+
+// Update in case of update
+
+const notifier = updateNotifier({ pkg });
+notifier.notify();
+
+// Run app
+
+openupmCli.parse(process.argv);
+
+// print help if no command is given
+if (openupmCli.args.length === 0) openupmCli.help();


### PR DESCRIPTION
This change shrinks `cli/index.ts`. Composition root and other global app setup was moved into `index.ts`. Logic for each command was moved into the corresponding cmd file. This is in preparation for overhauling the option logic which in itself is in preparation for #397.