### PR TITLE
feat: stable tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ The add command fails if the package is not qualified:
 
 You shall either resolve these issues manually or add the option `-f` to continue.
 
+You may specify the version to add in a few different ways:
+
+- A specific version like `com.my.package@1.2.0`
+- The latest tag like `com.my.package@latest` which will install the latest
+published version, including pre-releases.
+- No version at all like `com.my.package` which is identical to using the 
+"latest" tag.
+- The stable tag like `com.my.package@stable` which will install the latest
+stable version, ie. excluding pre-releases.
+
 You can also add [testables](https://docs.unity3d.com/Manual/cus-tests.html) when importing:
 
 ```

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -21,6 +21,7 @@ import {
 } from "../domain/common-errors";
 import { stringifyEditorVersion } from "../domain/editor-version";
 import {
+  NoStableError,
   NoVersionsError,
   VersionNotFoundError,
   type ResolvePackumentVersionError,
@@ -96,6 +97,8 @@ function makeErrorMessageFor(error: unknown): string {
     return "Could not determine path of home directory.";
   if (error instanceof NoSystemUserProfilePath)
     return "Could not determine path of system user directory.";
+  if (error instanceof NoStableError)
+    return "Seems like the package you requested has no stable versions.";
   return "A fatal error occurred.";
 }
 

--- a/src/domain/package-reference.ts
+++ b/src/domain/package-reference.ts
@@ -50,7 +50,12 @@ export type PackageReference = DomainName | ReferenceWithVersion;
  * @param s The string.
  */
 function isVersionReference(s: string): s is VersionReference {
-  return s === "latest" || isZod(s, SemanticVersion) || isZod(s, PackageUrl);
+  return (
+    s === "latest" ||
+    s === "stable" ||
+    isZod(s, SemanticVersion) ||
+    isZod(s, PackageUrl)
+  );
 }
 
 /**

--- a/src/domain/package-reference.ts
+++ b/src/domain/package-reference.ts
@@ -6,10 +6,20 @@ import { trySplitAtFirstOccurrenceOf } from "./string-utils";
 import { assertZod, isZod } from "./zod-utils";
 
 /**
- * A string with the format of one of the supported version tags.
- * NOTE: Currently we only support "latest".
+ * The "latest" tag string. Specifies that the latest version is requested.
  */
-export type PackageTag = "latest";
+export type LatestTag = "latest";
+
+/**
+ * The "stable" tag string. Specifies that the latest stable version is
+ * requested.
+ */
+export type StableTag = "stable";
+
+/**
+ * A string with the format of one of the supported version tags.
+ */
+export type PackageTag = LatestTag | StableTag;
 
 /**
  * Reference to a version, either directly by a semantic version or via an
@@ -23,7 +33,7 @@ export type VersionReference = SemanticVersion | PackageUrl | PackageTag;
 export type ReferenceWithVersion = `${DomainName}@${VersionReference}`;
 
 /**
- * A version-reference that is resolvable.
+ * A {@link VersionReference} that is resolvable.
  * Mostly this excludes {@link PackageUrl}s.
  */
 export type ResolvableVersion = Exclude<VersionReference, PackageUrl>;

--- a/src/domain/semantic-version.ts
+++ b/src/domain/semantic-version.ts
@@ -14,3 +14,28 @@ export const SemanticVersion = z
  * @see https://semver.org/.
  */
 export type SemanticVersion = z.TypeOf<typeof SemanticVersion>;
+
+/**
+ * Compares to semantic versions to see which is larger. Can be used for
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted Array.prototype.toSorted}.
+ * @param a The first version.
+ * @param b The second version.
+ * @returns A number indicating the sorting order of the numbers.
+ *   - a > b -> 1.
+ *   - a = b -> 0.
+ *   - a < b -> -1.
+ */
+export function compareVersions(
+  a: SemanticVersion,
+  b: SemanticVersion
+): -1 | 0 | 1 {
+  return semver.compare(a, b, false);
+}
+
+/**
+ * Checks wheter a semantic version is stable.
+ * @param version The version to check.
+ */
+export function isStable(version: SemanticVersion): boolean {
+  return semver.prerelease(version) === null;
+}

--- a/test/common/data-packument.ts
+++ b/test/common/data-packument.ts
@@ -74,13 +74,17 @@ class UnityPackumentBuilder {
 
   /**
    * Adds a version to this package.
+   * The order in which you add versions to the packument is important because
+   * every time you call this function the version specified in the packument's
+   * "dist-tags" is overriden to the given version.
    * @param version The name of the version.
    * @param build A builder function.
+   * @returns The builder for chaining.
    */
   addVersion(
     version: string,
     build?: (builder: UnityPackumentVersionBuilder) => unknown
-  ): UnityPackumentBuilder {
+  ): this {
     assert(isZod(version, SemanticVersion), `${version} is semantic version`);
     const builder = new UnityPackumentVersionBuilder(
       this.packument.name,


### PR DESCRIPTION
Adds the "stable" tag. Users can now exclude pre-release versions when installing packages.

This should fix #395.