### PR TITLE
feat: add list cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ openupm deps com.my.package
 
 Checkout [the commands doc page](./docs/cmd-deps.md) for more information.
 
+### List installed packages
+
+Use `openupm ls` to print the names and versions of installed packages.
+
+```sh
+openupm ls
+```
+
+Checkout [the commands doc page](./docs/cmd-ls.md) for more information.
+
 ### Global command options
 
 There are also some global options that work for every command. You can read about them [here](./docs/global-opts.md).

--- a/docs/cmd-ls.md
+++ b/docs/cmd-ls.md
@@ -1,0 +1,18 @@
+
+# `openupm ls`
+
+The `ls` command prints the name and version of each installed package for a project.
+
+This command has the `list` alias. On this doc page we will always use the primary command name `ls`.
+
+## Options
+
+### Project directory
+
+By default openupm expects that you run the add command inside your Unity projects root directory. Based on this it determines relative paths to your package manifest etc.
+
+If you need to run openupm from somewhere else you can change the working directory using the `--chdir`/`-c` option. This option accepts an **absolute** path to a Unity projects root directory.
+
+```sh
+openupm add com.my.package -c /home/user/dev/MyProject
+```

--- a/src/cli/cmd-ls.ts
+++ b/src/cli/cmd-ls.ts
@@ -1,0 +1,27 @@
+import { Command } from "@commander-js/extra-typings";
+import { Logger } from "npmlog";
+import type { DebugLog } from "../domain/logging";
+import type { ReadTextFile } from "../io/fs";
+import { withErrorLogger } from "./error-logging";
+
+/**
+ * Makes the `openupm ls` cli command with the given dependencies.
+ * @param readTextFile IO function for reading a text file.
+ * @param debugLog IO function for debug-logs.
+ * @param log Logger for cli output.
+ * @returns The command.
+ */
+export function makeLsCmd(
+  readTextFile: ReadTextFile,
+  debugLog: DebugLog,
+  log: Logger
+) {
+  return new Command("ls")
+    .aliases(["list"])
+    .summary("list all currently installed packages")
+    .description(
+      `Print the names and versions of all installed packages.
+openupm ls`
+    )
+    .action(withErrorLogger(log, async function (options) {}));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { fetchCheckUrlExists } from "../io/www";
 import { makeAddCmd } from "./cmd-add";
 import { makeDepsCmd } from "./cmd-deps";
 import { makeLoginCmd } from "./cmd-login";
+import { makeLsCmd } from "./cmd-ls";
 import { makeRemoveCmd } from "./cmd-remove";
 import { makeSearchCmd } from "./cmd-search";
 import { makeViewCmd } from "./cmd-view";
@@ -113,6 +114,8 @@ export function makeOpenupmCli(
       log
     )
   );
+
+  program.addCommand(makeLsCmd(readTextFile, debugLog, log));
 
   // prompt for invalid command
   program.on("command:*", function () {

--- a/test/e2e/ls.test.ts
+++ b/test/e2e/ls.test.ts
@@ -1,0 +1,28 @@
+import { ResultCodes } from "../../src/cli/result-codes";
+import { buildProjectManifest } from "../common/data-project-manifest";
+import { runOpenupm } from "./run";
+import { prepareHomeDirectory } from "./setup/directories";
+import { prepareUnityProject } from "./setup/project";
+
+describe("list installed packages", () => {
+  test("should list installed packages", async () => {
+    const homeDirectory = await prepareHomeDirectory();
+    const projectDirectory = await prepareUnityProject(homeDirectory, {
+      manifest: buildProjectManifest((manifest) =>
+        manifest
+          .addDependency("dev.comradevanti.opt-unity", "2.0.0", true, true)
+          .addDependency("com.unity.ugui", "1.0.0", true, false)
+      ),
+    });
+
+    const result = await runOpenupm(projectDirectory, ["ls"]);
+
+    expect(result.code).toEqual(ResultCodes.Ok);
+    expect(result.stdErr).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("dev.comradevanti.opt-unity@2.0.0"),
+        expect.stringContaining("com.unity.ugui@1.0.0"),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
This PR adds the `list` command. It behaves like calling `npm ls` without an argument and lists all installed dependencies.

See #351 