### PR TITLE
refactor: rename symbols

### DIFF
--- a/src/app/get-registry-packument-version.ts
+++ b/src/app/get-registry-packument-version.ts
@@ -1,7 +1,7 @@
 import { AsyncResult, Err } from "ts-results-es";
 import { PackumentNotFoundError } from "../domain/common-errors";
 import { DomainName } from "../domain/domain-name";
-import { ResolvableVersion } from "../domain/package-reference";
+import { ResolvableVersion } from "../domain/package-spec";
 import {
   ResolvePackumentVersionError,
   tryResolvePackumentVersion,

--- a/src/cli/error-logging.ts
+++ b/src/cli/error-logging.ts
@@ -61,16 +61,16 @@ function makeErrorMessageFor(error: unknown): string {
       error.version
     )}.`;
   if (error instanceof CompatibilityCheckFailedError)
-    return `Could not confirm editor compatibility for ${error.packageRef}.`;
+    return `Could not confirm editor compatibility for ${error.packageSpec}.`;
   if (error instanceof PackageIncompatibleError)
     return `"${
-      error.packageRef
+      error.packageSpec
     }" is not compatible with Unity ${stringifyEditorVersion(
       error.editorVersion
     )}.`;
   if (error instanceof UnresolvedDependenciesError)
     return (
-      `"${error.packageRef}" has one or more unresolved dependencies and was not added.${EOL}` +
+      `"${error.packageSpec}" has one or more unresolved dependencies and was not added.${EOL}` +
       `${error.dependencies.map(stringifyUnresolvedDependency).join(EOL)}`
     );
   if (error instanceof NoVersionsError)

--- a/src/cli/validators.ts
+++ b/src/cli/validators.ts
@@ -1,15 +1,16 @@
 import { DomainName } from "../domain/domain-name";
-import { isPackageReference } from "../domain/package-reference";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { isPackageSpec, type PackageSpec } from "../domain/package-spec";
 import { coerceRegistryUrl } from "../domain/registry-url";
 import { isZod } from "../domain/zod-utils";
 import { mustBeParsable, mustSatisfy } from "./cli-parsing";
 
 /**
- * {@link CliValueParser} for checking that a string is a {@link PackageReference}.
+ * {@link CliValueParser} for checking that a string is a {@link PackageSpec}.
  */
-export const mustBePackageReference = mustSatisfy(
-  isPackageReference,
-  (input) => `"${input}" is not a valid package-reference`
+export const mustBePackageSpec = mustSatisfy(
+  isPackageSpec,
+  (input) => `"${input}" is not a valid package-spec`
 );
 
 /**

--- a/src/domain/dependency-graph.ts
+++ b/src/domain/dependency-graph.ts
@@ -1,6 +1,6 @@
-import { recordEntries } from "./record-utils";
 import { DomainName } from "./domain-name";
 import { ResolvePackumentVersionError } from "./packument";
+import { recordEntries } from "./record-utils";
 import { RegistryUrl } from "./registry-url";
 import { SemanticVersion } from "./semantic-version";
 
@@ -125,7 +125,7 @@ export function makeGraphFromSeed(
 }
 
 /**
- * Attempts to get the next unresolved package reference from a dependency
+ * Attempts to get the next unresolved package-spec from a dependency
  * graph.
  * @param graph The graph to search.
  * @returns A tuple with the name and version of the next unresolved package or

--- a/src/domain/package-spec.ts
+++ b/src/domain/package-spec.ts
@@ -28,9 +28,9 @@ export type PackageTag = LatestTag | StableTag;
 export type VersionReference = SemanticVersion | PackageUrl | PackageTag;
 
 /**
- * A package reference that includes a version.
+ * A package-spec that includes a version.
  */
-export type ReferenceWithVersion = `${DomainName}@${VersionReference}`;
+export type PackageAtVersion = `${DomainName}@${VersionReference}`;
 
 /**
  * A {@link VersionReference} that is resolvable.
@@ -42,8 +42,9 @@ export type ResolvableVersion = Exclude<VersionReference, PackageUrl>;
  * References a package. Could be just the name or a reference to a specific
  * version. Not as specific as a {@link PackageId} as other version-formats
  * besides semantic versions, such as "latest" are also allowed.
+ * @see https://docs.npmjs.com/cli/v8/using-npm/package-spec
  */
-export type PackageReference = DomainName | ReferenceWithVersion;
+export type PackageSpec = DomainName | PackageAtVersion;
 
 /**
  * Checks if a string is a version-reference.
@@ -59,10 +60,10 @@ function isVersionReference(s: string): s is VersionReference {
 }
 
 /**
- * Checks if a string is a package-reference.
+ * Checks if a string is a package-spec.
  * @param s The string.
  */
-export function isPackageReference(s: string): s is PackageReference {
+export function isPackageSpec(s: string): s is PackageSpec {
   const [name, version] = trySplitAtFirstOccurrenceOf(s, "@");
   return (
     isZod(name, DomainName) && (version === null || isVersionReference(version))
@@ -70,13 +71,13 @@ export function isPackageReference(s: string): s is PackageReference {
 }
 
 /**
- * Split a package-reference into the name and version if present.
- * @param reference The reference.
+ * Split a package-spec into the name and version if present.
+ * @param spec The spec.
  */
-export function splitPackageReference(
-  reference: PackageReference
+export function splitPackageSpec(
+  spec: PackageSpec
 ): [DomainName, VersionReference | null] {
-  const [name, version] = trySplitAtFirstOccurrenceOf(reference, "@") as [
+  const [name, version] = trySplitAtFirstOccurrenceOf(spec, "@") as [
     DomainName,
     VersionReference | null
   ];
@@ -84,15 +85,15 @@ export function splitPackageReference(
 }
 
 /**
- * Constructs a package-reference.
+ * Constructs a package-spec.
  * @param name The package-name. Will be validated to be a {@link DomainName}.
  * @param version Optional version-reference. Will be validated to be a
  * {@link VersionReference}.
  */
-export function makePackageReference(
+export function makePackageSpec(
   name: string,
   version: string | null
-): PackageReference {
+): PackageSpec {
   assertZod(name, DomainName);
   if (version === null) return name;
   assert(
@@ -103,11 +104,9 @@ export function makePackageReference(
 }
 
 /**
- * Checks if the package-reference includes a version.
- * @param reference The package-reference.
+ * Checks if the package-spec includes a version.
+ * @param spec The package-spec.
  */
-export function hasVersion(
-  reference: PackageReference
-): reference is ReferenceWithVersion {
-  return reference.includes("@");
+export function hasVersion(spec: PackageSpec): spec is PackageAtVersion {
+  return spec.includes("@");
 }

--- a/src/domain/packument.ts
+++ b/src/domain/packument.ts
@@ -8,7 +8,7 @@ import {
   ResolvableVersion,
   type LatestTag,
   type StableTag,
-} from "./package-reference";
+} from "./package-spec";
 import { recordKeys } from "./record-utils";
 import { compareVersions, isStable, SemanticVersion } from "./semantic-version";
 

--- a/test/e2e/add.test.ts
+++ b/test/e2e/add.test.ts
@@ -22,14 +22,14 @@ describe("add packages", () => {
     const homeDir = await prepareHomeDirectory();
     const projectDir = await prepareUnityProject(homeDir);
 
-    const pkgRefs = cases.map((it) =>
+    const packageSpecs = cases.map((it) =>
       it.addVersion !== undefined
         ? `${it.packageName}@${it.addVersion}`
         : it.packageName
     );
     const output = await runOpenupm(projectDir, [
       "add",
-      ...pkgRefs,
+      ...packageSpecs,
       ...(registryOverride !== undefined
         ? [`--registry=${registryOverride}`]
         : []),
@@ -289,7 +289,7 @@ describe("add packages", () => {
     expect(output.stdOut).toEqual([]);
     expect(output.stdErr).toEqual(
       expect.arrayContaining([
-        expect.stringContaining(`"1,2,3" is not a valid package-reference`),
+        expect.stringContaining(`"1,2,3" is not a valid package-spec`),
       ])
     );
   });

--- a/test/unit/cli/dependency-logging.test.ts
+++ b/test/unit/cli/dependency-logging.test.ts
@@ -5,7 +5,7 @@ import {
   markRemoteResolved,
 } from "../../../src/domain/dependency-graph";
 import { stringifyDependencyGraph } from "../../../src/cli/dependency-logging";
-import { makePackageReference } from "../../../src/domain/package-reference";
+import { makePackageSpec } from "../../../src/domain/package-spec";
 import { someRegistryUrl } from "../../common/data-registry";
 import { PackumentNotFoundError } from "../../../src/domain/common-errors";
 import { unityRegistryUrl } from "../../../src/domain/registry-url";
@@ -46,7 +46,7 @@ describe("dependency-logging", () => {
 
       // Print just name@version
       expect(actual).toEqual([
-        `${makePackageReference(somePackage, someVersion)}`,
+        `${makePackageSpec(somePackage, someVersion)}`,
       ]);
     });
 
@@ -67,9 +67,9 @@ describe("dependency-logging", () => {
 
       // Print name@version plus dependencies in the next lines
       expect(actual).toEqual([
-        `${makePackageReference(somePackage, someVersion)}`,
-        `└─ ${makePackageReference(otherPackage, otherVersion)}`,
-        `└─ ${makePackageReference(anotherPackage, someVersion)}`,
+        `${makePackageSpec(somePackage, someVersion)}`,
+        `└─ ${makePackageSpec(otherPackage, otherVersion)}`,
+        `└─ ${makePackageSpec(anotherPackage, someVersion)}`,
       ]);
     });
 
@@ -88,7 +88,7 @@ describe("dependency-logging", () => {
 
       // Print name@version plus error message in next line
       expect(actual).toEqual([
-        `${makePackageReference(somePackage, someVersion)}`,
+        `${makePackageSpec(somePackage, someVersion)}`,
         `  - "${someRegistryUrl}": package not found`,
         `  - "${unityRegistryUrl}": version not found`,
       ]);
@@ -122,10 +122,10 @@ describe("dependency-logging", () => {
 
       // Print | next to nested trees
       expect(actual).toEqual([
-        `${makePackageReference(somePackage, someVersion)}`,
-        `└─ ${makePackageReference(otherPackage, otherVersion)}`,
-        `│  └─ ${makePackageReference(anotherPackage, someVersion)}`,
-        `└─ ${makePackageReference(thatPackage, someVersion)}`,
+        `${makePackageSpec(somePackage, someVersion)}`,
+        `└─ ${makePackageSpec(otherPackage, otherVersion)}`,
+        `│  └─ ${makePackageSpec(anotherPackage, someVersion)}`,
+        `└─ ${makePackageSpec(thatPackage, someVersion)}`,
       ]);
     });
 
@@ -160,13 +160,13 @@ describe("dependency-logging", () => {
       const actual = stringifyDependencyGraph(graph, somePackage, someVersion);
 
       expect(actual).toEqual([
-        `${makePackageReference(somePackage, someVersion)}`,
-        `└─ ${makePackageReference(otherPackage, otherVersion)}`,
-        `│  └─ ${makePackageReference(anotherPackage, someVersion)}`,
-        `│     └─ ${makePackageReference(thatPackage, someVersion)}`,
+        `${makePackageSpec(somePackage, someVersion)}`,
+        `└─ ${makePackageSpec(otherPackage, otherVersion)}`,
+        `│  └─ ${makePackageSpec(anotherPackage, someVersion)}`,
+        `│     └─ ${makePackageSpec(thatPackage, someVersion)}`,
         // Because this package was printed before, now only its name is printed
         // with a string at the end that indicates that this is a duplicate.
-        `└─ ${makePackageReference(anotherPackage, someVersion)} ..`,
+        `└─ ${makePackageSpec(anotherPackage, someVersion)} ..`,
       ]);
     });
   });

--- a/test/unit/domain/package-spec.test.ts
+++ b/test/unit/domain/package-spec.test.ts
@@ -1,19 +1,19 @@
 import fc from "fast-check";
 import {
-  isPackageReference,
-  makePackageReference,
-  splitPackageReference,
-} from "../../../src/domain/package-reference";
+  isPackageSpec,
+  makePackageSpec,
+  splitPackageSpec,
+} from "../../../src/domain/package-spec";
 import { arbDomainName } from "./domain-name.arb";
 import { arbPackageUrl } from "./package-url.arb";
 import { arbSemanticVersion } from "./semantic-version.arb";
 
-describe("package-reference", () => {
+describe("package-spec", () => {
   describe("validation", () => {
     it("should be ok for just name", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
-          expect(isPackageReference(packumentName)).toBeTruthy();
+          expect(isPackageSpec(packumentName)).toBeTruthy();
         })
       );
     });
@@ -22,7 +22,7 @@ describe("package-reference", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `${packumentName}@1.2.3`;
-          expect(isPackageReference(input)).toBeTruthy();
+          expect(isPackageSpec(input)).toBeTruthy();
         })
       );
     });
@@ -31,7 +31,7 @@ describe("package-reference", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `${packumentName}@file:/path/to/${packumentName}`;
-          expect(isPackageReference(input)).toBeTruthy();
+          expect(isPackageSpec(input)).toBeTruthy();
         })
       );
     });
@@ -40,7 +40,7 @@ describe("package-reference", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `${packumentName}@http://my.server/${packumentName}`;
-          expect(isPackageReference(input)).toBeTruthy();
+          expect(isPackageSpec(input)).toBeTruthy();
         })
       );
     });
