### PR TITLE
test: stabilize built-in dependency e2e fixture

### DIFF
--- a/.github/verdaccio/com.builtin.package/v1.0.0/package.json
+++ b/.github/verdaccio/com.builtin.package/v1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.builtin.package",
+  "version": "1.0.0",
+  "dependencies": {
+    "com.unity.modules.imageconversion": "1.0.0"
+  }
+}

--- a/test/e2e/add.test.ts
+++ b/test/e2e/add.test.ts
@@ -299,12 +299,13 @@ describe("add packages", () => {
     await testSuccessfulAdd(
       [
         {
-          packageName: "org.khronos.unitygltf",
-          expectedVersion: "2.12.0",
-          addVersion: "2.12.0",
+          packageName: "com.builtin.package",
+          expectedVersion: "1.0.0",
+          addVersion: "1.0.0",
         },
       ],
-      ["org.khronos.unitygltf"]
+      ["com.builtin.package"],
+      e2eTestRegistryUrl
     );
   });
 


### PR DESCRIPTION
## Summary
- replace the built-in dependency add e2e case's drifting public package with a local Verdaccio fixture
- keep the test focused on Unity built-in dependency resolution while avoiding mutable OpenUPM package metadata

## Validation
- npm run build
- npm run test:unit
- npm run test:integration
- targeted e2e validation for the built-in dependency add case