### PR TITLE
fix: allow underscores in domain name segments

### DIFF
--- a/src/domain/domain-name.ts
+++ b/src/domain/domain-name.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const segmentRegex = /^(?!.*--|^-.*|.*-$)[a-zA-Z0-9-]+$/;
+const segmentRegex = /^(?!.*--|^-.*|.*-$)[a-zA-Z0-9-_]+$/;
 
 function domainSegmentsIn(hostName: string): string[] {
   return hostName.split(".");

--- a/test/unit/domain/domain-name.test.ts
+++ b/test/unit/domain/domain-name.test.ts
@@ -9,6 +9,7 @@ describe("domain-name", () => {
       "com.openupm",
       "at.ac.my-school",
       "dev.comradevanti123",
+      "org.nuget.sqlitepclraw.bundle_e_sqlite3",
     ])(`should be ok for "%s"`, (s) => {
       expect(isZod(s, DomainName)).toBeTruthy();
     });


### PR DESCRIPTION
Update domain name validation regex to permit underscores in domain segments, expanding support for package naming conventions. Fixed #420