@@ -49,7 +49,7 @@ describe("package-reference", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `${packumentName}@git@github:user/${packumentName}`;
-          expect(isPackageReference(input)).toBeTruthy();
+          expect(isPackageSpec(input)).toBeTruthy();
         })
       );
     });
@@ -58,7 +58,7 @@ describe("package-reference", () => {
       fc.assert(
         fc.property(arbDomainName, (packumentName) => {
           const input = `${packumentName}@latest`;
-          expect(isPackageReference(input)).toBeTruthy();
+          expect(isPackageSpec(input)).toBeTruthy();
         })
       );
     });
@@ -73,14 +73,14 @@ describe("package-reference", () => {
       // Bad tag
       "my.package@ltst",
     ])(`"should not be ok for "%s"`, (input) => {
-      expect(isPackageReference(input)).not.toBeTruthy();
+      expect(isPackageSpec(input)).not.toBeTruthy();
     });
   });
 
   describe("split", () => {
     function shouldSplitCorrectly(name: string, version?: string) {
-      const [actualName, actualVersion] = splitPackageReference(
-        makePackageReference(name, version ?? null)
+      const [actualName, actualVersion] = splitPackageSpec(
+        makePackageSpec(name, version ?? null)
       );
       expect(actualName).toEqual(name);
       expect(actualVersion).toEqual(version ?? null);


### PR DESCRIPTION
After looking at the npm documentation, seems like the term for a package-name with or without version is called a "package spec"

https://docs.npmjs.com/cli/v8/using-npm/package-spec

Renamed relevant symbols to match this term