### PR TITLE
refacor: packument fetch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import RegClient from "another-npm-registry-client";
 import npmlog from "npmlog";
 import updateNotifier from "update-notifier";
 import pkg from "../package.json";
@@ -29,11 +28,7 @@ const debugLogToConsole: DebugLog = async function (message, context) {
   return log.verbose("", `${message}${contextMessage}`);
 };
 
-const registryClient = new RegClient({ log });
-const fetchPackument = getRegistryPackumentUsing(
-  registryClient,
-  debugLogToConsole
-);
+const fetchPackument = getRegistryPackumentUsing(debugLogToConsole);
 const searchRegistry = searchRegistryUsing(debugLogToConsole);
 const fetchAllPackuments = getAllRegistryPackumentsUsing(debugLogToConsole);
 const getAuthToken = getAuthTokenUsing(debugLogToConsole);

--- a/test/integration/app/add-dependencies.test.ts
+++ b/test/integration/app/add-dependencies.test.ts
@@ -1,4 +1,3 @@
-import RegClient from "another-npm-registry-client";
 import nock from "nock";
 import {
   addDependenciesUsing,
@@ -81,10 +80,7 @@ describe("add dependencies", () => {
   const someProjectDir = "/users/some-user/projects/SomeProject";
 
   function makeDependencies() {
-    const fetchPackument = getRegistryPackumentUsing(
-      new RegClient(),
-      noopLogger
-    );
+    const fetchPackument = getRegistryPackumentUsing(noopLogger);
 
     const log = makeMockLogger();
 

--- a/test/integration/app/resolve-dependencies.test.ts
+++ b/test/integration/app/resolve-dependencies.test.ts
@@ -1,4 +1,3 @@
-import RegClient from "another-npm-registry-client";
 import nock from "nock";
 import { resolveDependenciesUsing } from "../../../src/app/resolve-dependencies";
 import { PackumentNotFoundError } from "../../../src/domain/common-errors";
@@ -32,11 +31,10 @@ describe("dependency resolving", () => {
   const someVersion = SemanticVersion.parse("1.0.0");
   const otherVersion = SemanticVersion.parse("2.0.0");
 
-  const registryClient = new RegClient();
   const resolveDependencies = partialApply(
     resolveDependenciesUsing,
     fetchCheckUrlExists,
-    getRegistryPackumentUsing(registryClient, noopLogger)
+    getRegistryPackumentUsing(noopLogger)
   );
 
   afterEach(() => {

--- a/test/integration/io/registry.test.ts
+++ b/test/integration/io/registry.test.ts
@@ -1,7 +1,5 @@
-import type RegClient from "another-npm-registry-client";
 import { default as npmSearch, default as search } from "libnpmsearch";
 import npmFetch from "npm-registry-fetch";
-import { DomainName } from "../../../src/domain/domain-name";
 import { noopLogger } from "../../../src/domain/logging";
 import {
   HttpErrorLike,
@@ -9,12 +7,9 @@ import {
 } from "../../../src/io/common-errors";
 import {
   getAllRegistryPackumentsUsing,
-  getRegistryPackumentUsing,
   searchRegistryUsing,
 } from "../../../src/io/registry";
-import { buildPackument } from "../../common/data-packument";
 import { someRegistry } from "../../common/data-registry";
-import { mockRegClientGetResult } from "./registry-client.mock";
 
 jest.mock("npm-registry-fetch");
 jest.mock("libnpmsearch");
@@ -107,67 +102,6 @@ describe("registry io", () => {
       const actual = await npmApiSearch(someRegistry, "wow");
 
       expect(actual).toEqual(expected);
-    });
-  });
-
-  describe("fetch", () => {
-    const packageA = DomainName.parse("package-a");
-
-    function makeDependencies() {
-      const regClient: jest.Mocked<RegClient.Instance> = {
-        adduser: jest.fn(),
-        get: jest.fn(),
-      };
-
-      const fetchRegistryPackument = getRegistryPackumentUsing(
-        regClient,
-        noopLogger
-      );
-      return { fetchRegistryPackument, regClient } as const;
-    }
-    it("should get existing packument", async () => {
-      // TODO: Use prop test
-      const packument = buildPackument(packageA);
-      const { fetchRegistryPackument, regClient } = makeDependencies();
-      mockRegClientGetResult(regClient, null, packument);
-
-      const actual = await fetchRegistryPackument(someRegistry, packageA);
-
-      expect(actual).toEqual(packument);
-    });
-
-    it("should not find unknown packument", async () => {
-      const { fetchRegistryPackument, regClient } = makeDependencies();
-      mockRegClientGetResult(
-        regClient,
-        {
-          message: "not found",
-          name: "FakeError",
-          statusCode: 404,
-        },
-        null
-      );
-
-      const actual = await fetchRegistryPackument(someRegistry, packageA);
-
-      expect(actual).toBeNull();
-    });
-
-    it("should fail for errors", async () => {
-      const { fetchRegistryPackument, regClient } = makeDependencies();
-      mockRegClientGetResult(
-        regClient,
-        {
-          message: "Unauthorized",
-          name: "FakeError",
-          statusCode: 401,
-        },
-        null
-      );
-
-      await expect(
-        fetchRegistryPackument(someRegistry, packageA)
-      ).rejects.toBeInstanceOf(Error);
     });
   });
 });


### PR DESCRIPTION
Currently we use `another-npm-registry-client` for fetching packuments. This is a fork of a deprecated library. This change instead uses the currently maintained library for fetching packuments that is maintained by npm Just to modernize the dependencies a bit.