### PR TITLE
feat: add global options deprecation warnings

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,16 @@ const verboseOpt = new Option(
 
 const colorOpt = new Option("--no-color", "disable color").default(true);
 
+const registryDeprecatedOpt = new Option("-r, --registry <url>")
+  .argParser(() => true)
+  .default(false)
+  .hideHelp(true);
+
+const chdirDeprecatedOpt = new Option("-c, --chdir <path>")
+  .argParser(() => true)
+  .default(false)
+  .hideHelp(true);
+
 /**
  * Makes the openupm cli app with the given dependencies.
  * @param fetchPackument IO function for fetching registry packuments.
@@ -52,7 +62,9 @@ export function makeOpenupmCli(
   const program = createCommand()
     .version(module.exports.version)
     .addOption(verboseOpt)
-    .addOption(colorOpt);
+    .addOption(colorOpt)
+    .addOption(chdirDeprecatedOpt)
+    .addOption(registryDeprecatedOpt);
 
   program.on("option:verbose", function () {
     const verbose = program.opts().verbose;
@@ -66,6 +78,24 @@ export function makeOpenupmCli(
       chalk.level = 0;
       log.disableColor();
     }
+  });
+
+  program.on(`option:${chdirDeprecatedOpt.name()}`, function () {
+    log.warn(
+      "",
+      `--chdir/-c is no longer supported as a global option!
+Instead, you should add it to the specific command you are running.
+Example: openupm add --chdir /some/path com.my.package`
+    );
+  });
+
+  program.on(`option:${registryDeprecatedOpt.name()}`, function () {
+    log.warn(
+      "",
+      `--registry/-r is no longer supported as a global option!
+Instead, you should add it to the specific command you are running.
+Example: openupm add -r https://packages.my-registry.com com.my.package`
+    );
   });
 
   program.addCommand(


### PR DESCRIPTION
BREAKING CHANGE:

As part of ac31f01cced0acc1994e3a8d16f3be103b10afe1 global options which are only relevant to some commands have been moved to those specific commands.

This left some users confused, because this was done without warning or major version change. This change seeks to remedy this, by adding deprecation warnings as well as triggering a major version bump.