### PR TITLE
fix: Allow any number for minor version number

### DIFF
--- a/src/domain/editor-version.ts
+++ b/src/domain/editor-version.ts
@@ -128,7 +128,7 @@ export const tryParseEditorVersion = function (
     locBuild?: `${number}`;
   };
   const regex =
-    /^(?<major>\d+)\.(?<minor>[1234])(\.(?<patch>\d+)((?<flag>a|b|f|c)(?<build>\d+)((?<loc>c)(?<locBuild>\d+))?)?)?/;
+    /^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+)((?<flag>a|b|f|c)(?<build>\d+)((?<loc>c)(?<locBuild>\d+))?)?)?/;
   const match = regex.exec(version);
   if (!match) return null;
   const groups = <RegexMatchGroups>match.groups;


### PR DESCRIPTION
Currently only numbers 1-4 are allowed in the minor version number. Since Unity 6, also the number 0 is used (6000.0). This commit changes the regex for the minor version number to include any number, which fixes support for Unity 6 and is more permissive in case any other numbers are used by Unity in the future.