### PR TITLE
test: allow slower add e2e cases

### DIFF
--- a/test/e2e/add.test.ts
+++ b/test/e2e/add.test.ts
@@ -8,6 +8,8 @@ import { prepareUnityProject } from "./setup/project";
 import { e2eTestRegistryUrl } from "./setup/test-registry";
 
 describe("add packages", () => {
+  jest.setTimeout(30000);
+
   type SuccessfulAddCase = {
     packageName: string;
     addVersion?: string;


### PR DESCRIPTION
## Summary
- give the add e2e suite an explicit timeout for live dependency-resolution cases
- prevent timeout-aborted add cases from leaking async project mutations into following tests

## Validation
- npm run build
- targeted add e2e suite with local registry fixtures